### PR TITLE
fix(coredns): return NODATA for AAAA on IPv4-only cluster

### DIFF
--- a/kubernetes/apps/kube-system/coredns/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/coredns/app/helmrelease.yaml
@@ -39,6 +39,16 @@ spec:
               fallthrough in-addr.arpa ip6.arpa
           - name: autopath
             parameters: "@kubernetes"
+          # Cluster is IPv4-only (Cilium enable-ipv6=false, no IPv6 egress).
+          # Answer AAAA queries with NODATA so resolvers fall back to A
+          # immediately instead of wasting attempts on unreachable IPv6
+          # (e.g. Flux source-controller pulling from ghcr / github.io).
+          # Safe cluster-wide: every Service/Pod is IPv4-only, so AAAA NODATA
+          # matches what the kubernetes plugin already returns internally.
+          - name: template
+            parameters: ANY AAAA
+            configBlock: |-
+              rcode NOERROR
           - name: forward
             parameters: . /etc/resolv.conf
           - name: cache


### PR DESCRIPTION
## What
Add a CoreDNS `template ANY AAAA { rcode NOERROR }` plugin so AAAA (IPv6) queries return **NODATA**.

## Why
The cluster is **IPv4-only** — Cilium `enable-ipv6=false`, nodes have only IPv4 addresses, and there's no IPv6 egress. But cluster DNS still returned AAAA records for external names. Go's dialer (Flux **source-controller**) tries the IPv6 address first and fails:

```
dial tcp [2606:50c0:8002::153]:443: connect: network is unreachable
```

…then falls back to IPv4 and succeeds. Net effect: intermittent `OCIArtifactLayerOperationFailed` / `ChartPullError` against `ghcr` / `pkg-containers.githubusercontent.com` / `backube.github.io`. Sources still showed `Ready` (cached artifacts + IPv4 retry), but every fresh pull wasted IPv6 attempts.

## Fix
Return NODATA for AAAA so resolvers immediately use A records — no IPv6 dial attempts.

## Safety / blast radius
- **Cluster-wide AAAA → NODATA.** Safe here because every Service/Pod is IPv4-only; the `kubernetes` plugin already returns NODATA for AAAA on these. A-record resolution and PTR (reverse) are untouched (template matches type AAAA only).
- No effect on any workload that previously worked — nothing in this cluster can reach external IPv6 anyway.
- `kubectl kustomize` renders the plugin correctly; pre-commit passed. (flux-local couldn't run due to an unrelated Windows temp-file perms bug.)

## ⚠️ Note for merge
This touches **cluster DNS**. After merge, watch the CoreDNS rollout:
```
kubectl -n kube-system rollout status deploy/coredns
kubectl -n kube-system logs deploy/coredns | tail
```
CoreDNS does a rolling update (replicaCount 2); if the Corefile were ever rejected, the old pod stays serving. Verify with `dig`:
```
# external: A returns address, AAAA returns NODATA
dig +short github.com A ; dig +short github.com AAAA
# internal still resolves
dig +short kubernetes.default.svc.cluster.local
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)