### PR TITLE
fix(ai): set explicit Authorization/Bearer location on apikey policy

### DIFF
--- a/kubernetes/apps/ai/agentgateway/app/policies/apikey-policy.yaml
+++ b/kubernetes/apps/ai/agentgateway/app/policies/apikey-policy.yaml
@@ -21,5 +21,12 @@ spec:
   traffic:
     apiKeyAuthentication:
       mode: Strict
+      # The CRD documents Authorization/Bearer as the default location, but
+      # the 1.2.1 data plane does not apply it ("no API Key found" despite a
+      # valid Bearer header) - set it explicitly.
+      location:
+        header:
+          name: Authorization
+          prefix: "Bearer "
       secretRef:
         name: agentgateway-api-keys


### PR DESCRIPTION
The CRD says an omitted `apiKeyAuthentication.location` defaults to `Authorization: Bearer …`, but the **1.2.1 data plane does not apply that default** — requests with a valid Bearer key are rejected with `api key authentication failure: no API Key found` (verified with curl directly against the `public` data plane, bypassing envoy). Explicit `location.header {name: Authorization, prefix: "Bearer "}` fixes it.

Upstream-worthy bug; we pin the explicit location regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)