### PR TITLE
tune(rook-ceph): gentler off-peak scrubs + high_client_ops mclock

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -69,6 +69,14 @@ spec:
           # each OSD at 2GB despite the 8Gi pod limit). 6GiB leaves heap+headroom.
           osd_memory_target: "6442450944" # 6 GiB
           osd_recovery_max_active: "3" # Don't overwhelm homelab hardware
+          # Gentler, off-peak scrubbing for the consumer NVMe: 1 scrub per OSD
+          # at a time (was 3 -> ~23 concurrent deep-scrubs cluster-wide), and
+          # confine to 01:00-07:00. See docs/ceph-performance-review.md.
+          osd_max_scrubs: "1"
+          osd_scrub_begin_hour: "1"
+          osd_scrub_end_hour: "7"
+          # Prioritise client I/O over background work on latency-sensitive drives.
+          osd_mclock_profile: high_client_ops
 
         client.rgw:
           # Explicitly set realm to prevent orphan default zone/zonegroup creation


### PR DESCRIPTION
Performance tuning for the consumer NVMe (apply when ready — **hold until Prometheus is healthy** so we can watch the effect).

## Changes (`cluster/helmrelease.yaml` cephConfig.osd)
- **`osd_max_scrubs: 1`** (was 3) — re-enabling scrubs spawned ~23 concurrent deep-scrubs cluster-wide; one-per-OSD is much gentler on the drives.
- **`osd_scrub_begin_hour: 1` / `osd_scrub_end_hour: 7`** — confine scrubbing to off-peak.
- **`osd_mclock_profile: high_client_ops`** (was balanced) — prioritise client I/O latency over background scrub/recovery.

## Notes
- All runtime-applied via Rook (no rebalance, no data movement).
- Already-optimal items left untouched: PG balancer (upmap, perfectly balanced), osd_memory_target (6 GiB), osd_max_backfills (1).
- Does not change the fundamental consumer-NVMe ceiling — datacenter/PLP drives remain the durable fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)