### PR TITLE
fix(agentmemory): allow the viewer host/origin (forbidden host)

### DIFF
--- a/kubernetes/apps/ai/agentmemory/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/agentmemory/app/helmrelease.yaml
@@ -56,6 +56,10 @@ spec:
               AGENTMEMORY_TOOLS: all
               III_REST_PORT: "3111"
               RUST_LOG: warn
+              # The viewer (:3113) rejects any Host/Origin not in its allow-list
+              # with "Forbidden host" — add the external hostname behind envoy.
+              VIEWER_ALLOWED_HOSTS: agentmemory.${SECRET_DOMAIN}
+              VIEWER_ALLOWED_ORIGINS: https://agentmemory.${SECRET_DOMAIN}
               # Embeddings via the in-cluster Ollama (OpenAI-compatible). Requires
               # an embedding model pulled into Ollama (`ollama pull nomic-embed-text`)
               # and OPENAI_EMBEDDING_DIMENSIONS matching that model (nomic = 768).


### PR DESCRIPTION
The agentmemory viewer (`:3113`) rejects requests whose Host/Origin aren't in its allow-list with **Forbidden host** — so `https://agentmemory.${SECRET_DOMAIN}` 403s. Set `VIEWER_ALLOWED_HOSTS` / `VIEWER_ALLOWED_ORIGINS` to the external hostname behind the envoy-internal route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)