### PR TITLE
fix(tdarr): disable transcode workers on in-cluster nodes

### DIFF
--- a/kubernetes/apps/media/tdarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/tdarr/app/helmrelease.yaml
@@ -119,8 +119,10 @@ spec:
                 value: mapped
               - name: ffmpegVersion
                 value: "7"
+              # Transcoding is handled by an external GPU node (see tdarr-node-lb).
+              # In-cluster Talos nodes only run health-check workers.
               - name: transcodegpuWorkers
-                value: "1"
+                value: "0"
               - name: transcodecpuWorkers
                 value: "0"
               - name: healthcheckgpuWorkers


### PR DESCRIPTION
## What
Set `transcodegpuWorkers` to `0` on the in-cluster `tdarr-node` DaemonSet (`transcodecpuWorkers` was already `0`).

## Why
Transcoding is handled by an **external GPU node** (exposed via `tdarr-node-lb` on `8266`). The in-cluster Talos DaemonSet seeded `transcodegpuWorkers=1`, which re-applied as `seededWorkerLimits` on every pod restart/re-registration and reverted manual UI changes back to 1 transcode worker.

Live state confirmed the drift: `workerLimits.transcodegpu=0` (manual UI change) vs `seededWorkerLimits.transcodegpu=1` (from YAML).

## Effect
- Talos nodes no longer pick up transcode jobs — change now survives pod restarts.
- Health-check workers retained (`healthcheckgpu=1`, `healthcheckcpu=1`) so Talos nodes still verify file integrity.
- External GPU node remains the only transcoder.

## Note
A persisted per-hour `schedule` (in the `tdarr-config` PVC, not git) still lists `transcodegpu: 1`. It isn't currently forcing transcode on (live is `0`), but if "Use schedule" is enabled it could re-apply `1` — would need zeroing out in the UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)