### PR TITLE
fix(hermes): auto-start gateway-default on boot (keeps cron + messaging up)

### DIFF
--- a/kubernetes/apps/ai/hermes/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/hermes/app/helmrelease.yaml
@@ -195,6 +195,27 @@ spec:
                 memory: 512Mi
               limits:
                 memory: 2Gi
+            # The gateway profile persists "stopped" in /opt/data/gateway_state.json
+            # on graceful shutdown, and the image's boot reconcile won't auto-start a
+            # "stopped" profile -> the cron scheduler + messaging platforms stay DOWN
+            # after any pod restart. Force the registered `gateway-default` s6 service
+            # up on every container start. Idempotent (no-op if reconcile already
+            # started it); only ever the ONE registered service, so no double-gateway.
+            lifecycle:
+              postStart:
+                exec:
+                  command:
+                    - sh
+                    - -c
+                    - |
+                      for i in $(seq 1 30); do
+                        if [ -d /run/service/gateway-default ]; then
+                          /command/s6-svc -u /run/service/gateway-default || true
+                          break
+                        fi
+                        sleep 2
+                      done
+                      exit 0
           # Browser VS Code over the agent's state PVC. Same pod as `app`, so it
           # shares the RWO /opt/data mount (no multi-attach, no node affinity).
           # Runs as uid 10000 to own /opt/data (hermes owns it as 10000). LAN-only


### PR DESCRIPTION
**Bug found while wiring the commit-watcher cron.** The gateway profile persists `gateway_state: "stopped"` in `/opt/data/gateway_state.json` on graceful shutdown, and the image's boot reconcile **only registers (doesn't start) a stopped profile**. So after any pod restart, the `gateway-default` s6 service — which runs the **cron scheduler + messaging platforms (Telegram)** — stays down. The `dashboard` service serves chat independently, which masked it. It's been down since the overhaul rolled the pod at 00:15Z (cron jobs incl. the user's `wiki-sync`/`ai-wiki-ingest` stopped firing).

Fix: a `postStart` hook that force-starts the registered `gateway-default` s6 service on every container start. Idempotent (no-op if reconcile already started it), and only ever the one registered service — so no double-gateway (the #957 issue). Verified live: `s6-svc -u` brought the gateway up (`✓ running`, cron scheduler banner).

🤖 Generated with [Claude Code](https://claude.com/claude-code)