### PR TITLE
fix(talos): target Talos v1.13.2 instead of v1.13.3

### DIFF
--- a/kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   talos:
     # renovate: datasource=docker depName=ghcr.io/siderolabs/installer
-    version: v1.13.3
+    version: v1.13.2
   policy:
     rebootMode: powercycle
   healthChecks:

--- a/talos/talenv.yaml
+++ b/talos/talenv.yaml
@@ -1,4 +1,4 @@
 # renovate: datasource=docker depName=ghcr.io/siderolabs/installer
-talosVersion: v1.13.3
+talosVersion: v1.13.2
 # renovate: datasource=docker depName=ghcr.io/siderolabs/kubelet
 kubernetesVersion: v1.36.1


### PR DESCRIPTION
The v1.13.3 Talos upgrade **failed permanently on talos-1** (tuppr `TalosUpgrade` is stuck in `Failed`; all nodes are still on v1.12.6). Retarget to **v1.13.2** — the version proven in upstream `onedr0p/home-ops` alongside k8s v1.36.1.

### Changes
- `talos/talenv.yaml`: `talosVersion` v1.13.3 → v1.13.2
- tuppr `TalosUpgrade` CR: `spec.talos.version` v1.13.3 → v1.13.2

### Behaviour
- On merge, tuppr re-evaluates the `TalosUpgrade` and retries the rollout (1.12.6 → 1.13.2), one node at a time, gated by the existing health checks (volsync not syncing + `CephCluster` `HEALTH_OK`).
- tuppr preserves each node's **current installer schematic** (`89b72ce2…`), so extensions (i915, intel-ucode, mei, nfsrahead) are retained.

### Notes / follow-ups
- **Schematic drift (separate issue):** nodes run schematic `89b72ce2…` but `talconfig.yaml` now specifies `ac2b7006…`. This upgrade does **not** reconcile that — applying the repo's desired extensions/kernel args needs a `task talos:generate-config` + apply, handled separately.
- If talos-1 fails again on v1.13.2, the failure is node-specific (talos-1 has also been behind today's Cilium OOM / osd flap / mon crashes) and we should investigate the node directly.
- After nodes reach v1.13.2, #866 (KubernetesUpgrade → v1.36.1) becomes safe to merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)