### PR TITLE
feat(container): update image ghcr.io/browserless/chromium ( v2.49.0 ➔ v2.50.1 )

### DIFF
--- a/kubernetes/apps/selfhosted/rsshub/playwright/hr.yaml
+++ b/kubernetes/apps/selfhosted/rsshub/playwright/hr.yaml
@@ -25,7 +25,7 @@ spec:
           app:
             image:
               repository: ghcr.io/browserless/chromium
-              tag: v2.49.0
+              tag: v2.50.1
             env:
               TZ: ${TIMEZONE}
               DATA_DIR: /config/


### PR DESCRIPTION
Routine Renovate bump (single-file). Triaged low-risk.