### PR TITLE
fix(rook): clear BlueStore signature in WipeDiskJob with wipefs + blkdiscard

### DIFF
--- a/.taskfiles/rook/templates/WipeDiskJob.tmpl.yaml
+++ b/.taskfiles/rook/templates/WipeDiskJob.tmpl.yaml
@@ -1,7 +1,9 @@
 ---
-# IMPORTANT: This template uses ceph-volume to properly clear BlueStore labels.
-# Standard tools (sgdisk, dd) do NOT clear BlueStore superblock metadata.
-# See: .claude/skills/ceph-rook/references/osd-recovery.md
+# IMPORTANT: Clears a single OSD disk so the operator re-provisions it cleanly.
+# ceph-volume zap removes BlueStore labels, but `wipefs -af` is required to erase
+# the blkid signature that lsblk/the operator key on (without it the disk shows
+# FSTYPE=ceph_bluestore and is skipped as "already configured"). blkdiscard does a
+# full-device TRIM as a final safeguard.
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -22,14 +24,22 @@ spec:
           command: ["/bin/bash", "-c"]
           args:
             - |
-              echo "Wiping disk /host${disk} with ceph-volume..."
-              # Use ceph-volume to properly clear BlueStore labels and LVM metadata
-              ceph-volume lvm zap --destroy /host${disk} || echo "ceph-volume lvm zap failed, trying raw zap..."
-              # Fallback to raw zap for non-LVM OSDs
-              ceph-volume raw zap /host${disk} || echo "ceph-volume raw zap completed or not applicable"
-              # Final cleanup: issue TRIM/discard to SSD and notify kernel
-              blkdiscard /host${disk} || echo "blkdiscard not supported"
+              echo "== Wiping disk /host${disk} =="
+              echo "-- before --"; lsblk -f /host${disk} 2>/dev/null; wipefs /host${disk} 2>/dev/null
+              # Clear BlueStore labels + LVM metadata via ceph-volume
+              ceph-volume lvm zap --destroy /host${disk} || echo "ceph-volume lvm zap not applicable"
+              # Erase any remaining filesystem/BlueStore signatures (this is what
+              # lsblk/blkid key on; without it the operator sees a "configured" disk)
+              wipefs -af /host${disk} || echo "wipefs failed"
+              # Destroy the partition table
+              sgdisk --zap-all /host${disk} || echo "sgdisk not applicable"
+              # Full-device TRIM/discard (forced) to clear all data on the SSD
+              blkdiscard -f /host${disk} || echo "blkdiscard not supported"
+              # Belt-and-suspenders: zero the head of the device
+              dd if=/dev/zero of=/host${disk} bs=1M count=100 oflag=direct conv=fsync || true
               partprobe /host${disk} || true
+              udevadm settle 2>/dev/null || true
+              echo "-- after --"; lsblk -f /host${disk} 2>/dev/null; wipefs /host${disk} 2>/dev/null
               echo "Disk wipe complete for /host${disk}"
           securityContext:
             privileged: true


### PR DESCRIPTION
## Problem

During a single-OSD disk replacement (osd-1 on talos-3), `task rook:reset-disk` ran the WipeDiskJob, which did `ceph-volume lvm zap` + a 10 MB `dd`. That left the **`ceph_bluestore` blkid signature at offset 0x0**. The rook operator's osd-prepare then saw `FSTYPE=ceph_bluestore` and skipped the disk ("no new devices to configure ... already configured"), so the wiped disk could not be re-provisioned and the OSD pod was stuck `Init:Error`.

`wipefs -af` (which erases the blkid signature lsblk/the operator key on) cleared it immediately; after that the operator provisioned a fresh OSD on the disk.

## Change

`WipeDiskJob.tmpl.yaml`:
- Add `wipefs -af` (the key fix) and `sgdisk --zap-all`
- Use `blkdiscard -f` (full-device TRIM) and a 100 MB `dd` safeguard
- Print before/after `lsblk -f` + `wipefs` for verification
- Drop the invalid `ceph-volume raw zap` call (unrecognized args on ceph v19)

Verified live: re-running with this logic cleared the signature and the operator rebuilt the OSD cleanly (HEALTH_OK, 6/6 up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)