### PR TITLE
fix(monitoring): raise Prometheus memory limit 3Gi->8Gi (OOM crash loop)

### DIFF
--- a/kubernetes/apps/monitoring/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/app/helmrelease.yaml
@@ -121,9 +121,11 @@ spec:
         resources:
           requests:
             cpu: 100m
-            memory: 2Gi
-          limits:
             memory: 3Gi
+          # 3Gi OOMKilled the pod during TSDB head compaction (self-reinforcing
+          # crash loop). Node has ample headroom; 8Gi absorbs the compaction spike.
+          limits:
+            memory: 8Gi
         retention: 14d
         retentionSize: 50GB
         ruleSelectorNilUsesHelmValues: false


### PR DESCRIPTION
## Problem
`prometheus-kube-prometheus-stack-0` was in `CrashLoopBackOff`, **OOMKilled (137)** repeatedly (9 restarts in 32m, down ~1h).

## Root cause
Prometheus replays the WAL fine, reaches *"Server is ready"*, then **OOMs during the first TSDB head-block compaction** (`compact.go: write block started` → killed). The 3Gi limit was too low for the compaction spike, so compaction never completed and the head/WAL kept growing — a self-reinforcing loop. Likely tipped over by the `82.18.0 → 86.0.1` chart jump (#852) increasing series.

## Fix
Raise `prometheusSpec.resources`: requests `2Gi → 3Gi`, limits `3Gi → 8Gi`. Node `talos-1` is at ~15% memory (~80GB free), so this is safe and lets one compaction finish, breaking the loop.

Live-patched the `Prometheus` CR for immediate recovery; this PR persists it so Flux doesn't revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)