### PR TITLE
fix(open-webui): raise sqlalchemy db pool (QueuePool exhaustion)

### DIFF
--- a/kubernetes/apps/ai/open-webui/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/open-webui/app/helmrelease.yaml
@@ -38,6 +38,12 @@ spec:
               tag: v0.9.6@sha256:90eae5b419e40b4c3dd684582b2c83440b36f9ae2f6532c09639b2ba4ee65158
             env:
               ENABLE_CHANNELS: true
+              # SQLAlchemy pool: defaults (5+10) saturate when large model
+              # lists hammer postgres -> QueuePool TimeoutError, UI hangs
+              DATABASE_POOL_SIZE: 10
+              DATABASE_POOL_MAX_OVERFLOW: 20
+              DATABASE_POOL_TIMEOUT: 30
+              DATABASE_POOL_RECYCLE: 3600
               # Ollama
               ENABLE_FORWARD_USER_INFO_HEADERS: true
               ENABLE_OLLAMA_API: true


### PR DESCRIPTION
Open-WebUI appeared "crashed" but the pod was healthy (0 restarts, /health 200). Logs showed:

```
sqlalchemy.exc.TimeoutError: QueuePool limit of size 5 overflow 10 reached, connection timed out, timeout 30.00
```

Importing ~485 models from the per-provider gateway connections saturated the default pool; all requests then hung 30s → UI freeze. Fix: `DATABASE_POOL_SIZE=10`, `DATABASE_POOL_MAX_OVERFLOW=20`, `DATABASE_POOL_RECYCLE=3600` (max 30 conns — fine within postgres-17 limits). Root-cause mitigation: pin explicit Model IDs per connection (485 → ~10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)