### PR TITLE
fix(hermes): gatus 302 + grok-4 cost pricing

### DIFF
--- a/kubernetes/apps/ai/agentgateway/app/rules/cost.yaml
+++ b/kubernetes/apps/ai/agentgateway/app/rules/cost.yaml
@@ -77,6 +77,21 @@ spec:
         - record: *price
           labels: { gen_ai_request_model: google/gemini-2.0-flash-lite-001, gen_ai_token_type: output }
           expr: vector(0.30)
+        # --- xAI (Grok) - the grok-4 alias resolves to grok-4.3; family is
+        # flat-priced at $1.25 in / $2.50 out per 1M tokens. Price both ids
+        # since clients may send either. ---
+        - record: *price
+          labels: { gen_ai_request_model: grok-4, gen_ai_token_type: input }
+          expr: vector(1.25)
+        - record: *price
+          labels: { gen_ai_request_model: grok-4, gen_ai_token_type: output }
+          expr: vector(2.50)
+        - record: *price
+          labels: { gen_ai_request_model: grok-4.3, gen_ai_token_type: input }
+          expr: vector(1.25)
+        - record: *price
+          labels: { gen_ai_request_model: grok-4.3, gen_ai_token_type: output }
+          expr: vector(2.50)
 
     - name: ai-llm-cost
       rules:

--- a/kubernetes/apps/ai/hermes/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/hermes/app/helmrelease.yaml
@@ -102,7 +102,8 @@ spec:
           gatus.home-operations.com/endpoint: |-
             url: https://hermes.${SECRET_DOMAIN}/
             conditions:
-              - "[STATUS] == any(200, 401)"
+              # Dashboard 302-redirects unauthenticated requests to its login.
+              - "[STATUS] == any(200, 302, 401)"
             group: ai
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"


### PR DESCRIPTION
Follow-ups to #951 (Hermes deploy), verified against the live rollout.

- **fix(hermes):** the dashboard 302-redirects unauthenticated requests to its login, so the gatus health condition now accepts `any(200, 302, 401)` (was `200, 401`) to avoid a false-down alert.
- **feat(agentgateway):** price `grok-4` (+ its `grok-4.3` alias) at xAI's published API rate **$1.25/1M input, $2.50/1M output**, so Hermes' xAI traffic shows estimated USD instead of landing in the unpriced-models series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)