### PR TITLE
feat(container): update chart kube-prometheus-stack ( 86.0.1 ➔ 86.1.0 )

### DIFF
--- a/kubernetes/apps/monitoring/kube-prometheus-stack/app/ocirepository.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/app/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 86.0.1
+    tag: 86.1.0
   url: oci://ghcr.io/prometheus-community/charts/kube-prometheus-stack


### PR DESCRIPTION
Re-created fresh from main; the Renovate branch `renovate/...kube-prometheus-stack-86.x` was stale (pre-SOPS-cutover) and conflicted. Supersedes #884.

🤖 Generated with [Claude Code](https://claude.com/claude-code)