### PR TITLE
fix(rook-ceph): drop deviceClass nvme from cephfs data0 (fix overlapping roots)

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -225,10 +225,14 @@ spec:
             parameters:
               compression_mode: none
           dataPools:
-            # Single pool for all data - identical performance on all-NVMe
+            # Single pool for all data - identical performance on all-NVMe.
+            # No deviceClass: all OSDs are one class, so pinning data0 to the
+            # nvme shadow root made it the ONLY pool on root -2 while every other
+            # pool uses root -1 (default) -> "overlapping roots" -> the PG
+            # autoscaler skipped ALL pools. Using the default root fixes that.
+            # See docs/ceph-performance-review.md.
             - name: data0
               failureDomain: host
-              deviceClass: nvme
               replicated:
                 size: 3
               parameters:


### PR DESCRIPTION
Removes `deviceClass: nvme` from the `ceph-filesystem-data0` pool.

## Why
data0 was the **only** pool pinned to the nvme device-class root (`default~nvme`); all other pools use the default root. With a single OSD device class, those roots overlap, and the PG autoscaler **skips every pool** ("won't scale due to overlapping roots"). The deviceClass bought nothing (one class). Removing it puts data0 on the default root → no overlap → autoscaler (already `bulk=true`) can finally scale.

## Impact
Remaps data0 → **~800 GB rebalance**, throttled by `osd_max_backfills=1`.

## Safety / timing
- Done after a clean deep-scrub + passing load test (no slow-ops under 23 concurrent deep-scrubs), integrity restored (pg 7.4 + 2.7 repaired), temps healthy (44–63 °C).
- sabnzbd suspended → low competing load.
- Pausable anytime with `ceph osd set norebalance` (reversible).

🤖 Generated with [Claude Code](https://claude.com/claude-code)