### PR TITLE
feat(monitoring): LLM observability — tempo traces, cost rules, dashboards

### DIFF
--- a/kubernetes/apps/ai/agentgateway-dashboards/app/agentgateway.json
+++ b/kubernetes/apps/ai/agentgateway-dashboards/app/agentgateway.json
@@ -1,0 +1,1309 @@
+{
+  "annotations": {},
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 0,
+      "panels": [],
+      "title": "Overview",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "fillOpacity": 10,
+            "gradientMode": "opacity",
+            "showPoints": "never"
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 0,
+        "y": 1
+      },
+      "interval": "5s",
+      "options": {
+        "legend": {
+          "calcs": [
+            "last",
+            "max",
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Last",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "asc"
+        }
+      },
+      "repeatDirection": "h",
+      "targets": [
+        {
+          "expr": "sum by (pod,namespace) (container_memory_working_set_bytes{image=\"\",namespace=~\"$namespace\"}) * on(pod, namespace) group_left(gateway_networking_k8s_io_gateway_name) agentgateway_build_info{namespace=~\"$namespace\",gateway_networking_k8s_io_gateway_name=~\"$gateway_name\"}",
+          "legendFormat": "{{namespace}}/{{pod}}",
+          "refId": ""
+        }
+      ],
+      "title": "Memory",
+      "transformations": [],
+      "transparent": false,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "fillOpacity": 10,
+            "gradientMode": "opacity",
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 12,
+        "y": 1
+      },
+      "interval": "5s",
+      "options": {
+        "legend": {
+          "calcs": [
+            "last",
+            "max",
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Last",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "asc"
+        }
+      },
+      "repeatDirection": "h",
+      "targets": [
+        {
+          "expr": "sum by (pod,namespace) (irate(container_cpu_usage_seconds_total{image=\"\",namespace=~\"$namespace\"}[$__rate_interval]) * on(pod, namespace) group_left(gateway_networking_k8s_io_gateway_name) agentgateway_build_info{namespace=~\"$namespace\",gateway_networking_k8s_io_gateway_name=~\"$gateway_name\"})",
+          "legendFormat": "{{namespace}}/{{pod}}",
+          "refId": ""
+        }
+      ],
+      "title": "CPU",
+      "transformations": [],
+      "transparent": false,
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 11
+      },
+      "id": 0,
+      "panels": [],
+      "title": "Requests",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "fillOpacity": 10,
+            "gradientMode": "opacity",
+            "showPoints": "never"
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 0,
+        "y": 12
+      },
+      "interval": "5s",
+      "options": {
+        "legend": {
+          "calcs": [
+            "last",
+            "max",
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Last",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "asc"
+        }
+      },
+      "repeatDirection": "h",
+      "targets": [
+        {
+          "expr": "sum by (pod,namespace) (rate(agentgateway_requests_total{namespace=~\"$namespace\",gateway=~\"$gateway\"}[$__rate_interval]))",
+          "legendFormat": "{{namespace}}/{{pod}}",
+          "refId": ""
+        }
+      ],
+      "title": "Requests (by Pod)",
+      "transformations": [],
+      "transparent": false,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "fillOpacity": 10,
+            "gradientMode": "opacity",
+            "showPoints": "never"
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 12,
+        "y": 12
+      },
+      "interval": "5s",
+      "options": {
+        "legend": {
+          "calcs": [
+            "last",
+            "max",
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Last",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "asc"
+        }
+      },
+      "repeatDirection": "h",
+      "targets": [
+        {
+          "expr": "sum by (gateway) (rate(agentgateway_requests_total{namespace=~\"$namespace\",gateway=~\"$gateway\"}[$__rate_interval]))",
+          "legendFormat": "{{gateway}}",
+          "refId": ""
+        }
+      ],
+      "title": "Requests (by Gateway)",
+      "transformations": [],
+      "transparent": false,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "fillOpacity": 10,
+            "gradientMode": "opacity",
+            "showPoints": "never"
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 0,
+        "y": 22
+      },
+      "interval": "5s",
+      "options": {
+        "legend": {
+          "calcs": [
+            "last",
+            "max",
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Last",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "asc"
+        }
+      },
+      "repeatDirection": "h",
+      "targets": [
+        {
+          "expr": "sum by (gateway,status) (rate(agentgateway_requests_total{namespace=~\"$namespace\",gateway=~\"$gateway\"}[$__rate_interval]))",
+          "legendFormat": "{{gateway}}: {{status}}",
+          "refId": ""
+        }
+      ],
+      "title": "Requests (by Status)",
+      "transformations": [],
+      "transparent": false,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "fillOpacity": 10,
+            "gradientMode": "opacity",
+            "showPoints": "never"
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 12,
+        "y": 22
+      },
+      "interval": "5s",
+      "options": {
+        "legend": {
+          "calcs": [
+            "last",
+            "max",
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Last",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "asc"
+        }
+      },
+      "repeatDirection": "h",
+      "targets": [
+        {
+          "expr": "sum by (gateway,reason) (rate(agentgateway_requests_total{namespace=~\"$namespace\",gateway=~\"$gateway\"}[$__rate_interval]))",
+          "legendFormat": "{{gateway}}: {{reason}}",
+          "refId": ""
+        }
+      ],
+      "title": "Requests (by Reason)",
+      "transformations": [],
+      "transparent": false,
+      "type": "timeseries"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 32
+      },
+      "id": 0,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "fillOpacity": 10,
+                "gradientMode": "opacity",
+                "showPoints": "never"
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 0,
+            "y": 33
+          },
+          "interval": "5s",
+          "options": {
+            "legend": {
+              "calcs": [
+                "last",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true,
+              "sortBy": "Last",
+              "sortDesc": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "asc"
+            }
+          },
+          "repeatDirection": "h",
+          "targets": [
+            {
+              "expr": "sum by (gen_ai_token_type,gen_ai_request_model,gateway) (rate(agentgateway_gen_ai_client_token_usage_sum{namespace=~\"$namespace\",gateway=~\"$gateway\"}[$__rate_interval]))",
+              "legendFormat": "{{gateway}}: {{gen_ai_request_model}} ({{gen_ai_token_type}})",
+              "refId": ""
+            }
+          ],
+          "title": "Token Consumption",
+          "transformations": [],
+          "transparent": false,
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "fillOpacity": 10,
+                "gradientMode": "opacity",
+                "showPoints": "never"
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 12,
+            "y": 33
+          },
+          "interval": "5s",
+          "options": {
+            "legend": {
+              "calcs": [
+                "last",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true,
+              "sortBy": "Last",
+              "sortDesc": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "asc"
+            }
+          },
+          "repeatDirection": "h",
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.5, sum by (le,gateway,gen_ai_request_model) (rate(agentgateway_gen_ai_server_time_to_first_token_bucket{namespace=~\"$namespace\",gateway=~\"$gateway\"}[$__rate_interval])))",
+              "legendFormat": "{{gateway}}: {{gen_ai_request_model}}",
+              "refId": ""
+            }
+          ],
+          "title": "Time To First Token",
+          "transformations": [],
+          "transparent": false,
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "fillOpacity": 10,
+                "gradientMode": "opacity",
+                "showPoints": "never"
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 0,
+            "y": 43
+          },
+          "interval": "5s",
+          "options": {
+            "legend": {
+              "calcs": [
+                "last",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true,
+              "sortBy": "Last",
+              "sortDesc": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "asc"
+            }
+          },
+          "repeatDirection": "h",
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.5, sum by (le,gateway,gen_ai_request_model) (rate(agentgateway_gen_ai_server_request_duration_bucket{namespace=~\"$namespace\",gateway=~\"$gateway\"}[$__rate_interval])))",
+              "legendFormat": "{{gateway}}: {{gen_ai_request_model}}",
+              "refId": ""
+            }
+          ],
+          "title": "Request Time",
+          "transformations": [],
+          "transparent": false,
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "fillOpacity": 10,
+                "gradientMode": "opacity",
+                "showPoints": "never"
+              },
+              "unit": "tps"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 12,
+            "y": 43
+          },
+          "interval": "5s",
+          "options": {
+            "legend": {
+              "calcs": [
+                "last",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true,
+              "sortBy": "Last",
+              "sortDesc": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "asc"
+            }
+          },
+          "repeatDirection": "h",
+          "targets": [
+            {
+              "expr": "1 / histogram_quantile(0.5, sum by (le,gateway,gen_ai_request_model) (rate(agentgateway_gen_ai_server_time_per_output_token_bucket{namespace=~\"$namespace\",gateway=~\"$gateway\"}[$__rate_interval])))",
+              "legendFormat": "{{gateway}}: {{gen_ai_request_model}}",
+              "refId": ""
+            }
+          ],
+          "title": "Tokens Per Second",
+          "transformations": [],
+          "transparent": false,
+          "type": "timeseries"
+        }
+      ],
+      "title": "LLM",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 53
+      },
+      "id": 0,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "fillOpacity": 10,
+                "gradientMode": "opacity",
+                "showPoints": "never"
+              },
+              "unit": "reqps"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 0,
+            "y": 54
+          },
+          "interval": "5s",
+          "options": {
+            "legend": {
+              "calcs": [
+                "last",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true,
+              "sortBy": "Last",
+              "sortDesc": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "asc"
+            }
+          },
+          "repeatDirection": "h",
+          "targets": [
+            {
+              "expr": "sum by (gateway,method) (rate(agentgateway_mcp_requests_total{namespace=~\"$namespace\",gateway=~\"$gateway\"}[$__rate_interval]))",
+              "legendFormat": "{{gateway}}: {{method}}",
+              "refId": ""
+            }
+          ],
+          "title": "MCP Calls (by method)",
+          "transformations": [],
+          "transparent": false,
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "fillOpacity": 10,
+                "gradientMode": "opacity",
+                "showPoints": "never"
+              },
+              "unit": "reqps"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 12,
+            "y": 54
+          },
+          "interval": "5s",
+          "options": {
+            "legend": {
+              "calcs": [
+                "last",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true,
+              "sortBy": "Last",
+              "sortDesc": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "asc"
+            }
+          },
+          "repeatDirection": "h",
+          "targets": [
+            {
+              "expr": "sum by (gateway,server,resource) (rate(agentgateway_mcp_requests_total{namespace=~\"$namespace\",gateway=~\"$gateway\",method=\"tools/call\"}[$__rate_interval]))",
+              "legendFormat": "{{gateway}}: {{server}}/{{resource}}",
+              "refId": ""
+            }
+          ],
+          "title": "Tool Calls (by tool)",
+          "transformations": [],
+          "transparent": false,
+          "type": "timeseries"
+        }
+      ],
+      "title": "MCP",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 64
+      },
+      "id": 0,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "fillOpacity": 10,
+                "gradientMode": "opacity",
+                "showPoints": "never"
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 0,
+            "y": 65
+          },
+          "interval": "5s",
+          "options": {
+            "legend": {
+              "calcs": [
+                "last",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true,
+              "sortBy": "Last",
+              "sortDesc": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "asc"
+            }
+          },
+          "repeatDirection": "h",
+          "targets": [
+            {
+              "expr": "(histogram_quantile(0.50, sum by (le,gateway,route) (rate(agentgateway_request_duration_seconds_bucket{namespace=~\"$namespace\",gateway=~\"$gateway\"}[$__rate_interval])))) == (histogram_quantile(0.50, sum by (le,gateway,route) (rate(agentgateway_request_duration_seconds_bucket{namespace=~\"$namespace\",gateway=~\"$gateway\"}[$__rate_interval]))))",
+              "legendFormat": "{{gateway}}: {{route}} p50",
+              "refId": ""
+            },
+            {
+              "expr": "(histogram_quantile(0.95, sum by (le,gateway,route) (rate(agentgateway_request_duration_seconds_bucket{namespace=~\"$namespace\",gateway=~\"$gateway\"}[$__rate_interval])))) == (histogram_quantile(0.95, sum by (le,gateway,route) (rate(agentgateway_request_duration_seconds_bucket{namespace=~\"$namespace\",gateway=~\"$gateway\"}[$__rate_interval]))))",
+              "legendFormat": "{{gateway}}: {{route}} p95",
+              "refId": ""
+            },
+            {
+              "expr": "(histogram_quantile(0.99, sum by (le,gateway,route) (rate(agentgateway_request_duration_seconds_bucket{namespace=~\"$namespace\",gateway=~\"$gateway\"}[$__rate_interval])))) == (histogram_quantile(0.99, sum by (le,gateway,route) (rate(agentgateway_request_duration_seconds_bucket{namespace=~\"$namespace\",gateway=~\"$gateway\"}[$__rate_interval]))))",
+              "legendFormat": "{{gateway}}: {{route}} p99",
+              "refId": ""
+            }
+          ],
+          "title": "Latency by Route",
+          "transformations": [],
+          "transparent": false,
+          "type": "timeseries"
+        }
+      ],
+      "title": "Latency",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 75
+      },
+      "id": 0,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "fillOpacity": 10,
+                "gradientMode": "opacity",
+                "showPoints": "never"
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 0,
+            "y": 76
+          },
+          "interval": "5s",
+          "options": {
+            "legend": {
+              "calcs": [
+                "last",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true,
+              "sortBy": "Last",
+              "sortDesc": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "asc"
+            }
+          },
+          "repeatDirection": "h",
+          "targets": [
+            {
+              "expr": "sum by (url) (rate(agentgateway_xds_message_total[$__rate_interval]))",
+              "legendFormat": "{{url}}",
+              "refId": ""
+            }
+          ],
+          "title": "XDS Messages by Type",
+          "transformations": [],
+          "transparent": false,
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "fillOpacity": 10,
+                "gradientMode": "opacity",
+                "showPoints": "never"
+              },
+              "unit": "bytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 12,
+            "y": 76
+          },
+          "interval": "5s",
+          "options": {
+            "legend": {
+              "calcs": [
+                "last",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true,
+              "sortBy": "Last",
+              "sortDesc": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "asc"
+            }
+          },
+          "repeatDirection": "h",
+          "targets": [
+            {
+              "expr": "sum by (url) (rate(agentgateway_xds_message_bytes_total[$__rate_interval])) / sum by (url) (rate(agentgateway_xds_message_total[$__rate_interval]))",
+              "legendFormat": "{{url}}",
+              "refId": ""
+            }
+          ],
+          "title": "XDS Average Message Size",
+          "transformations": [],
+          "transparent": false,
+          "type": "timeseries"
+        }
+      ],
+      "title": "XDS",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 86
+      },
+      "id": 0,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "fillOpacity": 10,
+                "gradientMode": "opacity",
+                "showPoints": "never"
+              },
+              "unit": "bytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 0,
+            "y": 87
+          },
+          "interval": "5s",
+          "options": {
+            "legend": {
+              "calcs": [
+                "last",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true,
+              "sortBy": "Last",
+              "sortDesc": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "asc"
+            }
+          },
+          "repeatDirection": "h",
+          "targets": [
+            {
+              "expr": "agentgateway_cgroup_usage{namespace=~\"$namespace\",gateway_networking_k8s_io_gateway_name=~\"$gateway_name\",pod=~\"$pod\"}",
+              "legendFormat": "{{namespace}}/{{pod}} usage",
+              "refId": ""
+            },
+            {
+              "expr": "agentgateway_cgroup_working_set{namespace=~\"$namespace\",gateway_networking_k8s_io_gateway_name=~\"$gateway_name\",pod=~\"$pod\"}",
+              "legendFormat": "{{namespace}}/{{pod}} working set",
+              "refId": ""
+            },
+            {
+              "expr": "agentgateway_cgroup_anon{namespace=~\"$namespace\",gateway_networking_k8s_io_gateway_name=~\"$gateway_name\",pod=~\"$pod\"}",
+              "legendFormat": "{{namespace}}/{{pod}} anonymous",
+              "refId": ""
+            },
+            {
+              "expr": "agentgateway_cgroup_file{namespace=~\"$namespace\",gateway_networking_k8s_io_gateway_name=~\"$gateway_name\",pod=~\"$pod\"}",
+              "legendFormat": "{{namespace}}/{{pod}} file",
+              "refId": ""
+            },
+            {
+              "expr": "agentgateway_cgroup_kernel{namespace=~\"$namespace\",gateway_networking_k8s_io_gateway_name=~\"$gateway_name\",pod=~\"$pod\"}",
+              "legendFormat": "{{namespace}}/{{pod}} kernel",
+              "refId": ""
+            },
+            {
+              "expr": "agentgateway_cgroup_sock{namespace=~\"$namespace\",gateway_networking_k8s_io_gateway_name=~\"$gateway_name\",pod=~\"$pod\"}",
+              "legendFormat": "{{namespace}}/{{pod}} socket",
+              "refId": ""
+            },
+            {
+              "expr": "agentgateway_cgroup_slab{namespace=~\"$namespace\",gateway_networking_k8s_io_gateway_name=~\"$gateway_name\",pod=~\"$pod\"}",
+              "legendFormat": "{{namespace}}/{{pod}} slab",
+              "refId": ""
+            }
+          ],
+          "title": "Cgroup Memory",
+          "transformations": [],
+          "transparent": false,
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "fillOpacity": 10,
+                "gradientMode": "opacity",
+                "showPoints": "never"
+              },
+              "unit": "bytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 12,
+            "y": 87
+          },
+          "interval": "5s",
+          "options": {
+            "legend": {
+              "calcs": [
+                "last",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true,
+              "sortBy": "Last",
+              "sortDesc": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "asc"
+            }
+          },
+          "repeatDirection": "h",
+          "targets": [
+            {
+              "expr": "agentgateway_process_rss{namespace=~\"$namespace\",gateway_networking_k8s_io_gateway_name=~\"$gateway_name\",pod=~\"$pod\"}",
+              "legendFormat": "{{namespace}}/{{pod}} rss",
+              "refId": ""
+            },
+            {
+              "expr": "agentgateway_process_pss{namespace=~\"$namespace\",gateway_networking_k8s_io_gateway_name=~\"$gateway_name\",pod=~\"$pod\"}",
+              "legendFormat": "{{namespace}}/{{pod}} pss",
+              "refId": ""
+            },
+            {
+              "expr": "agentgateway_process_private_dirty{namespace=~\"$namespace\",gateway_networking_k8s_io_gateway_name=~\"$gateway_name\",pod=~\"$pod\"}",
+              "legendFormat": "{{namespace}}/{{pod}} private dirty",
+              "refId": ""
+            },
+            {
+              "expr": "agentgateway_process_private_clean{namespace=~\"$namespace\",gateway_networking_k8s_io_gateway_name=~\"$gateway_name\",pod=~\"$pod\"}",
+              "legendFormat": "{{namespace}}/{{pod}} private clean",
+              "refId": ""
+            },
+            {
+              "expr": "agentgateway_process_shared_clean{namespace=~\"$namespace\",gateway_networking_k8s_io_gateway_name=~\"$gateway_name\",pod=~\"$pod\"}",
+              "legendFormat": "{{namespace}}/{{pod}} shared clean",
+              "refId": ""
+            },
+            {
+              "expr": "agentgateway_process_swap{namespace=~\"$namespace\",gateway_networking_k8s_io_gateway_name=~\"$gateway_name\",pod=~\"$pod\"}",
+              "legendFormat": "{{namespace}}/{{pod}} swap",
+              "refId": ""
+            }
+          ],
+          "title": "Process Memory",
+          "transformations": [],
+          "transparent": false,
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "fillOpacity": 10,
+                "gradientMode": "opacity",
+                "showPoints": "never"
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 0,
+            "y": 97
+          },
+          "interval": "5s",
+          "options": {
+            "legend": {
+              "calcs": [
+                "last",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true,
+              "sortBy": "Last",
+              "sortDesc": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "asc"
+            }
+          },
+          "repeatDirection": "h",
+          "targets": [
+            {
+              "expr": "agentgateway_tokio_num_workers{namespace=~\"$namespace\",gateway_networking_k8s_io_gateway_name=~\"$gateway_name\",pod=~\"$pod\"}",
+              "legendFormat": "{{namespace}}/{{pod}} workers",
+              "refId": ""
+            },
+            {
+              "expr": "agentgateway_tokio_num_alive_tasks{namespace=~\"$namespace\",gateway_networking_k8s_io_gateway_name=~\"$gateway_name\",pod=~\"$pod\"}",
+              "legendFormat": "{{namespace}}/{{pod}} alive tasks",
+              "refId": ""
+            },
+            {
+              "expr": "agentgateway_tokio_global_queue_depth{namespace=~\"$namespace\",gateway_networking_k8s_io_gateway_name=~\"$gateway_name\",pod=~\"$pod\"}",
+              "legendFormat": "{{namespace}}/{{pod}} global queue depth",
+              "refId": ""
+            }
+          ],
+          "title": "Tokio Runtime",
+          "transformations": [],
+          "transparent": false,
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "fillOpacity": 10,
+                "gradientMode": "opacity",
+                "showPoints": "never"
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 12,
+            "y": 97
+          },
+          "interval": "5s",
+          "options": {
+            "legend": {
+              "calcs": [
+                "last",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true,
+              "sortBy": "Last",
+              "sortDesc": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "asc"
+            }
+          },
+          "repeatDirection": "h",
+          "targets": [
+            {
+              "expr": "sum by (tag) (agentgateway_build_info{namespace=~\"$namespace\",gateway_networking_k8s_io_gateway_name=~\"$gateway_name\",pod=~\"$pod\"})",
+              "legendFormat": "{{tag}}",
+              "refId": ""
+            }
+          ],
+          "title": "Build Versions",
+          "transformations": [],
+          "transparent": false,
+          "type": "timeseries"
+        }
+      ],
+      "title": "Runtime",
+      "type": "row"
+    }
+  ],
+  "refresh": "15s",
+  "schemaVersion": 36,
+  "style": "dark",
+  "templating": {
+    "list": [
+      {
+        "auto": false,
+        "auto_count": 30,
+        "auto_min": "10s",
+        "hide": 0,
+        "id": "00000000-0000-0000-0000-000000000000",
+        "includeAll": false,
+        "multi": false,
+        "name": "datasource",
+        "query": "prometheus",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "auto": false,
+        "auto_count": 30,
+        "auto_min": "10s",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "$datasource"
+        },
+        "hide": 0,
+        "id": "00000000-0000-0000-0000-000000000000",
+        "includeAll": true,
+        "label": "Namespace",
+        "multi": true,
+        "name": "namespace",
+        "query": "label_values(agentgateway_build_info,namespace)",
+        "refresh": 2,
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "auto": false,
+        "auto_count": 30,
+        "auto_min": "10s",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "$datasource"
+        },
+        "hide": 0,
+        "id": "00000000-0000-0000-0000-000000000000",
+        "includeAll": true,
+        "label": "Gateway",
+        "multi": true,
+        "name": "gateway_name",
+        "query": "label_values(agentgateway_build_info{namespace=~\"$namespace\"},gateway_networking_k8s_io_gateway_name)",
+        "refresh": 2,
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "auto": false,
+        "auto_count": 30,
+        "auto_min": "10s",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "$datasource"
+        },
+        "hide": 2,
+        "id": "00000000-0000-0000-0000-000000000000",
+        "includeAll": true,
+        "label": "Gateway Full Name",
+        "multi": true,
+        "name": "gateway",
+        "query": "query_result(label_join(agentgateway_build_info{namespace=~\"$namespace\",gateway_networking_k8s_io_gateway_name=~\"$gateway_name\"}, \"gateway\", \"/\", \"namespace\", \"gateway_networking_k8s_io_gateway_name\"))",
+        "refresh": 2,
+        "regex": "/.*gateway=\"([^\"]+).*/",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "auto": false,
+        "auto_count": 30,
+        "auto_min": "10s",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "$datasource"
+        },
+        "hide": 0,
+        "id": "00000000-0000-0000-0000-000000000000",
+        "includeAll": true,
+        "label": "Pod",
+        "multi": true,
+        "name": "pod",
+        "query": "query_result(agentgateway_build_info{namespace=~\"$namespace\",gateway_networking_k8s_io_gateway_name=~\"$gateway_name\"})",
+        "refresh": 2,
+        "regex": ".*pod=\"([^\"]+)\".*",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-30m",
+    "to": "now"
+  },
+  "timezone": "browser",
+  "title": "Agentgateway",
+  "uid": "agentgateway"
+}

--- a/kubernetes/apps/ai/agentgateway-dashboards/app/kustomization.yaml
+++ b/kubernetes/apps/ai/agentgateway-dashboards/app/kustomization.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# agentgateway.json is vendored from the official chart
+# (oci://cr.agentgateway.dev/charts/agentgateway, files/agentgateway-dashboard.json).
+# Re-vendor when bumping the chart version.
+configMapGenerator:
+  - name: agentgateway-dashboard
+    files:
+      - agentgateway.json
+  - name: llm-cost-dashboard
+    files:
+      - llm-cost.json
+generatorOptions:
+  disableNameSuffixHash: true
+  annotations:
+    grafana_folder: AI/ML
+  labels:
+    grafana_dashboard: "true"

--- a/kubernetes/apps/ai/agentgateway-dashboards/app/llm-cost.json
+++ b/kubernetes/apps/ai/agentgateway-dashboards/app/llm-cost.json
@@ -1,0 +1,230 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [
+    {
+      "title": "Agentgateway",
+      "type": "link",
+      "url": "/d/agentgateway"
+    }
+  ],
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "currencyUSD",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "lineWidth": 2,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 16,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": [
+            "sum"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "ai:gen_ai_cost_usd:rate5m * 3600",
+          "legendFormat": "{{gen_ai_request_model}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Estimated cost rate ($/hour) by model",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "currencyUSD",
+          "decimals": 2
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 8,
+        "x": 16,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "colorMode": "value",
+        "graphMode": "area"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(sum by (gen_ai_request_model, gen_ai_token_type) (increase(agentgateway_gen_ai_client_token_usage_sum[$__range])) * on (gen_ai_request_model, gen_ai_token_type) group_left () ai:llm_token_price_per_million_usd) / 1e6",
+          "legendFormat": "spend",
+          "refId": "A"
+        }
+      ],
+      "title": "Estimated spend (dashboard time range)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "cps",
+          "custom": {
+            "drawStyle": "bars",
+            "fillOpacity": 60,
+            "stacking": {
+              "mode": "normal"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 16,
+        "x": 0,
+        "y": 9
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "ai:gen_ai_tokens:rate5m",
+          "legendFormat": "{{gen_ai_request_model}} ({{gen_ai_token_type}})",
+          "refId": "A"
+        }
+      ],
+      "title": "Token rate by model (tokens/s)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Models consuming tokens that have NO row in the price table (kubernetes/apps/ai/agentgateway/app/rules/cost.yaml). Keep this panel empty.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "cps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 8,
+        "x": 16,
+        "y": 9
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "ai:gen_ai_tokens_unpriced:rate5m",
+          "legendFormat": "{{gen_ai_request_model}} ({{gen_ai_token_type}})",
+          "refId": "A"
+        }
+      ],
+      "title": "Unpriced models (should be empty)",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "1m",
+  "schemaVersion": 39,
+  "tags": [
+    "ai",
+    "llm",
+    "cost"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
+  "timezone": "browser",
+  "title": "LLM Cost",
+  "uid": "ai-llm-cost",
+  "version": 1
+}

--- a/kubernetes/apps/ai/agentgateway-dashboards/ks.yaml
+++ b/kubernetes/apps/ai/agentgateway-dashboards/ks.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app agentgateway-dashboards
+  namespace: &namespace ai
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  targetNamespace: *namespace
+  interval: 1h
+  retryInterval: 2m
+  timeout: 3m
+  path: "./kubernetes/apps/ai/agentgateway-dashboards/app"
+  prune: true
+  wait: false
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/ai/agentgateway/app/kustomization.yaml
+++ b/kubernetes/apps/ai/agentgateway/app/kustomization.yaml
@@ -35,6 +35,8 @@ resources:
 - ./httproute-internal.yaml
 - ./httproute-api-external.yaml
 - ./externalsecret-apikeys.yaml
+- ./podmonitor.yaml
+- ./rules/cost.yaml
 - ./ocirepository.yaml
 - ./service-admin-ui.yaml
 - ./externalsecret-tls.yaml

--- a/kubernetes/apps/ai/agentgateway/app/podmonitor.yaml
+++ b/kubernetes/apps/ai/agentgateway/app/podmonitor.yaml
@@ -1,0 +1,21 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/monitoring.coreos.com/podmonitor_v1.json
+# Scrapes the agentgateway data-plane pods directly (port metrics=15020).
+# Needed because the chart's proxy ServiceMonitor selects a `metrics` port
+# on the per-Gateway Services, which the deployer does not create (Services
+# only expose the listener ports).
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: agentgateway-data-plane
+spec:
+  jobLabel: gateway.networking.k8s.io/gateway-name
+  selector:
+    matchLabels:
+      gateway.networking.k8s.io/gateway-class-name: agentgateway
+  podMetricsEndpoints:
+    - port: metrics
+      path: /metrics
+      interval: 30s
+      scrapeTimeout: 10s
+      honorLabels: true

--- a/kubernetes/apps/ai/agentgateway/app/policies/kustomization.yaml
+++ b/kubernetes/apps/ai/agentgateway/app/policies/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 resources:
 - authentik-policy.yaml
 - apikey-policy.yaml
+- tracing-policy.yaml

--- a/kubernetes/apps/ai/agentgateway/app/policies/tracing-policy.yaml
+++ b/kubernetes/apps/ai/agentgateway/app/policies/tracing-policy.yaml
@@ -1,0 +1,27 @@
+---
+# Export OTLP traces (gen_ai semantic conventions) from all three gateways
+# to Tempo in the monitoring namespace. 100% sampling - home-lab request
+# volume is low and per-request drill-down is the point.
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayPolicy
+metadata:
+  name: tracing-policy
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: internal
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: internal-noauth
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: public
+  frontend:
+    tracing:
+      backendRef:
+        name: tempo
+        namespace: monitoring
+        port: 4317
+      protocol: GRPC
+      randomSampling: "1.0"

--- a/kubernetes/apps/ai/agentgateway/app/rules/cost.yaml
+++ b/kubernetes/apps/ai/agentgateway/app/rules/cost.yaml
@@ -1,0 +1,102 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/monitoring.coreos.com/prometheusrule_v1.json
+# Estimated LLM spend computed from agentgateway native token metrics
+# (agentgateway_gen_ai_client_token_usage histogram, labels
+# gen_ai_request_model + gen_ai_token_type) multiplied by the price table
+# below. This is the GitOps replacement for LiteLLM's DB-based spend
+# tracking: tokens are exact, USD is an estimate.
+#
+# >>> PRICE TABLE - maintain me! USD per 1 MILLION tokens. <<<
+# Model names must match the `model` field clients send (the
+# gen_ai_request_model label). Models without a price row still show up in
+# the ai:gen_ai_tokens_unpriced:rate5m series (dashboard panel "Unpriced
+# models") so nothing is silently uncounted.
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: agentgateway-llm-cost
+spec:
+  groups:
+    - name: ai-llm-token-prices
+      rules:
+        # --- OpenAI ---
+        - record: &price ai:llm_token_price_per_million_usd
+          labels: { gen_ai_request_model: gpt-4o, gen_ai_token_type: input }
+          expr: vector(2.50)
+        - record: *price
+          labels: { gen_ai_request_model: gpt-4o, gen_ai_token_type: output }
+          expr: vector(10.00)
+        - record: *price
+          labels: { gen_ai_request_model: gpt-4o-mini, gen_ai_token_type: input }
+          expr: vector(0.15)
+        - record: *price
+          labels: { gen_ai_request_model: gpt-4o-mini, gen_ai_token_type: output }
+          expr: vector(0.60)
+        - record: *price
+          labels: { gen_ai_request_model: gpt-5, gen_ai_token_type: input }
+          expr: vector(1.25)
+        - record: *price
+          labels: { gen_ai_request_model: gpt-5, gen_ai_token_type: output }
+          expr: vector(10.00)
+        - record: *price
+          labels: { gen_ai_request_model: gpt-5-mini, gen_ai_token_type: input }
+          expr: vector(0.25)
+        - record: *price
+          labels: { gen_ai_request_model: gpt-5-mini, gen_ai_token_type: output }
+          expr: vector(2.00)
+        # --- Anthropic ---
+        - record: *price
+          labels: { gen_ai_request_model: claude-sonnet-4-6, gen_ai_token_type: input }
+          expr: vector(3.00)
+        - record: *price
+          labels: { gen_ai_request_model: claude-sonnet-4-6, gen_ai_token_type: output }
+          expr: vector(15.00)
+        - record: *price
+          labels: { gen_ai_request_model: claude-haiku-4-5, gen_ai_token_type: input }
+          expr: vector(1.00)
+        - record: *price
+          labels: { gen_ai_request_model: claude-haiku-4-5, gen_ai_token_type: output }
+          expr: vector(5.00)
+        - record: *price
+          labels: { gen_ai_request_model: claude-opus-4-6, gen_ai_token_type: input }
+          expr: vector(5.00)
+        - record: *price
+          labels: { gen_ai_request_model: claude-opus-4-6, gen_ai_token_type: output }
+          expr: vector(25.00)
+        # --- DeepSeek ---
+        - record: *price
+          labels: { gen_ai_request_model: deepseek-chat, gen_ai_token_type: input }
+          expr: vector(0.27)
+        - record: *price
+          labels: { gen_ai_request_model: deepseek-chat, gen_ai_token_type: output }
+          expr: vector(1.10)
+        # --- Gemini (incl. linkwarden tagging model) ---
+        - record: *price
+          labels: { gen_ai_request_model: google/gemini-2.0-flash-lite-001, gen_ai_token_type: input }
+          expr: vector(0.075)
+        - record: *price
+          labels: { gen_ai_request_model: google/gemini-2.0-flash-lite-001, gen_ai_token_type: output }
+          expr: vector(0.30)
+
+    - name: ai-llm-cost
+      rules:
+        # token consumption rate by model and direction
+        - record: ai:gen_ai_tokens:rate5m
+          expr: |
+            sum by (gen_ai_request_model, gen_ai_token_type) (
+              rate(agentgateway_gen_ai_client_token_usage_sum[5m])
+            )
+        # estimated USD per second by model (integrate in Grafana for $/day)
+        - record: ai:gen_ai_cost_usd:rate5m
+          expr: |
+            sum by (gen_ai_request_model) (
+              ai:gen_ai_tokens:rate5m
+              * on (gen_ai_request_model, gen_ai_token_type) group_left ()
+              ai:llm_token_price_per_million_usd
+            ) / 1e6
+        # tokens flowing for models missing a price row (keep this empty!)
+        - record: ai:gen_ai_tokens_unpriced:rate5m
+          expr: |
+            ai:gen_ai_tokens:rate5m
+            unless on (gen_ai_request_model, gen_ai_token_type)
+            ai:llm_token_price_per_million_usd

--- a/kubernetes/apps/ai/kustomization.yaml
+++ b/kubernetes/apps/ai/kustomization.yaml
@@ -10,6 +10,7 @@ components:
 
 resources:
   - ./agentgateway/ks.yaml
+  - ./agentgateway-dashboards/ks.yaml
   - ./kokoro/ks.yaml
   - ./perplexica/ks.yaml
   - ./ollama/ks.yaml

--- a/kubernetes/apps/monitoring/grafana/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/grafana/app/helmrelease.yaml
@@ -187,7 +187,7 @@ spec:
                   "id": 3,
                   "options": {
                     "code": {"language": "plaintext", "showLineNumbers": false, "showMiniMap": false},
-                    "content": "## 🤖 AI/ML\n- [AgentGateway](/d/agentgateway)\n- [LiteLLM](/d/litellm)\n- [Qdrant](/d/qdrant-observatory)\n- [Ollama](/d/ollama-llm-inference)\n\n## 🎬 Media\n- [Plex](/d/plex-media-server-exporter)\n- [Jellyfin](/d/jellyfin-media-server)\n- [Immich](/d/immich-overview)\n- [Tdarr](/d/tdarr)",
+                    "content": "## 🤖 AI/ML\n- [AgentGateway](/d/agentgateway)\n- [LLM Cost](/d/ai-llm-cost)\n- [Qdrant](/d/qdrant-observatory)\n- [Ollama](/d/ollama-llm-inference)\n\n## 🎬 Media\n- [Plex](/d/plex-media-server-exporter)\n- [Jellyfin](/d/jellyfin-media-server)\n- [Immich](/d/immich-overview)\n- [Tdarr](/d/tdarr)",
                     "mode": "markdown"
                   },
                   "title": "AI/ML & Media",
@@ -382,22 +382,10 @@ spec:
           url: https://raw.githubusercontent.com/emqx/emqx-exporter/main/grafana-dashboard/template/emqx-5/rule-engine-rate.json
           datasource: Prometheus
 
-      ai-ml:
-        agentgateway:
-          # renovate: dashboardName="AgentGateway Overview"
-          gnetId: 24590
-          revision: 1
-          datasource:
-            - name: DS_PROMETHEUS
-              value: Prometheus
-
-        litellm:
-          # renovate: dashboardName="LiteLLM"
-          gnetId: 24965
-          revision: 1
-          datasource:
-            - name: DS_PROMETHEUS
-              value: Prometheus
+      # NOTE: agentgateway + llm-cost dashboards are sidecar-discovered
+      # ConfigMaps (kubernetes/apps/ai/agentgateway-dashboards/), vendored
+      # from the official chart - the old gnetId 24590/24965 entries are gone
+      # (litellm was removed; the kgateway-org dashboard is superseded).
 
         qdrant-observatory:
           # renovate: depName="Qdrant Observatory"
@@ -571,6 +559,14 @@ spec:
             url: http://alertmanager.monitoring.svc.cluster.local:9093
             jsonData:
               implementation: prometheus
+          - name: Tempo
+            type: tempo
+            uid: tempo
+            access: proxy
+            url: http://tempo.monitoring.svc.cluster.local:3200
+            jsonData:
+              tracesToMetrics:
+                datasourceUid: prometheus
 
         deleteDatasources:
           - name: Alertmanager
@@ -578,6 +574,8 @@ spec:
           - name: Prometheus
             orgId: 1
           - name: Loki
+            orgId: 1
+          - name: Tempo
             orgId: 1
 
     env:

--- a/kubernetes/apps/monitoring/kustomization.yaml
+++ b/kubernetes/apps/monitoring/kustomization.yaml
@@ -16,6 +16,7 @@ resources:
   - ./kube-prometheus-stack/ks.yaml
   - ./loki/ks.yaml
   - ./prometheus-operator/ks.yaml
+  - ./tempo/ks.yaml
   - ./promtail/ks.yaml
   - ./gatus/ks.yaml
   - ./kromgo/ks.yaml

--- a/kubernetes/apps/monitoring/tempo/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/tempo/app/helmrelease.yaml
@@ -1,0 +1,41 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+# Grafana Tempo (single binary) - OTLP trace backend for the AI model
+# gateway (agentgateway exports gen_ai spans via OTLP/gRPC :4317).
+# Traces are ephemeral (7d retention, no volsync).
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: tempo
+spec:
+  interval: 30m
+  timeout: 10m
+  chartRef:
+    kind: OCIRepository
+    name: tempo
+  dependsOn:
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+  values:
+    tempo:
+      reportingEnabled: false
+      retention: 168h
+      receivers:
+        otlp:
+          protocols:
+            grpc:
+              endpoint: 0.0.0.0:4317
+            http:
+              endpoint: 0.0.0.0:4318
+      resources:
+        requests:
+          cpu: 50m
+          memory: 256Mi
+        limits:
+          memory: 1Gi
+    persistence:
+      enabled: true
+      storageClassName: ceph-block
+      size: 20Gi
+    serviceMonitor:
+      enabled: true

--- a/kubernetes/apps/monitoring/tempo/app/kustomization.yaml
+++ b/kubernetes/apps/monitoring/tempo/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml
+  - ./referencegrant.yaml

--- a/kubernetes/apps/monitoring/tempo/app/ocirepository.yaml
+++ b/kubernetes/apps/monitoring/tempo/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: tempo
+spec:
+  interval: 10m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 2.2.0
+  url: oci://ghcr.io/grafana-community/helm-charts/tempo

--- a/kubernetes/apps/monitoring/tempo/app/referencegrant.yaml
+++ b/kubernetes/apps/monitoring/tempo/app/referencegrant.yaml
@@ -1,0 +1,18 @@
+---
+# Allow the agentgateway tracing policy (ns ai) to reference the tempo
+# Service across namespaces (Gateway API spec-correct, even though
+# agentgateway does not currently enforce ReferenceGrant for policy
+# backendRefs).
+apiVersion: gateway.networking.k8s.io/v1
+kind: ReferenceGrant
+metadata:
+  name: allow-agentgateway-tracing
+spec:
+  from:
+    - group: agentgateway.dev
+      kind: AgentgatewayPolicy
+      namespace: ai
+  to:
+    - group: ""
+      kind: Service
+      name: tempo

--- a/kubernetes/apps/monitoring/tempo/ks.yaml
+++ b/kubernetes/apps/monitoring/tempo/ks.yaml
@@ -1,0 +1,21 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app tempo
+  namespace: &namespace monitoring
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  interval: 30m
+  timeout: 5m
+  path: "./kubernetes/apps/monitoring/tempo/app"
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false


### PR DESCRIPTION
## Phase 4 — deep LLM observability (metrics → cost → traces)

### Trace backend: Tempo (decision gate resolved)
VictoriaTraces was evaluated per plan but is **pre-GA** (v0.6.0, helm chart 0.0.5, Grafana via generic Jaeger datasource only) → **Tempo single-binary** (grafana-community chart 2.2.0, Tempo 2.10.5). 20Gi ceph-block, 7d retention, no volsync (traces are ephemeral). OTLP gRPC 4317 / HTTP 4318.

### Tracing
`AgentgatewayPolicy` `frontend.tracing` on all 3 gateways → OTLP/gRPC to Tempo, 100% sampling. Every LLM request becomes a trace with gen_ai attributes (model, token usage), drillable in Grafana Explore via the new **Tempo datasource** (tracesToMetrics wired to Prometheus). ReferenceGrant added for spec-correct cross-ns backendRef.

### Dashboards (`AI/ML` folder, sidecar-discovered)
- **Agentgateway** — vendored from the official 1.2.1 chart (same uid as the old gnetId entry → existing links keep working). Panels: Token Consumption, Time To First Token, Tokens Per Second, Requests by Gateway/Status, Latency by Route, MCP calls.
- **LLM Cost** (`/d/ai-llm-cost`) — cost rate by model, range spend, token rates, and an **"Unpriced models" panel that must stay empty** (models missing from the price table show here instead of being silently uncounted).

### Cost rules (PrometheusRule `agentgateway-llm-cost`)
GitOps price table (USD per 1M tokens per model+direction — **maintain it as prices change**) × `agentgateway_gen_ai_client_token_usage` → `ai:gen_ai_cost_usd:rate5m`. Declarative replacement for LiteLLM's DB spend tracking.

### Monitoring bugfix
Restored the data-plane **PodMonitor**: the chart's proxy ServiceMonitor selects a `metrics` **Service** port that the deployer never creates (pods expose `15020` directly) — verified live; without this no proxy metrics get scraped.

### Verify after merge
- Tempo pod Ready; `flux get hr -n monitoring tempo`
- Grafana → AI/ML folder shows both dashboards; Explore → Tempo shows spans after a chat request
- Prometheus: `ai:gen_ai_cost_usd:rate5m` series appear after the first completion through the gateway

🤖 Generated with [Claude Code](https://claude.com/claude-code)
