### PR TITLE
fix(hermes): stop double-gateway CrashLoop (idle main CMD)

### DIFF
--- a/kubernetes/apps/ai/hermes/README.md
+++ b/kubernetes/apps/ai/hermes/README.md
@@ -111,6 +111,12 @@ expose every repo — don't use those.)
 - **Single-writer state.** `/opt/data` (sessions/memories/skills, incl. SQLite)
   is not concurrency-safe → `replicas: 1` + `strategy: Recreate` + RWO
   `ceph-block` PVC. Do not scale up.
+- **Gateway runs via the profile service, not the CMD.** The image auto-starts a
+  `gateway-default` s6 service (the `default` profile gateway: cron + messaging).
+  The container CMD is therefore idled (`args: ["sleep","infinity"]`) — passing
+  `gateway run` started a *second* gateway that collided at startup and
+  CrashLooped the pod. The `dashboard` s6 service serves chat independently.
+  Don't set `args` back to `gateway run`.
 - **Runs as root then drops** to UID 10000 (s6-overlay), so no `runAsNonRoot`
   here — `fsGroup: 10000` makes the PVC writable for the dropped user.
 - **Cost tracking:** the default `xai-oauth` Grok path talks to xAI **directly**,

--- a/kubernetes/apps/ai/hermes/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/hermes/app/helmrelease.yaml
@@ -56,8 +56,15 @@ spec:
             image:
               repository: docker.io/nousresearch/hermes-agent
               tag: v2026.6.5
-            # Start the long-running gateway server (matches upstream docker usage).
-            args: ["gateway", "run"]
+            # The image's `gateway-default` s6 *profile* service already runs the
+            # gateway (cron + messaging platforms). Passing `gateway run` here too
+            # started a SECOND gateway that collided at startup ("Another gateway
+            # instance started during our startup. Exiting to avoid
+            # double-running.") -> exit 1 -> CrashLoopBackOff. So idle the main CMD
+            # and let gateway-default be the sole gateway; the `dashboard` s6
+            # service serves chat independently. main-wrapper.sh execs a bare
+            # executable directly, so `sleep infinity` is a valid no-op CMD.
+            args: ["sleep", "infinity"]
             env:
               # --- LLM backend ---
               # Model + provider routing live in /opt/data/config.yaml, seeded by


### PR DESCRIPTION
## Why

Hermes was intermittently CrashLooping (4 restarts). Root cause: **two gateways**.

- The image auto-starts a `gateway-default` s6 **profile** service (run script `exec hermes gateway run`; `reconcile: profile=default action=started`) — this is the real cron + messaging gateway.
- The container CMD `args: ["gateway","run"]` started a **second** `hermes gateway run`.

They race at startup; one logs `Another gateway instance (PID 138) started during our startup. Exiting to avoid double-running.` and exits 1 → s6 tears down the container → CrashLoopBackOff. Recovers when the race doesn't collide → intermittent.

Confirmed *not* the node (talos-1 healthy, no pressure, only Hermes flapping), *not* PR #956 (boot clean, no `OPENAI`/provider error), and chat is healthy on `grok-4.3`.

## Fix

Idle the main CMD: `args: ["sleep","infinity"]`. `main-wrapper.sh` execs a bare executable directly (`first arg is an executable → exec it directly (sleep, bash, sh)`), so `main-hermes` just sleeps. `gateway-default` becomes the sole gateway (cron/messaging preserved); the `dashboard` s6 service keeps serving Grok.

This reverses the earlier `gateway run` CMD, whose premise (CMD = the only gateway) is stale now that the image auto-starts the profile gateway. README + a "don't revert args" note added.

## Verify after merge

```bash
kubectl -n ai rollout status deploy/hermes
kubectl -n ai get pod -l app.kubernetes.io/name=hermes   # RESTARTS should stop climbing
kubectl -n ai logs deploy/hermes -c app | grep -i "double-running" || echo "no collision"
kubectl -n ai exec deploy/hermes -c app -- hermes cron list   # cron still present
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)