### PR TITLE
fix(cilium): raise agent memory limit to 1Gi to stop OOMKills

### DIFF
--- a/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
@@ -93,9 +93,9 @@ spec:
     resources:
       requests:
         cpu: 100m
-        memory: 256Mi
-      limits:
         memory: 512Mi
+      limits:
+        memory: 1Gi
     securityContext:
       capabilities:
         ciliumAgent:


### PR DESCRIPTION
## Root cause
The cilium-agent daemonset memory limit (`512Mi`) is too low. Agents sit at ~420Mi steady-state and spike past the limit under endpoint/identity churn, getting **OOMKilled** (talos-3 ×7, lastTerm=OOMKilled) or error-restarting (talos-1 @ 19:55Z).

## Impact (incident on 2026-05-30)
Each agent death briefly drops the node datapath, which cascaded:
- `osd.3` (talos-1) lost heartbeat and **flapped** down/up every ~5 min
- Ceph mass-**blocklisted** the disrupted kernel clients (**550 entries**)
- Cluster-wide `rbd map (108)` mount failures (postgres, linkwarden, paperless, syncthing, ntfy…)
- CSI rbdplugin restarts ("driver not registered")
- Postgres failover → replica-3 **timeline divergence** (required re-bootstrap)
- Historically: mons lag → full resync → `MonitorDBStore::clear` RocksDB assert → mon crash loop (election epoch 19574)

## Change
| | before | after |
|---|---|---|
| cilium-agent request | 256Mi | **512Mi** |
| cilium-agent limit | 512Mi | **1Gi** |

Gives comfortable headroom over the ~420Mi steady-state. Flux rolls the agents one node at a time on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)