### PR TITLE
feat(sabnzbd): resume now Ceph is stable

### DIFF
--- a/kubernetes/apps/downloads/sabnzbd/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/sabnzbd/app/helmrelease.yaml
@@ -16,11 +16,6 @@ spec:
   values:
     controllers:
       sabnzbd:
-        # Suspended (replicas 0) during the 2026-06-01 Ceph slow-ops incident:
-        # sabnzbd's download + par2/unrar/7zip storm on CephFS overwhelms the
-        # DRAM-less Lexar OSDs. Restore to 1 once Ceph is stable / drives sorted.
-        # See docs/ceph-performance-review.md.
-        replicas: 0
         annotations:
           reloader.stakater.com/auto: "true"
 


### PR DESCRIPTION
Reverts the #901 suspend (`replicas: 0` → app-template default of 1).

Safe to resume: Ceph is `HEALTH_OK` and hardened (compression off, bulk PG autoscaling → 128 PGs, larger OSD/MDS cache, gentler off-peak scrubs, high_client_ops mClock, osd.0 rebuilt). sabnzbd also has the relaxed liveness probes from #899, so par2/unrar/7zip post-processing won't trip the kill-loop again.

After merge: verify the pod runs `1/1` and its config (RWO ceph-block) + downloads (RWX cephfs) PVCs mount and work.