### PR TITLE
fix(container): update image ghcr.io/home-operations/charts/tuppr ( 0.1.37 ➔ 0.1.39 )

### DIFF
--- a/kubernetes/apps/system-upgrade/tuppr/app/ocirepository.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/app/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 0.1.37
+    tag: 0.1.39
   url: oci://ghcr.io/home-operations/charts/tuppr


### PR DESCRIPTION
Renovate dependency update. Triaged as a safe low-risk bump.