### PR TITLE
feat(hermes): deploy hermes-agent routed through agentgateway (xAI)

### DIFF
--- a/kubernetes/apps/ai/hermes/README.md
+++ b/kubernetes/apps/ai/hermes/README.md
@@ -1,0 +1,53 @@
+# Hermes Agent
+
+[NousResearch/hermes-agent](https://github.com/NousResearch/hermes-agent) — a
+self-improving conversational AI agent (learning loop, persistent memory,
+skills). Self-contained Python image; no upstream Helm chart, so this is a
+hand-authored `app-template` deploy.
+
+Dashboard (chat UI) at `https://hermes.${SECRET_DOMAIN}` (basic auth).
+
+## LLM backend
+
+All LLM traffic goes through **agentgateway** (the single model gateway), like
+every other AI app here. Hermes points at the keyless `internal-noauth`
+gateway, which injects the real provider key:
+
+| Setting | Value |
+| ------- | ----- |
+| `OPENAI_BASE_URL` | `http://internal-noauth.ai.svc.cluster.local/xai/v1` |
+| `OPENAI_API_KEY`  | placeholder (gateway injects the real xAI key) |
+| `OPENAI_MODEL`    | a model your xAI subscription serves (**set this**) |
+
+Hermes requires a **≥64k token context window** and a tool-calling-capable
+model — Grok models satisfy both.
+
+**Local models later:** when the local vLLM backend exists, add a backend +
+HTTPRoute under `../agentgateway/app/backends/` and change only `OPENAI_BASE_URL`
+(e.g. `.../vllm/v1`). Nothing else in this deploy changes.
+
+## Prerequisites (manual, before first sync)
+
+1. **1Password item `hermes`** (vault used by the `onepassword`
+   ClusterSecretStore) with fields:
+   - `HERMES_DASHBOARD_USER`
+   - `HERMES_DASHBOARD_PASSWORD`
+   - `HERMES_DASHBOARD_SECRET` — `openssl rand -hex 32`
+2. **Confirm the model id**: list what xAI serves and set `OPENAI_MODEL`:
+   ```bash
+   kubectl -n ai run -it --rm curl --image=curlimages/curl --restart=Never -- \
+     -s http://internal-noauth.ai.svc.cluster.local/xai/v1/models
+   ```
+
+## Notes
+
+- **Single-writer state.** `/opt/data` (sessions/memories/skills, incl. SQLite)
+  is not concurrency-safe → `replicas: 1` + `strategy: Recreate` + RWO
+  `ceph-block` PVC. Do not scale up.
+- **Runs as root then drops** to UID 10000 (s6-overlay), so no `runAsNonRoot`
+  here — `fsGroup: 10000` makes the PVC writable for the dropped user.
+- **Cost tracking:** Grok models have no price row in
+  `../agentgateway/app/rules/cost.yaml`, so spend shows under "unpriced models"
+  until you add `grok-*` input/output rows. Token counts are still tracked.
+- **Ports:** `9119` dashboard (exposed), `8642` OpenAI-compatible API
+  (not enabled here — set `API_SERVER_ENABLED=true` + `API_SERVER_KEY` to use it).

--- a/kubernetes/apps/ai/hermes/app/externalsecret.yaml
+++ b/kubernetes/apps/ai/hermes/app/externalsecret.yaml
@@ -1,0 +1,30 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+# Hermes web-dashboard basic-auth credentials. The agent's dashboard can run
+# arbitrary commands via its terminal backends, so it must NOT be exposed
+# unauthenticated - basic auth is the minimum gate (swap to Authentik OIDC
+# later via HERMES_DASHBOARD_OIDC_* if desired).
+#
+# 1Password item `hermes` fields:
+#   HERMES_DASHBOARD_USER      - dashboard login username
+#   HERMES_DASHBOARD_PASSWORD  - dashboard login password
+#   HERMES_DASHBOARD_SECRET    - session-signing secret (e.g. `openssl rand -hex 32`)
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name hermes
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: *name
+    template:
+      data:
+        HERMES_DASHBOARD_BASIC_AUTH_USERNAME: "{{ .HERMES_DASHBOARD_USER }}"
+        HERMES_DASHBOARD_BASIC_AUTH_PASSWORD: "{{ .HERMES_DASHBOARD_PASSWORD }}"
+        HERMES_DASHBOARD_BASIC_AUTH_SECRET: "{{ .HERMES_DASHBOARD_SECRET }}"
+  dataFrom:
+    - extract:
+        key: hermes

--- a/kubernetes/apps/ai/hermes/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/hermes/app/helmrelease.yaml
@@ -1,0 +1,117 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app hermes
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  install:
+    remediation:
+      retries: -1
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  values:
+    controllers:
+      hermes:
+        # Single source of truth at /opt/data (sessions/memories/skills) is not
+        # safe for concurrent writers -> exactly one replica, recreate on update.
+        replicas: 1
+        strategy: Recreate
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: docker.io/nousresearch/hermes-agent
+              tag: v2026.6.5
+            # Start the long-running gateway server (matches upstream docker usage).
+            args: ["gateway", "run"]
+            env:
+              # --- LLM backend: route through the internal agentgateway -> xAI ---
+              # The `internal-noauth` gateway injects the real xAI key (xai-secret),
+              # so OPENAI_API_KEY here is just the non-empty placeholder Hermes
+              # requires. To move to local models later, only this base_url
+              # changes (e.g. .../vllm/v1) - the rest of the deploy stays put.
+              OPENAI_BASE_URL: http://internal-noauth.ai.svc.cluster.local/xai/v1
+              OPENAI_API_KEY: gateway-injects-real-key
+              # TODO: set to the exact xAI model id your subscription serves.
+              # List options:
+              #   curl http://internal-noauth.ai.svc.cluster.local/xai/v1/models
+              OPENAI_MODEL: grok-4
+              # --- Web dashboard (chat / management UI) on :9119 ---
+              HERMES_DASHBOARD: "1"
+              HERMES_DASHBOARD_HOST: 0.0.0.0
+              HERMES_DASHBOARD_PORT: "9119"
+              # --- Run as the image's default `hermes` user. The s6 init starts
+              # as root, chowns /opt/data, then drops to UID 10000. ---
+              HERMES_UID: "10000"
+              HERMES_GID: "10000"
+            envFrom:
+              # Dashboard basic-auth credentials (HERMES_DASHBOARD_BASIC_AUTH_*).
+              - secretRef:
+                  name: *app
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  tcpSocket:
+                    port: &dash 9119
+                  initialDelaySeconds: 10
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness: *probes
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  tcpSocket:
+                    port: *dash
+                  initialDelaySeconds: 10
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  # Generous: first boot initialises config/skills under /opt/data.
+                  failureThreshold: 30
+            resources:
+              requests:
+                cpu: 100m
+                memory: 512Mi
+              limits:
+                memory: 2Gi
+    defaultPodOptions:
+      securityContext:
+        # s6 starts as root then drops to 10000; fsGroup makes the ceph-block
+        # PVC group-writable so the dropped user owns its state at /opt/data.
+        fsGroup: 10000
+        fsGroupChangePolicy: OnRootMismatch
+    service:
+      app:
+        ports:
+          http:
+            port: *dash
+    route:
+      app:
+        annotations:
+          gatus.home-operations.com/endpoint: |-
+            url: https://hermes.${SECRET_DOMAIN}/
+            conditions:
+              - "[STATUS] == any(200, 401)"
+            group: ai
+        hostnames:
+          - "{{ .Release.Name }}.${SECRET_DOMAIN}"
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+            sectionName: https
+    persistence:
+      data:
+        existingClaim: *app
+        globalMounts:
+          - path: /opt/data

--- a/kubernetes/apps/ai/hermes/app/kustomization.yaml
+++ b/kubernetes/apps/ai/hermes/app/kustomization.yaml
@@ -1,0 +1,31 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: ai
+patches:
+- patch: |-
+    apiVersion: helm.toolkit.fluxcd.io/v2
+    kind: HelmRelease
+    metadata:
+      name: _
+    spec:
+      install:
+        crds: CreateReplace
+        strategy:
+          name: RetryOnFailure
+      rollback:
+        cleanupOnFail: true
+        recreate: true
+      upgrade:
+        cleanupOnFail: true
+        crds: CreateReplace
+        strategy:
+          name: RemediateOnFailure
+        remediation:
+          remediateLastFailure: true
+          retries: 2
+  target:
+    group: helm.toolkit.fluxcd.io
+    kind: HelmRelease
+resources:
+- ./externalsecret.yaml
+- ./helmrelease.yaml

--- a/kubernetes/apps/ai/hermes/ks.yaml
+++ b/kubernetes/apps/ai/hermes/ks.yaml
@@ -1,0 +1,40 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app hermes
+  namespace: &namespace ai
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  components:
+    - ../../../../components/volsync
+  dependsOn:
+    - name: onepassword-store
+      namespace: security
+    # Hermes routes all LLM traffic through the internal agentgateway.
+    - name: agentgateway
+      namespace: *namespace
+  interval: 1h
+  path: ./kubernetes/apps/ai/hermes/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+    substitute:
+      APP: *app
+      VOLSYNC_CAPACITY: 10Gi
+      VOLSYNC_SCHEDULE_CEPH: "35 */4 * * *"
+      VOLSYNC_SCHEDULE_MINIO: "35 */6 * * *"
+      VOLSYNC_SCHEDULE_R2: "10 2 * * *"
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 5m
+  wait: false

--- a/kubernetes/apps/ai/kustomization.yaml
+++ b/kubernetes/apps/ai/kustomization.yaml
@@ -11,6 +11,7 @@ components:
 resources:
   - ./agentgateway/ks.yaml
   - ./agentgateway-dashboards/ks.yaml
+  - ./hermes/ks.yaml
   - ./kokoro/ks.yaml
   - ./perplexica/ks.yaml
   - ./ollama/ks.yaml


### PR DESCRIPTION
## What

Deploys [NousResearch/hermes-agent](https://github.com/NousResearch/hermes-agent) (self-improving conversational AI agent) into the `ai` namespace.

Upstream ships **no** Helm chart / CRD, so this is a hand-authored `app-template` deploy from the official image (`nousresearch/hermes-agent:v2026.6.5`).

## How

- **Single-replica, `Recreate`, RWO `ceph-block` PVC at `/opt/data`** — the agent's state (sessions/memories/skills, incl. SQLite) is not safe for concurrent writers.
- **LLM backend via the keyless `internal-noauth` agentgateway → xAI**: `OPENAI_BASE_URL=http://internal-noauth.ai.svc.cluster.local/xai/v1`. The gateway injects the real xAI key; `OPENAI_API_KEY` is a placeholder. Switching to **local models later is a one-line `OPENAI_BASE_URL` change**.
- **Dashboard** (`:9119`) exposed at `hermes.${SECRET_DOMAIN}` via `envoy-internal`, gated with **basic auth** (the agent can run commands via terminal backends, so it is not left open).
- Runs as the image's default `hermes` user — s6 starts as root, chowns `/opt/data`, drops to UID 10000; `fsGroup: 10000`, no forced `runAsNonRoot` (matches the open-webui precedent).
- Triple volsync backups (ceph/minio/r2) via the standard component.

## Required before the pod is healthy (runtime, not CI)

- [ ] 1Password item **`hermes`**: `HERMES_DASHBOARD_USER`, `HERMES_DASHBOARD_PASSWORD`, `HERMES_DASHBOARD_SECRET`
- [ ] Confirm `OPENAI_MODEL` (defaulted to `grok-4`) against `/xai/v1/models`

## Validation

- `kustomize build` (app + namespace) ✓
- HelmRelease inflated through app-template `5.0.1` via `helm template` ✓ — confirms `replicas: 1`, `Recreate`, `/opt/data` mount, ports/route on `9119`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)