### PR TITLE
fix(rook-ceph): restore immutable ceph-block StorageClass params (unstall HR)

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -191,7 +191,12 @@ spec:
           allowVolumeExpansion: true
           volumeBindingMode: Immediate
           parameters:
-            compression_mode: none
+            # StorageClass parameters are IMMUTABLE — these must match the live SC
+            # or the Helm upgrade fails ("field is immutable") and rolls back the
+            # whole release. Compression is controlled at the pool level (above);
+            # this only tags new RBD images and the pool 'none' setting governs.
+            compression_mode: aggressive
+            compression_algorithm: zstd
             imageFormat: "2"
             imageFeatures: layering,fast-diff,object-map,deep-flatten,exclusive-lock
             csi.storage.k8s.io/provisioner-secret-name: rook-csi-rbd-provisioner


### PR DESCRIPTION
## Problem
PR #900 changed the `ceph-block` **StorageClass** `compression_mode` `aggressive`→`none`. StorageClass `parameters` are **immutable** in Kubernetes, so every Helm upgrade failed:
```
cannot patch "ceph-block" StorageClass ... parameters ... field is immutable
```
…and rolled back the **entire** rook-ceph-cluster release. Result: the HR went `Stalled` (retries exceeded) and **none** of the intended changes (#900 pool compression + cache, #902 bulk) ever applied — the cluster stayed on the old release.

## Fix
Restore the StorageClass params to match the live object (`compression_mode: aggressive`, `compression_algorithm: zstd`) so Helm sees no diff on the immutable SC. Compression stays disabled at the **pool level** (`spec.parameters.compression_mode: none`) — that's what governs OSD-side compression; the SC value only tags new RBD images.

Unblocks the stalled upgrade so pool-compression + `osd_memory_target` + `bulk` PG autoscaling all land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)