### PR TITLE
feat(grafana): add Ceph dashboards (Cluster/OSD/Pools)

### DIFF
--- a/kubernetes/apps/monitoring/grafana/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/grafana/app/helmrelease.yaml
@@ -109,6 +109,29 @@ spec:
               path: /var/lib/grafana/dashboards/storage
 
     dashboards:
+      storage:
+        # Official Ceph dashboards (work with rook-ceph mgr/exporter ceph_* metrics)
+        ceph-cluster:
+          # renovate: dashboardName="Ceph Cluster"
+          gnetId: 2842
+          revision: 18
+          datasource:
+            - name: DS_PROMETHEUS
+              value: Prometheus
+        ceph-osd:
+          # renovate: dashboardName="Ceph - OSD (Single)"
+          gnetId: 5336
+          revision: 9
+          datasource:
+            - name: DS_PROMETHEUS
+              value: Prometheus
+        ceph-pools:
+          # renovate: dashboardName="Ceph - Pools"
+          gnetId: 5342
+          revision: 9
+          datasource:
+            - name: DS_PROMETHEUS
+              value: Prometheus
       default:
         external-dns:
           # renovate: dashboardName="External-DNS"


### PR DESCRIPTION
Adds the official Ceph Grafana dashboards so Ceph performance is viewable directly in Grafana (Option A — no Ceph-dashboard iframe embedding).

## Dashboards (in the **Storage** folder)
- **2842** Ceph Cluster — health, capacity, IOPS, throughput, latency
- **5336** Ceph - OSD (Single) — per-OSD perf (spot slow/failing disks)
- **5342** Ceph - Pools — per-pool usage/throughput

Metrics are already scraped via the rook-ceph mgr + exporter ServiceMonitors (verified: 4/4 ceph targets up, `ceph_*` metrics present), and Prometheus is healthy again, so these will populate immediately.

Imported via the chart's `gnetId`+`revision` with the standard `DS_PROMETHEUS → Prometheus` datasource override, matching the existing dashboards in this file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)