### PR TITLE
chore(renovate): pin Talos to <1.13.3 (known-bad upgrade)

### DIFF
--- a/.renovate/overrides.json5
+++ b/.renovate/overrides.json5
@@ -34,5 +34,17 @@
       matchPackageNames: ["public.ecr.aws/emqx/emqx"],
       allowedVersions: "<5.9.0",
     },
+    {
+      // v1.13.3 upgrade failed permanently on talos-1 (tuppr TalosUpgrade
+      // stuck Failed, nodes stranded on v1.12.6). Pinned to v1.13.2 in #867.
+      // Hold the installer image + talosctl CLI here until v1.13.3+ is proven.
+      description: "Pin Talos to <1.13.3 (1.13.3 upgrade fails on talos-1, see #867)",
+      matchPackageNames: [
+        "ghcr.io/siderolabs/installer",
+        "siderolabs/talos",
+        "/factory\\.talos\\.dev/",
+      ],
+      allowedVersions: "<1.13.3",
+    },
   ],
 }


### PR DESCRIPTION
Stops Renovate from re-proposing **Talos v1.13.3**, which fails permanently on talos-1 (tuppr `TalosUpgrade` stuck Failed). The cluster is intentionally pinned to v1.13.2 per #867.

Adds an `allowedVersions: "<1.13.3"` rule covering the installer image, the `factory.talos.dev` override, and the `siderolabs/talos` (talosctl) CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)