### PR TITLE
feat(talos): enable hostDNS forwardKubeDNSToHost

### DIFF
--- a/talos/patches/global/machine-features.yaml
+++ b/talos/patches/global/machine-features.yaml
@@ -7,3 +7,8 @@ machine:
       allowedKubernetesNamespaces:
         - actions-runner-system
         - system-upgrade
+    # Requires Cilium socketLB hostNamespaceOnly (enabled in cilium HelmRelease)
+    hostDNS:
+      enabled: true
+      forwardKubeDNSToHost: true
+      resolveMemberNames: true


### PR DESCRIPTION
Second half of the hostDNS work. The Cilium prerequisite (#869, socketLB `hostNamespaceOnly`) is merged and **verified live**: `bpf-lb-sock=true`, `hostns-only=true`, DNS resolving normally. So it's now safe to enable the Talos feature.

### Change (`talos/patches/global/machine-features.yaml`)
```yaml
machine:
  features:
    hostDNS:
      enabled: true
      forwardKubeDNSToHost: true
      resolveMemberNames: true
```

### Apply note
This is a machine-config patch — it takes effect on `task talos:generate-config` + `task talos:apply-node`, **not** via Flux. Recommended to **fold into the Talos v1.13.2 node cycle (#867/#868)** so it's a single apply rather than a separate node disruption.

### Post-apply verification
- `kubectl run -it --rm dnstest --image=busybox:1.36 --restart=Never -- nslookup kubernetes.default` still resolves
- host-level DNS works on nodes (kube-dns reachable from host namespace)

🤖 Generated with [Claude Code](https://claude.com/claude-code)