### PR TITLE
fix(hermes): activate agentmemory as the memory provider

### DIFF
--- a/kubernetes/apps/ai/hermes/app/resources/config.yaml
+++ b/kubernetes/apps/ai/hermes/app/resources/config.yaml
@@ -56,6 +56,10 @@ plugins:
     - agentmemory
 
 memory:
+  # `plugins.enabled` only LOADS the plugin (registers the provider); this line
+  # ACTIVATES agentmemory as the active memory backend so its session hooks fire.
+  # Without it Hermes shows `memory: provider (none)` and captures nothing.
+  provider: agentmemory
   auto_migrate: true
 
 # Messaging platforms. The gateway-default profile starts the Telegram platform


### PR DESCRIPTION
Hermes wasn't capturing anything to agentmemory. Root cause: `config.yaml` had `plugins.enabled: [agentmemory]` (which *loads* the plugin) but was missing `memory.provider: agentmemory` (which *activates* it as the memory backend). So the provider registered but stayed inactive — `hermes memory` showed `provider: none` and the session-end hooks never fired. Verified: a full agent session ran `ok` but produced zero agentmemory observe/session activity. joryirving's working config sets `memory.provider: agentmemory`; this matches it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)