### PR TITLE
feat(cilium): enable host-namespace socketLB (prereq for Talos hostDNS)

### DIFF
--- a/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
@@ -88,6 +88,12 @@ spec:
         trustCRDsExist: true
     rollOutCiliumPods: true
     routingMode: native
+    # Host-namespace-only socket LB. Prerequisite for Talos
+    # machine.features.hostDNS.forwardKubeDNSToHost; leaves the pod datapath
+    # unchanged (only host-namespace sockets use socket LB).
+    socketLB:
+      enabled: true
+      hostNamespaceOnly: true
     tunneling:
       mtu: 9000
     resources:


### PR DESCRIPTION
Prerequisite step so Talos `hostDNS.forwardKubeDNSToHost` can be enabled later (the comparison vs `onedr0p/home-ops` flagged it, but your live Cilium has `bpf-lb-sock: false`, so enabling the Talos feature now would break DNS).

### Change (`cilium/app/helmrelease.yaml`)
```yaml
socketLB:
  enabled: true
  hostNamespaceOnly: true
```
`hostNamespaceOnly` means **only host-namespace sockets** use socket LB — the pod datapath is unchanged, keeping this low-risk. Validated with `kustomize build`.

### ⚠️ Sequencing (two-step, do NOT do at once)
1. **Merge this PR first.** Flux rolls Cilium with socketLB host-ns enabled. Then **verify**:
   - `kubectl -n kube-system get cm cilium-config -o jsonpath='{.data.bpf-lb-sock}'` → should be `true`
   - DNS still resolves (`kubectl run -it --rm dnstest --image=busybox --restart=Never -- nslookup kubernetes.default`)
2. **Only after that's confirmed**, add the Talos feature (follow-up PR, `talos/patches/global/machine-features.yaml`) and apply via `task talos:generate-config` + `task talos:apply-node`:
   ```yaml
   machine:
     features:
       hostDNS:
         enabled: true
         forwardKubeDNSToHost: true
         resolveMemberNames: true
   ```

Doing both simultaneously risks a DNS outage if anything's misconfigured — hence the split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)