### PR TITLE
fix(authentik): pin chart back to 2026.5.0

### DIFF
--- a/kubernetes/apps/security/authentik/app/helmrelease.yaml
+++ b/kubernetes/apps/security/authentik/app/helmrelease.yaml
@@ -10,7 +10,7 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 2026.5.2
+    tag: 2026.5.0
   url: oci://ghcr.io/goauthentik/helm-charts/authentik
 ---
 # yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json


### PR DESCRIPTION
## Outage fix
The `2026.5.2` Renovate bump wedged the authentik helm release: **authentik-server stuck at `replicas=0`**, down since ~13:42 EDT, which also took down **coder** (OIDC `503`). Helm history showed v42–v45 all failing on the server deployment.

Recovered live via `helm rollback authentik 11` (last good, 2026.5.0 — ran clean since 05-27); server is back `1/1`. This PR pins the desired state to **2026.5.0** so Flux doesn't re-upgrade to the broken version when the (currently suspended) HR is resumed.

`2026.5.2` should be re-evaluated before bumping again (it's not a clean upgrade).

🤖 Generated with [Claude Code](https://claude.com/claude-code)