### PR TITLE
feat(ai): expose model API externally with per-consumer API keys

### DIFF
--- a/kubernetes/apps/ai/agentgateway/app/externalsecret-apikeys.yaml
+++ b/kubernetes/apps/ai/agentgateway/app/externalsecret-apikeys.yaml
@@ -1,0 +1,31 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+# Consumer API keys for the externally exposed model API (llm-api.*).
+# Each entry in the target Secret is one consumer: the entry name is the
+# consumer id, the JSON value carries the key plus metadata that policies
+# and access logs can reference (e.g. apiKey.user).
+#
+# 1Password item `ai-gateway-keys` fields:
+#   GATEWAY_KEY_SASCHA      - personal key (e.g. `openssl rand -hex 24`)
+#   GATEWAY_KEY_AUTOMATION  - shared key for scripts/automations
+# Add a new consumer = add a 1P field + an entry below.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: agentgateway-api-keys
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: agentgateway-api-keys
+    template:
+      data:
+        sascha: |
+          {"key": "{{ .GATEWAY_KEY_SASCHA }}", "metadata": {"user": "sascha"}}
+        automation: |
+          {"key": "{{ .GATEWAY_KEY_AUTOMATION }}", "metadata": {"user": "automation"}}
+  dataFrom:
+    - extract:
+        key: ai-gateway-keys

--- a/kubernetes/apps/ai/agentgateway/app/httproute-api-external.yaml
+++ b/kubernetes/apps/ai/agentgateway/app/httproute-api-external.yaml
@@ -1,0 +1,30 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/gateway.networking.k8s.io/httproute_v1.json
+# External (and internal) OpenAI-compatible API endpoint for the model
+# gateway. Envoy terminates TLS for llm-api.* and forwards to the
+# agentgateway `public` data-plane Service on its HTTP listener, where the
+# API-key policy (apikey-policy.yaml) enforces per-consumer bearer keys.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: agentgateway-api
+  annotations:
+    external-dns.alpha.kubernetes.io/target: "internal.${SECRET_DOMAIN},external.${SECRET_DOMAIN}"
+    gatus.home-operations.com/endpoint: |-
+      conditions: ["[STATUS] == 401"]
+      url: "https://llm-api.${SECRET_DOMAIN}/openai/v1/models"
+spec:
+  hostnames:
+    - "llm-api.${SECRET_DOMAIN}"
+  parentRefs:
+    - name: envoy-internal
+      namespace: network
+      sectionName: https
+    - name: envoy-external
+      namespace: network
+      sectionName: https
+  rules:
+    - backendRefs:
+        - name: public
+          namespace: ai
+          port: 80

--- a/kubernetes/apps/ai/agentgateway/app/kustomization.yaml
+++ b/kubernetes/apps/ai/agentgateway/app/kustomization.yaml
@@ -33,6 +33,8 @@ resources:
 - ./helmrelease.yaml
 - ./httproute.yaml
 - ./httproute-internal.yaml
+- ./httproute-api-external.yaml
+- ./externalsecret-apikeys.yaml
 - ./ocirepository.yaml
 - ./service-admin-ui.yaml
 - ./externalsecret-tls.yaml

--- a/kubernetes/apps/ai/agentgateway/app/policies/apikey-policy.yaml
+++ b/kubernetes/apps/ai/agentgateway/app/policies/apikey-policy.yaml
@@ -1,0 +1,25 @@
+---
+# Per-consumer API keys for the model API exposed via llm-api.* (the
+# `public` gateway HTTP listener that envoy forwards to). Keys are read from
+# the Authorization header with the `Bearer ` prefix (the default location),
+# matching what OpenAI-compatible clients send. The https listener keeps the
+# authentik extAuth policy for browser access.
+#
+# Keys live in the `ai-gateway-keys` 1Password item (see
+# externalsecret-apikeys.yaml) - never in Git. The in-cluster
+# `internal-noauth` gateway stays keyless for trusted workloads.
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayPolicy
+metadata:
+  name: apikey-policy
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: public
+      sectionName: http
+  traffic:
+    apiKeyAuthentication:
+      mode: Strict
+      secretRef:
+        name: agentgateway-api-keys

--- a/kubernetes/apps/ai/agentgateway/app/policies/kustomization.yaml
+++ b/kubernetes/apps/ai/agentgateway/app/policies/kustomization.yaml
@@ -2,3 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - authentik-policy.yaml
+- apikey-policy.yaml


### PR DESCRIPTION
## Phase 3 — external model API access

`https://llm-api.<domain>` becomes the OpenAI-compatible endpoint for everything outside the cluster (works from LAN via envoy-internal and from anywhere via Cloudflare tunnel → envoy-external).

### How it fits together
- Envoy terminates TLS, forwards to the agentgateway `public` data-plane Service (HTTP listener)
- `AgentgatewayPolicy` with `traffic.apiKeyAuthentication` (**Strict**) on that listener — keys read from the standard bearer Authorization header, i.e. plain OpenAI client config: base URL `https://llm-api.<domain>/openai/v1` (or any provider path) + your key
- Per-consumer keys with metadata (`user: sascha` etc.) — virtual-key-like, declaratively, no DB
- `internal-noauth` stays keyless for in-cluster workloads; authentik extAuth stays on the https listeners for browsers
- Gatus check expects **401** on the unauthenticated endpoint (auth gate alive)

### ⚠️ Action required after merge
Create 1Password item **`ai-gateway-keys`** (same vault as `ai-keys`) with fields:
- `GATEWAY_KEY_SASCHA` — a long random value
- `GATEWAY_KEY_AUTOMATION` — a long random value

Until then the ExternalSecret stays unsynced and the endpoint is 401-for-everyone (fails closed).

### Verify
Unauthenticated request to `/openai/v1/models` → 401; with a valid bearer key → 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
