### PR TITLE
feat(talos): add neighbor-table sysctls and fq qdisc

### DIFF
--- a/talos/patches/global/machine-sysctls.yaml
+++ b/talos/patches/global/machine-sysctls.yaml
@@ -24,6 +24,13 @@ machine:
     net.ipv4.tcp_wmem: "4096 65536 134217728"
     net.ipv4.tcp_window_scaling: 1
     net.ipv4.tcp_timestamps: 1
+    net.core.default_qdisc: fq            # Pair with BBR (fq + bbr) for proper packet pacing
+
+    # Neighbor/ARP table sizing - prevent "neighbour table overflow" packet drops
+    # in a busy multi-node cluster (from onedr0p/home-ops)
+    net.ipv4.neigh.default.gc_thresh1: 4096
+    net.ipv4.neigh.default.gc_thresh2: 8192
+    net.ipv4.neigh.default.gc_thresh3: 16384
 
     # File system optimizations
     fs.file-max: 1048576                  # More file handles


### PR DESCRIPTION
Adopts two low-risk network tunings observed in `onedr0p/home-ops` that your config was missing.

### Changes (`talos/patches/global/machine-sysctls.yaml`)
| sysctl | value | why |
|--------|-------|-----|
| `net.ipv4.neigh.default.gc_thresh1/2/3` | 4096 / 8192 / 16384 | Prevents **"neighbour table overflow"** ARP-table drops in a busy multi-node cluster — a plausible contributor to intermittent network blips. |
| `net.core.default_qdisc` | `fq` | You already set `tcp_congestion_control: bbr`, but BBR needs the `fq` qdisc for proper packet pacing. This completes that tuning. |

### Deliberately NOT changed (from the comparison)
- **kubePrism** — already enabled (Talos default; your Cilium already targets `127.0.0.1:7445`). No-op, skipped.
- **`hostDNS.forwardKubeDNSToHost`** — requires Cilium socketLB host-ns mode, but live Cilium has `bpf-lb-sock: false`. Adding it would risk breaking cluster DNS, so it's held pending a coordinated Cilium change.

### Apply note
These are machine-config patches — they take effect on the **next `task talos:generate-config` + apply** (or the next node cycle), not via Flux. Cleanest to fold into the upcoming Talos v1.13.2 node cycle (#867).

Validated with `yq` (valid YAML, correct keys).

🤖 Generated with [Claude Code](https://claude.com/claude-code)