### PR TITLE
fix(sabnzbd): relax probes and raise CPU limit to stop liveness kill loop

### DIFF
--- a/kubernetes/apps/downloads/sabnzbd/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/sabnzbd/app/helmrelease.yaml
@@ -76,7 +76,23 @@ spec:
               - secretRef:
                   name: sabnzbd-secret
             probes:
-              liveness: &probes
+              # SABnzbd's web API blocks during heavy post-processing (par2
+              # verify/repair, unrar/7zip). A 1s timeout tripped the liveness
+              # probe and killed a busy-but-healthy process, dropping it from
+              # the Service endpoints (gateway 503s). Probes are relaxed so only
+              # a genuinely dead process is restarted.
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /api?mode=version
+                    port: *port
+                  initialDelaySeconds: 0
+                  periodSeconds: 30
+                  timeoutSeconds: 15
+                  failureThreshold: 5
+              readiness:
                 enabled: true
                 custom: true
                 spec:
@@ -85,15 +101,14 @@ spec:
                     port: *port
                   initialDelaySeconds: 0
                   periodSeconds: 10
-                  timeoutSeconds: 1
+                  timeoutSeconds: 10
                   failureThreshold: 3
-              readiness: *probes
             resources:
               requests:
                 cpu: 500m # Increased from 5m to 500m
                 memory: 1024Mi
               limits:
-                cpu: 2000m # Added CPU limit
+                cpu: 4000m # Raised 2000m->4000m so par2/7zip aren't throttled (slow API trips probes)
                 memory: 6144Mi
             securityContext:
               allowPrivilegeEscalation: false


### PR DESCRIPTION
## Problem

SABnzbd was unreachable through the internal gateway (`upstream connect error or disconnect/reset before headers`). Root cause: a **liveness-probe kill loop**.

SABnzbd's web API is effectively single-threaded and blocks during heavy post-processing (par2 verify/repair, unrar/7zip extraction). The probes used `timeoutSeconds: 1`, so a busy-but-healthy process failed the probe:

```
Readiness probe failed: ...api?mode=version: context deadline exceeded
Liveness probe failed:  context deadline exceeded
Container app failed liveness probe, will be restarted
Readiness probe failed: connect: connection refused
```

Restarting a NotReady pod drops it from the Service endpoints → `envoy-internal` has no healthy upstream → gateway 5xx. Restarting mid-post-processing also worsens the backlog (vicious cycle). The process was never crashed or OOMKilled — it was killed for being busy.

## Fix

- Split `liveness`/`readiness` (they shared one anchor).
- Liveness: `timeoutSeconds 1→15`, `periodSeconds 10→30`, `failureThreshold 3→5` — only restart a genuinely dead process.
- Readiness: `timeoutSeconds 1→10`.
- CPU limit `2000m→4000m` so par2/7zip don't get throttled (throttling is part of what made the API slow enough to trip the probe).

## Test

- `task flux:test:ns NAMESPACE=downloads` (kustomize build/validate)
- After merge, Flux rolls the new probe config; pod should go `1/1` Ready and stay there through post-processing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)