### PR TITLE
feat(hermes): config.yaml-driven providers, drop global OPENAI_BASE_URL

### DIFF
--- a/kubernetes/apps/ai/hermes/README.md
+++ b/kubernetes/apps/ai/hermes/README.md
@@ -9,22 +9,59 @@ Dashboard (chat UI) at `https://hermes.${SECRET_DOMAIN}` (basic auth).
 
 ## LLM backend
 
-All LLM traffic goes through **agentgateway** (the single model gateway), like
-every other AI app here. Hermes points at the keyless `internal-noauth`
-gateway, which injects the real provider key:
+Hermes picks its model/provider from **`/opt/data/config.yaml`** (on the PVC), not
+from env. That file is seeded by the `seed-config` initContainer from the
+`hermes-config-seed` ConfigMap (`configmap.yaml`) **only if absent** — Hermes owns
+it afterwards (`hermes model` / `hermes config edit` rewrite it). Two providers are
+configured:
 
-| Setting | Value |
-| ------- | ----- |
-| `OPENAI_BASE_URL` | `http://internal-noauth.ai.svc.cluster.local/xai/v1` |
-| `OPENAI_API_KEY`  | placeholder (gateway injects the real xAI key) |
-| `OPENAI_MODEL`    | a model your xAI subscription serves (**set this**) |
+| Provider | Routing | Auth |
+| -------- | ------- | ---- |
+| `custom:gateway` | agentgateway `internal-noauth` → `/opencodego/v1` (kimi etc.) | keyless (gateway injects the opencodego key) |
+| `xai-oauth` (native) | **direct to xAI**, bypassing agentgateway | OAuth (Grok subscription, see below) |
 
-Hermes requires a **≥64k token context window** and a tool-calling-capable
-model — Grok models satisfy both.
+The default is `grok-4.3` via `xai-oauth`. Hermes needs a **≥64k context**,
+tool-calling model — Grok and kimi both qualify.
+
+> **No `OPENAI_BASE_URL`.** It used to point Hermes at the gateway, but it's a
+> *global* OpenAI-SDK override that pins the endpoint for **every** provider — it
+> was sending `grok-4.3` to `/opencodego`. Per-provider `base_url` in
+> `config.yaml` is the correct layer, so the `OPENAI_*` env vars were removed. If
+> Hermes ever won't boot without an OpenAI key, re-add a dummy `OPENAI_API_KEY`
+> **only** (never `OPENAI_BASE_URL`).
+
+**Switching models:** edit the ConfigMap + re-seed (below), or at runtime
+`kubectl -n ai exec -it deploy/hermes -c app -- hermes model` (writes config.yaml
+on the PVC). Add a 429 fail-over chain with `hermes fallback add` (e.g. primary
+`xai-oauth/grok-4.3`, fallback `custom:gateway/kimi-k2.6`).
+
+**Re-seed config.yaml** (after editing the ConfigMap, or to reset):
+```bash
+kubectl -n ai exec deploy/hermes -c app -- rm -f /opt/data/config.yaml
+kubectl -n ai rollout restart deploy/hermes
+```
+
+### xAI Grok subscription login (manual, one-time)
+
+The Grok **subscription** is used via Hermes' native `xai-oauth` provider (OAuth),
+which can't be done through the gateway (that path needs a console.x.ai API key, a
+separate product). The OAuth loopback callback can't reach a pod from your laptop,
+so use `--manual-paste`:
+
+```bash
+kubectl -n ai exec -it deploy/hermes -c app -- hermes auth add xai-oauth --no-browser --manual-paste
+```
+
+Open the printed URL, approve, then paste the **full** failed-callback URL (or a
+`?code=...&state=...` fragment, or a fresh bare code) at the prompt. Codes expire in
+~minutes; if it tracebacks on a stale/reused login, `hermes auth remove xai-oauth`
+and retry for a fresh `state`. Credentials persist in `/opt/data/auth.json` (PVC →
+Volsync-backed; `offline_access` refresh token renews automatically), so this is a
+one-time step per fresh PVC.
 
 **Local models later:** when the local vLLM backend exists, add a backend +
-HTTPRoute under `../agentgateway/app/backends/` and change only `OPENAI_BASE_URL`
-(e.g. `.../vllm/v1`). Nothing else in this deploy changes.
+HTTPRoute under `../agentgateway/app/backends/` and a `custom_providers` entry
+pointing at `.../vllm/v1`. Nothing else in this deploy changes.
 
 ## Prerequisites (manual, before first sync)
 
@@ -34,11 +71,10 @@ HTTPRoute under `../agentgateway/app/backends/` and change only `OPENAI_BASE_URL
    - `HERMES_DASHBOARD_PASSWORD`
    - `HERMES_DASHBOARD_SECRET` — `openssl rand -hex 32`
    - `GITHUB_LLM_WIKI_TOKEN` — fine-grained GitHub PAT (see **Git access** below)
-2. **Confirm the model id**: list what xAI serves and set `OPENAI_MODEL`:
-   ```bash
-   kubectl -n ai run -it --rm curl --image=curlimages/curl --restart=Never -- \
-     -s http://internal-noauth.ai.svc.cluster.local/xai/v1/models
-   ```
+2. **Authenticate the Grok subscription** once the pod is up — run the
+   `hermes auth add xai-oauth --manual-paste` flow in **LLM backend → xAI Grok
+   subscription login** above. (Until then Hermes has no working provider unless
+   you switch the seed to `custom:gateway`.)
 
 ## Git access (single private repo)
 
@@ -49,8 +85,8 @@ other repo on the account:
    Fine-grained tokens):
    - **Repository access:** *Only select repositories* → pick the one repo.
    - **Permissions:** *Contents* → **Read and write** (write enabled here).
-   - Set an expiry; rotate by updating `GIT_TOKEN` in 1Password (reloader
-     restarts the pod automatically).
+   - Set an expiry; rotate by updating `GITHUB_LLM_WIKI_TOKEN` in 1Password
+     (reloader restarts the pod automatically).
 2. Put the token in the `hermes` 1Password item as `GITHUB_LLM_WIKI_TOKEN`.
 
 The `hermes-git` ExternalSecret renders it into a `.git-credentials` file
@@ -77,8 +113,9 @@ expose every repo — don't use those.)
   `ceph-block` PVC. Do not scale up.
 - **Runs as root then drops** to UID 10000 (s6-overlay), so no `runAsNonRoot`
   here — `fsGroup: 10000` makes the PVC writable for the dropped user.
-- **Cost tracking:** Grok models have no price row in
-  `../agentgateway/app/rules/cost.yaml`, so spend shows under "unpriced models"
-  until you add `grok-*` input/output rows. Token counts are still tracked.
+- **Cost tracking:** the default `xai-oauth` Grok path talks to xAI **directly**,
+  bypassing agentgateway, so it does **not** appear in gateway cost/Tempo tracking
+  at all (a flat subscription, so there's no per-token spend anyway). Only the
+  `custom:gateway` path is metered by the gateway.
 - **Ports:** `9119` dashboard (exposed), `8642` OpenAI-compatible API
   (not enabled here — set `API_SERVER_ENABLED=true` + `API_SERVER_KEY` to use it).

--- a/kubernetes/apps/ai/hermes/app/configmap.yaml
+++ b/kubernetes/apps/ai/hermes/app/configmap.yaml
@@ -1,0 +1,31 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/core/configmap_v1.json
+# Seed for /opt/data/config.yaml. The `seed-config` initContainer copies this
+# into the PVC ONLY when config.yaml is absent (fresh PVC); Hermes owns the file
+# afterwards. To force a re-seed: edit this ConfigMap, then
+# `kubectl -n ai exec deploy/hermes -c app -- rm /opt/data/config.yaml` and
+# restart. Hermes fills in defaults for everything not set here.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: hermes-config-seed
+data:
+  config.yaml: |
+    # Named custom providers (each has its own base_url, so nothing relies on the
+    # global OPENAI_BASE_URL env, which is intentionally not set).
+    custom_providers:
+      # OpenCode Go (open models) via the internal agentgateway. The keyless
+      # internal-noauth gateway injects the real opencodego key, so no api_key.
+      # Referenced elsewhere as `custom:gateway`.
+      - name: gateway
+        base_url: http://internal-noauth.ai.svc.cluster.local/opencodego/v1
+        api_mode: chat_completions
+
+    # Default serving model. Grok via the native xai-oauth provider (subscription;
+    # creds added with `hermes auth add xai-oauth --manual-paste`, kept in
+    # /opt/data/auth.json). To serve kimi through the gateway instead:
+    #   model: { default: kimi-k2.6, provider: custom:gateway }
+    # Add a fallback chain at runtime with `hermes fallback add`.
+    model:
+      default: grok-4.3
+      provider: xai-oauth

--- a/kubernetes/apps/ai/hermes/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/hermes/app/helmrelease.yaml
@@ -25,6 +25,32 @@ spec:
         strategy: Recreate
         annotations:
           reloader.stakater.com/auto: "true"
+        initContainers:
+          # Seed /opt/data/config.yaml from the hermes-config-seed ConfigMap, but
+          # ONLY if it doesn't exist yet -> Hermes owns the file thereafter
+          # (`hermes model` / `config edit` write to it). To re-seed: edit the
+          # ConfigMap and `rm /opt/data/config.yaml`, then restart. Runs as root
+          # (pod default) so it can chown the file to the dropped 10000 user.
+          seed-config:
+            image:
+              repository: docker.io/library/busybox
+              tag: "1.38"
+            command:
+              - sh
+              - -c
+              - |
+                set -eu
+                if [ -f /opt/data/config.yaml ]; then
+                  echo "[seed] /opt/data/config.yaml exists - leaving it untouched"
+                else
+                  echo "[seed] writing /opt/data/config.yaml from ConfigMap"
+                  cp /seed/config.yaml /opt/data/config.yaml
+                  chown 10000:10000 /opt/data/config.yaml
+                  chmod 0644 /opt/data/config.yaml
+                fi
+            securityContext:
+              runAsUser: 0
+              runAsGroup: 0
         containers:
           app:
             image:
@@ -33,19 +59,22 @@ spec:
             # Start the long-running gateway server (matches upstream docker usage).
             args: ["gateway", "run"]
             env:
-              # --- LLM backend: route through the internal agentgateway to
-              # OpenCode Go (flat $10/mo sub). The `internal-noauth` gateway
-              # injects the real OpenCode key (opencodego-secret), so
-              # OPENAI_API_KEY here is just the non-empty placeholder Hermes
-              # requires. To switch provider/model later, change only these two
-              # lines (e.g. /xai/v1 + grok-4, or /<vllm>/v1 for local). ---
-              OPENAI_BASE_URL: http://internal-noauth.ai.svc.cluster.local/opencodego/v1
-              OPENAI_API_KEY: gateway-injects-real-key
-              # kimi-k2.6: strong agentic tool-caller, ~256k context (Hermes
-              # needs tool-calling + >=64k). Other Go ids: glm-5.1,
-              # deepseek-v4-pro, qwen3.7-max. List:
-              #   curl http://internal-noauth.ai.svc.cluster.local/opencodego/v1/models
-              OPENAI_MODEL: kimi-k2.6
+              # --- LLM backend ---
+              # Model + provider routing live in /opt/data/config.yaml, seeded by
+              # the `seed-config` initContainer from the `hermes-config-seed`
+              # ConfigMap (see configmap.yaml): a named `custom:gateway` provider
+              # points at the internal agentgateway, and the native `xai-oauth`
+              # provider serves the Grok subscription (creds in /opt/data/auth.json
+              # via `hermes auth add xai-oauth --manual-paste`).
+              #
+              # The old OPENAI_BASE_URL / OPENAI_API_KEY / OPENAI_MODEL env were
+              # REMOVED on purpose: OPENAI_BASE_URL is a global OpenAI-SDK override
+              # that hijacked the endpoint for EVERY provider (it pinned grok-4.3
+              # to /opencodego). Per-provider base_url in config.yaml is the right
+              # layer; OPENAI_BASE_URL only ever applied to the `openai-api`
+              # provider, which we no longer use. If Hermes ever refuses to boot
+              # without an OpenAI key, re-add a dummy `OPENAI_API_KEY` ONLY (never
+              # OPENAI_BASE_URL).
               # --- Web dashboard (chat / management UI) on :9119 ---
               HERMES_DASHBOARD: "1"
               HERMES_DASHBOARD_HOST: 0.0.0.0
@@ -141,3 +170,14 @@ spec:
           - path: /secrets/git/.git-credentials
             subPath: .git-credentials
             readOnly: true
+      # config.yaml template for the seed-config initContainer (mounted only
+      # there, read-only). The PVC `data` globalMount gives that init container
+      # /opt/data so it can write the seeded file.
+      config-seed:
+        type: configMap
+        name: hermes-config-seed
+        advancedMounts:
+          hermes:
+            seed-config:
+              - path: /seed
+                readOnly: true

--- a/kubernetes/apps/ai/hermes/app/kustomization.yaml
+++ b/kubernetes/apps/ai/hermes/app/kustomization.yaml
@@ -27,5 +27,6 @@ patches:
     group: helm.toolkit.fluxcd.io
     kind: HelmRelease
 resources:
+- ./configmap.yaml
 - ./externalsecret.yaml
 - ./helmrelease.yaml


### PR DESCRIPTION
## Problem

After authenticating the Grok subscription (`hermes auth add xai-oauth`), Hermes still posted `grok-4.3` to `…/opencodego/v1`. Root cause: **`OPENAI_BASE_URL` is a global OpenAI-SDK override** — it pins the endpoint for *every* provider, so selecting `xai-oauth` only changed the model name, not the endpoint.

## Fix

Move model/provider routing out of env and into `/opt/data/config.yaml`, using a **named custom provider** so the gateway has its own `base_url` (per [Hermes provider docs](https://hermes-agent.nousresearch.com/docs/integrations/providers)).

- **`configmap.yaml`** — `hermes-config-seed` holds a `config.yaml` template: a `custom:gateway` provider (agentgateway `/opencodego`) + native `xai-oauth` provider, default `grok-4.3`/`xai-oauth`.
- **`helmrelease.yaml`** —
  - new `seed-config` initContainer (busybox) copies the template to `/opt/data/config.yaml` **only if absent**, then `chown`s it to `10000` (Hermes owns it thereafter).
  - mounts the ConfigMap at `/seed` (init only); the PVC global mount gives the init `/opt/data`.
  - **removes `OPENAI_BASE_URL` / `OPENAI_API_KEY` / `OPENAI_MODEL`** (the hijack). Comment notes: re-add a dummy `OPENAI_API_KEY` only if boot fails — never `OPENAI_BASE_URL`.
- **`README.md`** — documents the seed/re-seed flow, the xAI OAuth `--manual-paste` login, and that the `xai-oauth` path bypasses gateway cost tracking.

## Post-merge (one-time, because the live PVC already has a config.yaml)

The seed is copy-if-absent, so the existing `/opt/data/config.yaml` won't be replaced automatically. After Flux rolls the new pod:

```bash
kubectl -n ai exec deploy/hermes -c app -- hermes config            # check current provider
# if it isn't grok-4.3/xai-oauth, adopt the seeded config:
kubectl -n ai exec deploy/hermes -c app -- rm -f /opt/data/config.yaml
kubectl -n ai rollout restart deploy/hermes
kubectl -n ai exec deploy/hermes -c app -- hermes status            # confirm Grok active
```

The `xai-oauth` credential in `/opt/data/auth.json` is untouched by the re-seed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)