### PR TITLE
feat(container): update image ghcr.io/prometheus-community/charts/kube-prometheus-stack ( 86.0.1 ➔ 86.1.0 )

### DIFF
--- a/kubernetes/apps/monitoring/kube-prometheus-stack/app/ocirepository.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/app/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 86.0.1
+    tag: 86.1.0
   url: oci://ghcr.io/prometheus-community/charts/kube-prometheus-stack


### PR DESCRIPTION
Renovate dependency update. Triaged as a safe low-risk bump.