### PR TITLE
revert(grafana): remove duplicate Ceph dashboards storage block (#906)

### DIFF
--- a/kubernetes/apps/monitoring/grafana/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/grafana/app/helmrelease.yaml
@@ -109,29 +109,6 @@ spec:
               path: /var/lib/grafana/dashboards/storage
 
     dashboards:
-      storage:
-        # Official Ceph dashboards (work with rook-ceph mgr/exporter ceph_* metrics)
-        ceph-cluster:
-          # renovate: dashboardName="Ceph Cluster"
-          gnetId: 2842
-          revision: 18
-          datasource:
-            - name: DS_PROMETHEUS
-              value: Prometheus
-        ceph-osd:
-          # renovate: dashboardName="Ceph - OSD (Single)"
-          gnetId: 5336
-          revision: 9
-          datasource:
-            - name: DS_PROMETHEUS
-              value: Prometheus
-        ceph-pools:
-          # renovate: dashboardName="Ceph - Pools"
-          gnetId: 5342
-          revision: 9
-          datasource:
-            - name: DS_PROMETHEUS
-              value: Prometheus
       default:
         external-dns:
           # renovate: dashboardName="External-DNS"


### PR DESCRIPTION
Reverts #906. The Ceph dashboards (2842/5336/5342) **already existed** in the grafana helmrelease (loaded via `gnetId`); #906 added a duplicate `storage:` mapping key, which breaks the grafana Flux Kustomization build (caught by flux-local CI, but #906 was merged before the check failed).

This restores the single, correct `storage:` block. The Ceph dashboards remain present in Grafana — nothing is lost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)