### PR TITLE
fix(emqx): pin operator back to 2.2.29 (OSS broker compat)

### DIFF
--- a/kubernetes/apps/database/emqx/operator/helmrelease.yaml
+++ b/kubernetes/apps/database/emqx/operator/helmrelease.yaml
@@ -9,7 +9,11 @@ spec:
   chart:
     spec:
       chart: emqx-operator
-      version: 2.3.1
+      # 2.3.x dropped support for EMQX OSS 5.8.x (calls Enterprise-only
+      # load_rebalance API -> 404 -> readiness gate never set). See
+      # emqx/emqx-operator#1202. Pin to last 2.2.x until broker moves to a
+      # 2.3.x-supported version or EMQX Enterprise.
+      version: 2.2.29
       sourceRef:
         kind: HelmRepository
         name: emqx-charts


### PR DESCRIPTION
## Outage fix
Operator **2.3.x dropped EMQX OSS 5.8.x support** — it calls the Enterprise-only `load_rebalance/global_status` API, gets 404, and treats it as fatal in the status reconcile (**emqx/emqx-operator#1202**, confirmed by maintainer). The reconcile aborts *before* setting the pod readiness gate, so emqx-core pods never go Ready → **empty service endpoints → MQTT down → zigbee2mqtt (and all MQTT clients) down**. Surfaced after today's node reboots forced readiness re-evaluation.

Reverts the operator (bumped to 2.3.1 in #738) back to **2.2.29**, the last release compatible with OSS 5.8.x. The brokers themselves are healthy (cluster clean, listening on 1883) — this is purely the operator's readiness-gate reconcile.

`2.3.x` needs either EMQX Enterprise or a broker on its supported matrix (5.9/5.10) before it can be used again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)