### PR TITLE
feat(rook-ceph): enable bulk PG autoscaling on block + cephfs data pools

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -179,6 +179,10 @@ spec:
           compressionMode: none
           parameters:
             compression_mode: none
+            # bulk=true: let the PG autoscaler provision a full PG complement for
+            # this large data pool and scale it up gradually (gentle backfill vs a
+            # hard pg_num jump). See docs/ceph-performance-review.md.
+            bulk: "true"
         storageClass:
           enabled: true
           name: ceph-block
@@ -224,6 +228,8 @@ spec:
                 size: 3
               parameters:
                 compression_mode: none
+                # bulk=true: autoscaler-driven PG growth for the main CephFS data pool.
+                bulk: "true"
           metadataServer:
             activeCount: 2
             activeStandby: true


### PR DESCRIPTION
Sets `bulk=true` on `ceph-blockpool` and `ceph-filesystem-data0` so the PG autoscaler provisions a proper PG complement for these large data pools (they were stuck at 8 / 16 PGs across 6 OSDs — too few for write parallelism, and a factor in the lease-contention wedge).

## Why bulk instead of a hard pg_num
- Autoscaler stays in control and **scales pg_num up gradually** (throttled), rather than a hard 8→128 jump → gentler backfill on the consumer drives.
- Self-maintaining as data grows.

## Timing / safety
- Applied while **sabnzbd is suspended and scrubs are paused** — lowest-load window.
- `osd_max_backfills=1` keeps the rebalance mild.
- Backfill will be monitored; if slow-ops reappear on the Lexar OSDs it can be paused instantly with `ceph osd set nobackfill` (reversible).

Deferred PG plan from `docs/ceph-performance-review.md`, done the autoscaler-native way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)