### PR TITLE
refactor(ai): repoint open-notebook/perplexica to agentgateway, pin gateway LB IPs

### DIFF
--- a/kubernetes/apps/ai-system/agentgateway/app/gateways/internal-noauth.yaml
+++ b/kubernetes/apps/ai-system/agentgateway/app/gateways/internal-noauth.yaml
@@ -3,6 +3,11 @@ kind: Gateway
 metadata:
   name: internal-noauth
 spec:
+  # Pin the LB IP Cilium originally auto-allocated, so the Service keeps it
+  # across recreation (e.g. the planned ai-system -> ai namespace move).
+  infrastructure:
+    annotations:
+      lbipam.cilium.io/ips: 10.50.0.28
   gatewayClassName: agentgateway
   listeners:
     - name: http

--- a/kubernetes/apps/ai-system/agentgateway/app/gateways/internal.yaml
+++ b/kubernetes/apps/ai-system/agentgateway/app/gateways/internal.yaml
@@ -3,6 +3,11 @@ kind: Gateway
 metadata:
   name: internal
 spec:
+  # Pin the LB IP Cilium originally auto-allocated, so the Service keeps it
+  # across recreation (e.g. the planned ai-system -> ai namespace move).
+  infrastructure:
+    annotations:
+      lbipam.cilium.io/ips: 10.50.0.27
   gatewayClassName: agentgateway
   listeners:
     - name: http

--- a/kubernetes/apps/ai-system/agentgateway/app/gateways/public.yaml
+++ b/kubernetes/apps/ai-system/agentgateway/app/gateways/public.yaml
@@ -3,6 +3,11 @@ kind: Gateway
 metadata:
   name: public
 spec:
+  # Pin the LB IP Cilium originally auto-allocated, so the Service keeps it
+  # across recreation (e.g. the planned ai-system -> ai namespace move).
+  infrastructure:
+    annotations:
+      lbipam.cilium.io/ips: 10.50.0.29
   gatewayClassName: agentgateway
   listeners:
     - name: http

--- a/kubernetes/apps/ai/open-notebook/app/externalsecret.yaml
+++ b/kubernetes/apps/ai/open-notebook/app/externalsecret.yaml
@@ -29,11 +29,14 @@ spec:
         # ELEVENLABS_API_KEY: "{{ .ELEVENLABS_API_KEY }}"
         # Optional: Ollama local models
         OLLAMA_API_BASE: "http://ollama:11434"
-        OPENAI_COMPATIBLE_API_KEY: "{{ .OPEN_NOTEBOOK_LITELLM_API_KEY }}"
+        # agentgateway internal-noauth injects the real provider key; the
+        # client just needs a non-empty placeholder.
+        OPENAI_COMPATIBLE_API_KEY: "agentgateway-noauth"
         # Optional: Security
         OPEN_NOTEBOOK_PASSWORD: "{{ .OPEN_NOTEBOOK_PASSWORD }}"
         # Application settings
-        OPENAI_COMPATIBLE_BASE_URL: "http://litellm:4000"
+        # OpenAI via agentgateway (path-per-provider; client appends /v1/...)
+        OPENAI_COMPATIBLE_BASE_URL: "http://internal-noauth.ai-system.svc.cluster.local/openai"
         LOG_LEVEL: "INFO"
         MAX_UPLOAD_SIZE: "100MB"
         ENABLE_ANALYTICS: "false"

--- a/kubernetes/apps/ai/open-webui/README.md
+++ b/kubernetes/apps/ai/open-webui/README.md
@@ -1,0 +1,36 @@
+# Open-WebUI
+
+Chat UI at `https://chat.${SECRET_DOMAIN}` (OIDC via Authentik).
+
+## Model connections (manual UI step)
+
+Open-WebUI stores API connections in its database (PersistentConfig), so they
+are **not** managed by GitOps. Configure them once in
+**Admin Settings → Connections → OpenAI API**.
+
+All LLM traffic goes through **agentgateway** (the single model gateway).
+agentgateway has no aggregated `/v1/models`, so add **one connection per
+provider path** — each connection contributes its own model list:
+
+| Provider   | API Base URL                                                          | API Key       |
+| ---------- | --------------------------------------------------------------------- | ------------- |
+| OpenAI     | `http://internal-noauth.ai-system.svc.cluster.local/openai/v1`        | any non-empty |
+| Anthropic  | `http://internal-noauth.ai-system.svc.cluster.local/anthropic/v1`     | any non-empty |
+| Groq       | `http://internal-noauth.ai-system.svc.cluster.local/groq/v1`          | any non-empty |
+| Gemini     | `http://internal-noauth.ai-system.svc.cluster.local/gemini/v1`        | any non-empty |
+| DeepSeek   | `http://internal-noauth.ai-system.svc.cluster.local/deepseek/v1`      | any non-empty |
+| OpenRouter | `http://internal-noauth.ai-system.svc.cluster.local/openrouter/v1`    | any non-empty |
+
+Notes:
+
+- The `internal-noauth` gateway **injects the real provider API key**
+  (per-provider `AgentgatewayBackend` + ExternalSecret from the 1Password
+  `ai-keys` item). The key entered in Open-WebUI is a placeholder — it just
+  has to be non-empty.
+- Provider passthrough model lists are unfiltered; disable unwanted models
+  under **Admin Settings → Models**.
+- After the agentgateway namespace move (`ai-system` → `ai`), update the URLs
+  to `internal-noauth.ai.svc.cluster.local`.
+- Backend definitions live in
+  `kubernetes/apps/ai-system/agentgateway/app/backends/` — adding a Backend
+  there (GitOps) and a matching connection here exposes a new provider.

--- a/kubernetes/apps/ai/perplexica/app/externalsecret.yaml
+++ b/kubernetes/apps/ai/perplexica/app/externalsecret.yaml
@@ -30,8 +30,10 @@ spec:
           API_KEY = ""
 
           [MODELS.CUSTOM_OPENAI]
-          API_KEY = "{{ .LITELLM_PERPLEXICA_API_KEY }}"
-          API_URL = "http://litellm:4000"
+          # agentgateway internal-noauth injects the real provider key; the
+          # client just needs a non-empty placeholder.
+          API_KEY = "agentgateway-noauth"
+          API_URL = "http://internal-noauth.ai-system.svc.cluster.local/openai"
           MODEL_NAME = ""
 
           [MODELS.OLLAMA]


### PR DESCRIPTION
## Phase 2.1 of AI namespace consolidation — consumer repoint (LiteLLM decoupling)

Decouples the two real LiteLLM consumers **before** LiteLLM is removed (next PR). LiteLLM keeps running as fallback until this is verified.

### Changes
- **open-notebook** `OPENAI_COMPATIBLE_BASE_URL` and **perplexica** `[MODELS.CUSTOM_OPENAI] API_URL`: `http://litellm:4000` → `http://internal-noauth.ai-system.svc.cluster.local/openai` — same client semantics (app appends `/v1/...`; the gateway strips the provider prefix and injects the real OpenAI key from the `ai-keys` 1Password item). API keys become non-empty placeholders (`internal-noauth` gateway needs none).
- **LB IP pinning**: the three agentgateway Gateways had Cilium-auto-allocated LoadBalancer IPs with no `lbipam.cilium.io/ips` annotation — IP churn risk on the upcoming namespace move. Pinned via `spec.infrastructure.annotations` (internal=`10.50.0.27`, internal-noauth=`10.50.0.28`, public=`10.50.0.29`).
- **Open-WebUI README**: documents the one-time Admin Settings → Connections setup (per-provider gateway URLs; Open-WebUI persists connections in its DB, so this is a UI step, not GitOps).

### Verification after merge
```
kubectl -n ai get externalsecret open-notebook perplexica-secret   # SecretSynced
kubectl -n ai rollout restart deploy open-notebook perplexica      # pick up new secrets
kubectl -n ai-system get svc internal internal-noauth public -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.metadata.annotations.lbipam\.cilium\.io/ips}{"\n"}{end}'
# functional: open-notebook + perplexica model calls succeed via gateway
```

Smoke-tested already: `internal-noauth/openai/v1/models` → 200 and `groq/v1/models` returns live model list on agentgateway v1.2.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)