### PR TITLE
fix(sabnzbd): suspend (replicas 0) during Ceph slow-ops incident

### DIFF
--- a/kubernetes/apps/downloads/sabnzbd/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/sabnzbd/app/helmrelease.yaml
@@ -16,6 +16,11 @@ spec:
   values:
     controllers:
       sabnzbd:
+        # Suspended (replicas 0) during the 2026-06-01 Ceph slow-ops incident:
+        # sabnzbd's download + par2/unrar/7zip storm on CephFS overwhelms the
+        # DRAM-less Lexar OSDs. Restore to 1 once Ceph is stable / drives sorted.
+        # See docs/ceph-performance-review.md.
+        replicas: 0
         annotations:
           reloader.stakater.com/auto: "true"
 


### PR DESCRIPTION
Sets `controllers.sabnzbd.replicas: 0` so Flux keeps sabnzbd suspended.

**Why:** during the 2026-06-01 Ceph slow-ops incident, sabnzbd's download + par2/unrar/7zip storm on the CephFS `ceph-filesystem-data0` pool repeatedly tips the DRAM-less Lexar NM790 OSDs into BlueStore slow-ops / laggy-PG wedges. A runtime `kubectl scale --replicas=0` is reverted by Flux on the next reconcile (~30 min), so this makes the suspension durable.

**Restore:** set `replicas: 1` (or remove the line) once Ceph is stable and the drive situation is addressed (see `docs/ceph-performance-review.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)