### PR TITLE
feat(container): update image ghcr.io/haveagitgat/tdarr_node ( 2.76.01 ➔ 2.77.01 )

### DIFF
--- a/kubernetes/apps/media/tdarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/tdarr/app/helmrelease.yaml
@@ -95,7 +95,7 @@ spec:
           app:
             image:
               repository: ghcr.io/haveagitgat/tdarr_node
-              tag: 2.76.01
+              tag: 2.77.01
             env:
               - name: TZ
                 value: America/New_York


### PR DESCRIPTION
Routine Renovate bump (single-file). Triaged low-risk.