### PR TITLE
fix(container): update image ghcr.io/grafana-community/helm-charts/loki ( 17.1.2 ➔ 17.1.5 )

### DIFF
--- a/kubernetes/apps/monitoring/loki/app/ocirepository.yaml
+++ b/kubernetes/apps/monitoring/loki/app/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 17.1.2
+    tag: 17.1.5
   url: oci://ghcr.io/grafana-community/helm-charts/loki


### PR DESCRIPTION
Renovate dependency update. Triaged as a safe low-risk bump.