### PR TITLE
fix(perplexica): use Recreate strategy for RWO PVCs

### DIFF
--- a/kubernetes/apps/ai/perplexica/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/perplexica/app/helmrelease.yaml
@@ -20,7 +20,8 @@ spec:
     controllers:
       perplexica:
         replicas: 1
-        strategy: RollingUpdate
+        # RWO PVCs (dbstore/uploads): RollingUpdate deadlocks on Multi-Attach
+        strategy: Recreate
         annotations:
           reloader.stakater.com/auto: "true"
         containers:


### PR DESCRIPTION
The Phase 2.1 secret repoint (#939) triggered a rollout that deadlocked: perplexica runs `RollingUpdate` with two RWO ceph-block PVCs (dbstore/uploads) → `Multi-Attach error` while the old pod holds the volumes. Same fix as the app-template v5 sweep: single-RWO apps need `strategy: Recreate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)