### PR TITLE
feat(hermes): scoped single-repo git access via fine-grained PAT

### DIFF
--- a/kubernetes/apps/ai/hermes/README.md
+++ b/kubernetes/apps/ai/hermes/README.md
@@ -33,11 +33,42 @@ HTTPRoute under `../agentgateway/app/backends/` and change only `OPENAI_BASE_URL
    - `HERMES_DASHBOARD_USER`
    - `HERMES_DASHBOARD_PASSWORD`
    - `HERMES_DASHBOARD_SECRET` — `openssl rand -hex 32`
+   - `GITHUB_LLM_WIKI_TOKEN` — fine-grained GitHub PAT (see **Git access** below)
 2. **Confirm the model id**: list what xAI serves and set `OPENAI_MODEL`:
    ```bash
    kubectl -n ai run -it --rm curl --image=curlimages/curl --restart=Never -- \
      -s http://internal-noauth.ai.svc.cluster.local/xai/v1/models
    ```
+
+## Git access (single private repo)
+
+Hermes is given access to **exactly one** private repo, without exposing any
+other repo on the account:
+
+1. **Create a fine-grained PAT** (GitHub → Settings → Developer settings →
+   Fine-grained tokens):
+   - **Repository access:** *Only select repositories* → pick the one repo.
+   - **Permissions:** *Contents* → **Read and write** (write enabled here).
+   - Set an expiry; rotate by updating `GIT_TOKEN` in 1Password (reloader
+     restarts the pod automatically).
+2. Put the token in the `hermes` 1Password item as `GITHUB_LLM_WIKI_TOKEN`.
+
+The `hermes-git` ExternalSecret renders it into a `.git-credentials` file
+(`https://x-access-token:<token>@github.com`); the file is mounted read-only at
+`/secrets/git/.git-credentials` and consumed by git's `store` credential helper,
+which is wired up purely through `GIT_CONFIG_*` env (no writable `$HOME`). A
+commit identity (`user.name` / `user.email`) is set for pushes — change the
+`GIT_CONFIG_VALUE_1/2` env if you want a different author.
+
+Because the PAT is **repo-scoped server-side**, this is the security boundary:
+even though git may present it for any `github.com` URL, GitHub rejects it for
+any repo outside the selected one. (A *classic* PAT or an account SSH key would
+expose every repo — don't use those.)
+
+> **Other hosts / SSH:** for GitLab use a *project* access/deploy token the same
+> way. For an even tighter, key-based boundary, a per-repo **deploy key**
+> (SSH, write-enabled) also works, but needs careful key-file permissions when
+> mounted from a Secret — the HTTPS PAT above avoids that.
 
 ## Notes
 

--- a/kubernetes/apps/ai/hermes/app/externalsecret.yaml
+++ b/kubernetes/apps/ai/hermes/app/externalsecret.yaml
@@ -28,3 +28,35 @@ spec:
   dataFrom:
     - extract:
         key: hermes
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+# Git credentials for the agent, rendered as a `.git-credentials` file that the
+# git `store` helper reads (the raw token never appears in a remote URL or env).
+#
+# Scope: use a GitHub *fine-grained* PAT restricted to "Only select
+# repositories" -> the single repo Hermes should touch, with Contents:
+# Read/Write. This is what keeps every other repo invisible - a classic PAT
+# would expose all repos the account can see.
+#
+# 1Password item `hermes` field:
+#   GITHUB_LLM_WIKI_TOKEN - github_pat_... (fine-grained, single-repo, Contents: R/W)
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name hermes-git
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: *name
+    template:
+      data:
+        # Host-level entry. The token is repo-scoped server-side by GitHub, so
+        # even though git may offer it for any github.com URL, GitHub rejects it
+        # for anything outside the selected repo.
+        .git-credentials: "https://x-access-token:{{ .GITHUB_LLM_WIKI_TOKEN }}@github.com"
+  dataFrom:
+    - extract:
+        key: hermes

--- a/kubernetes/apps/ai/hermes/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/hermes/app/helmrelease.yaml
@@ -54,6 +54,19 @@ spec:
               # as root, chowns /opt/data, then drops to UID 10000. ---
               HERMES_UID: "10000"
               HERMES_GID: "10000"
+              # --- Git access (single private repo). Inject a global git config
+              # via env (no writable $HOME needed): the `store` helper reads the
+              # token from the mounted `.git-credentials` file (see persistence
+              # below), and a commit identity is set for write access. The token
+              # is a fine-grained PAT scoped to ONE repo (hermes-git secret), so
+              # this grants no access to any other repo. ---
+              GIT_CONFIG_COUNT: "3"
+              GIT_CONFIG_KEY_0: credential.helper
+              GIT_CONFIG_VALUE_0: store --file=/secrets/git/.git-credentials
+              GIT_CONFIG_KEY_1: user.name
+              GIT_CONFIG_VALUE_1: Hermes Agent
+              GIT_CONFIG_KEY_2: user.email
+              GIT_CONFIG_VALUE_2: hermes@users.noreply.github.com
             envFrom:
               # Dashboard basic-auth credentials (HERMES_DASHBOARD_BASIC_AUTH_*).
               - secretRef:
@@ -118,3 +131,13 @@ spec:
         existingClaim: *app
         globalMounts:
           - path: /opt/data
+      # Single private-repo git token, rendered as `.git-credentials` by the
+      # hermes-git ExternalSecret and read by the git `store` helper (see
+      # GIT_CONFIG_* env above). reloader restarts the pod on token rotation.
+      git-credentials:
+        type: secret
+        name: hermes-git
+        globalMounts:
+          - path: /secrets/git/.git-credentials
+            subPath: .git-credentials
+            readOnly: true


### PR DESCRIPTION
## What

Give the Hermes agent read/write access to **a single private repo** without exposing any other repo on the account.

- **`externalsecret.yaml`** — new `hermes-git` ExternalSecret renders `GITHUB_LLM_WIKI_TOKEN` (fine-grained PAT in the `hermes` 1Password item) into a `.git-credentials` file. The raw token never appears in a remote URL or env var.
- **`helmrelease.yaml`** — mounts the file read-only at `/secrets/git/.git-credentials` and wires git via `GIT_CONFIG_*` env (credential `store` helper + commit identity `Hermes Agent <hermes@users.noreply.github.com>`). No writable `$HOME` needed.
- **`README.md`** — documents the prerequisite and single-repo scoping.

## Security boundary

The fine-grained PAT is **repo-scoped server-side by GitHub** — that is the boundary. Even though git may present the token for any `github.com` URL, GitHub rejects it for any repo outside the selected one. A classic PAT or account SSH key would expose everything; this does not.

## After merge

Flux syncs the `hermes-git` ExternalSecret and reloader restarts the pod. Verify:

```
kubectl -n ai get externalsecret hermes-git
kubectl -n ai exec deploy/hermes -- git ls-remote https://github.com/<owner>/<repo>.git
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)