### PR TITLE
fix(agentmemory): drop /v1 from Ollama embeddings base URL (404)

### DIFF
--- a/kubernetes/apps/ai/agentmemory/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/agentmemory/app/helmrelease.yaml
@@ -59,8 +59,10 @@ spec:
               # Embeddings via the in-cluster Ollama (OpenAI-compatible). Requires
               # an embedding model pulled into Ollama (`ollama pull nomic-embed-text`)
               # and OPENAI_EMBEDDING_DIMENSIONS matching that model (nomic = 768).
+              # NOTE: base URL is the host ROOT (no /v1) — agentmemory appends
+              # `/v1/embeddings` itself; a trailing /v1 yields /v1/v1/embeddings -> 404.
               EMBEDDING_PROVIDER: openai
-              OPENAI_BASE_URL: http://ollama.ai.svc.cluster.local:11434/v1
+              OPENAI_BASE_URL: http://ollama.ai.svc.cluster.local:11434
               OPENAI_EMBEDDING_MODEL: nomic-embed-text
               OPENAI_EMBEDDING_DIMENSIONS: "768"
               # Ollama ignores the key, but the openai client still wants one set.


### PR DESCRIPTION
agentmemory's openai embedding provider appends `/v1/embeddings` to `OPENAI_BASE_URL`, so a base ending in `/v1` hit `…/v1/v1/embeddings` → **404** (the vector-index embed failed and semantic search returned nothing).

Verified live against the running Ollama: `/v1/embeddings`=200, `/v1/v1/embeddings`=404. Fix uses the host root (no `/v1`), matching joryirving's reference config.

Caught while watching the #958 rollout: `observe`→201 and `search`→200 already work; this fixes the embed so search actually returns stored memories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)