### PR TITLE
feat(tuppr): add KubernetesUpgrade CR and enable monitoring

### DIFF
--- a/kubernetes/apps/system-upgrade/tuppr/app/helmrelease.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/app/helmrelease.yaml
@@ -11,3 +11,14 @@ spec:
   interval: 1h
   values:
     replicaCount: 2
+    monitoring:
+      serviceMonitor:
+        enabled: true
+      prometheusRule:
+        enabled: true
+      dashboards:
+        enabled: true
+        grafanaOperator:
+          enabled: true
+          matchLabels:
+            grafana.internal/instance: grafana

--- a/kubernetes/apps/system-upgrade/tuppr/upgrades/kubernetesupgrade.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/upgrades/kubernetesupgrade.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/tuppr.home-operations.com/kubernetesupgrade_v1alpha1.json
+apiVersion: tuppr.home-operations.com/v1alpha1
+kind: KubernetesUpgrade
+metadata:
+  name: kubernetes
+spec:
+  kubernetes:
+    # renovate: datasource=docker depName=ghcr.io/siderolabs/kubelet
+    version: v1.36.1
+  healthChecks:
+    - apiVersion: volsync.backube/v1alpha1
+      kind: ReplicationSource
+      expr: |-
+        status.conditions.filter(c, c.type == "Synchronizing").all(c, c.status == "False")
+    - apiVersion: ceph.rook.io/v1
+      kind: CephCluster
+      expr: |-
+        status.ceph.health in ['HEALTH_OK']

--- a/kubernetes/apps/system-upgrade/tuppr/upgrades/kustomization.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/upgrades/kustomization.yaml
@@ -4,3 +4,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./talosupgrade.yaml
+  - ./kubernetesupgrade.yaml


### PR DESCRIPTION
Brings the tuppr setup in line with upstream `onedr0p/home-ops`.

### Changes
- **`upgrades/kubernetesupgrade.yaml`** (new) — `KubernetesUpgrade` → `v1.36.1` (matches `talenv.yaml`). This was the missing piece: there was no resource driving Kubernetes upgrades, so the cluster stayed on k8s v1.35.2. Same health checks as the TalosUpgrade (volsync not syncing + `CephCluster` `HEALTH_OK`).
- **`app/helmrelease.yaml`** — enable `monitoring.serviceMonitor`, `monitoring.prometheusRule`, and `monitoring.dashboards` (grafana-operator). `matchLabels` adapted to this cluster's instance label `grafana.internal/instance: grafana` (onedr0p uses `dashboards: grafana`).
- **`upgrades/kustomization.yaml`** — reference the new CR.

Validated with `kustomize build`.

### ⚠️ Merge sequencing
The current `TalosUpgrade` is in **`Failed`** state (talos-1's upgrade job failed permanently on 2026-05-28), so all nodes are still on **Talos v1.12.6** / **k8s v1.35.2**. Kubernetes **v1.36.1 requires Talos v1.13.x**, so this `KubernetesUpgrade` should only take effect **after** the Talos v1.13.3 upgrade succeeds. Recommend resolving the talos-1 Talos-upgrade failure first, then merging (or merge the monitoring portion now and hold the k8s CR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)