### PR TITLE
chore(ai): temporarily remove open-webui and open-notebook

### DIFF
--- a/kubernetes/apps/ai/kustomization.yaml
+++ b/kubernetes/apps/ai/kustomization.yaml
@@ -14,7 +14,11 @@ resources:
   - ./kokoro/ks.yaml
   - ./perplexica/ks.yaml
   - ./ollama/ks.yaml
-  - ./open-notebook/ks.yaml
-  - ./open-webui/ks.yaml
+  # Temporarily removed (2026-06-07) - workloads/PVCs pruned, but manifests,
+  # postgres open-webui DB, surrealdb open_notebook ns, 1P items and volsync
+  # restic repos (ceph/minio/r2) are all kept. To revive: uncomment, then
+  # restore the PVC via the volsync ReplicationDestination flow.
+  # - ./open-notebook/ks.yaml
+  # - ./open-webui/ks.yaml
   - ./qdrant/ks.yaml
   - ./searxng/ks.yaml


### PR DESCRIPTION
Reversible removal ("for now"): both apps commented out of the `ai` namespace kustomization — Flux prunes deployments, routes, dragonfly and PVCs.

**Kept for revival:** manifests in git · postgres `open-webui` DB · surrealdb `open_notebook` ns · 1Password items · VolSync restic repos (all six sources verified `Successful` within the last hour pre-removal).

**Revive later:** uncomment the two lines; PVC data restorable via the VolSync ReplicationDestination flow if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)