### PR TITLE
fix(kubernetes): stop descheduler from evicting Ceph OSDs and critical pods

### DIFF
--- a/kubernetes/apps/kube-system/descheduler/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/descheduler/app/helmrelease.yaml
@@ -21,26 +21,20 @@ spec:
             - name: DefaultEvictor
               args:
                 evictFailedBarePods: true
-                evictLocalStoragePods: true
-                evictSystemCriticalPods: true
+                evictLocalStoragePods: false
+                evictSystemCriticalPods: false
             - name: LowNodeUtilization
               args:
                 metricsUtilization:
                   source: KubernetesMetrics
                 thresholds:
-                  cpu: 35
-                  memory: 35
-                  pods: 35
+                  cpu: 20
+                  memory: 20
+                  pods: 20
                 targetThresholds:
-                  cpu: 45
-                  memory: 45
-                  pods: 45
-            - name: HighNodeUtilization
-              args:
-                thresholds:
-                  cpu: 50
-                  memory: 50
-                  pods: 50
+                  cpu: 60
+                  memory: 60
+                  pods: 60
             - name: RemoveFailedPods
               args:
                 reasons:
@@ -64,7 +58,6 @@ spec:
             balance:
               enabled:
                 - LowNodeUtilization
-                - HighNodeUtilization
                 - RemovePodsViolatingTopologySpreadConstraint
             deschedule:
               enabled:


### PR DESCRIPTION
## Summary

- Remove `HighNodeUtilization` plugin — with all 3 nodes running at 10-27% memory, this was treating every node as a consolidation candidate and evicting pods from talos-1 every ~5 minutes
- Set `evictLocalStoragePods: false` and `evictSystemCriticalPods: false` to protect Ceph OSD pods (node-local) and system-critical workloads from eviction
- Widen `LowNodeUtilization` band to 20%/60% so it only fires on genuine imbalance

## Root cause

The descheduler was causing a full cascade: OSD-0 and OSD-3 entered CrashLoopBackOff on the `expand-bluefs` init container every time they were evicted and rescheduled, which blocked Ceph PVC provisioning cluster-wide, causing all Volsync hourly backups to fail with `FailedScheduling: pod has unbound immediate PersistentVolumeClaims` across every namespace. 18 PVs were also stuck as `VolumeFailedDelete` due to repeated detach/attach cycles on talos-1.

## Test plan

- [ ] Confirm descheduler no longer evicts pods from talos-1 after Flux reconciles
- [ ] Confirm OSD-0 and OSD-3 stay Running without restart
- [ ] Confirm next Volsync hourly backup runs successfully
- [ ] Monitor `kubectl get events -A --field-selector reason=BackOff` for absence of OSD entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)