### PR TITLE
fix(hermes): mount agentmemory provider at $HERMES_HOME/plugins (memory loader path)

### DIFF
--- a/kubernetes/apps/ai/hermes/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/hermes/app/helmrelease.yaml
@@ -400,15 +400,18 @@ spec:
               - path: /run/config/config.yaml
                 subPath: config.yaml
                 readOnly: true
-      # agentmemory plugin code, loaded by the agent from /opt/hermes/plugins
-      # (app container only). Enabled via `plugins.enabled` in config.yaml.
+      # agentmemory memory-provider plugin. The memory loader scans the
+      # user-installed dir $HERMES_HOME/plugins/<name> (= /opt/data/plugins/agentmemory,
+      # HERMES_HOME=/opt/data) alongside the bundled /opt/hermes/plugins/memory/.
+      # Mounting at the general /opt/hermes/plugins/ does NOT register it as a memory
+      # provider. Activated by `memory.provider: agentmemory` in config.yaml.
       plugin-agentmemory:
         type: configMap
         name: hermes-agentmemory-plugin
         advancedMounts:
           hermes:
             app:
-              - path: /opt/hermes/plugins/agentmemory
+              - path: /opt/data/plugins/agentmemory
                 readOnly: true
       # Skill sources, mounted into the seed-skills init which copies them onto
       # the PVC at /opt/data/skills (see initContainers above).

--- a/kubernetes/apps/ai/hermes/app/resources/config.yaml
+++ b/kubernetes/apps/ai/hermes/app/resources/config.yaml
@@ -48,17 +48,14 @@ auxiliary:
 web:
   search_backend: searxng
 
-# Persistent cross-session memory via the agentmemory service (ns ai). The plugin
-# code is mounted at /opt/hermes/plugins/agentmemory (see helmrelease.yaml); the
-# AGENTMEMORY_URL / AGENTMEMORY_SECRET env wire it to the service.
-plugins:
-  enabled:
-    - agentmemory
-
+# Persistent cross-session memory via the agentmemory service (ns ai). The memory-
+# provider plugin is mounted at $HERMES_HOME/plugins/agentmemory (=/opt/data/plugins/
+# agentmemory, see helmrelease.yaml) — the user-installed dir the memory loader scans;
+# AGENTMEMORY_URL / AGENTMEMORY_SECRET env wire it to the service. `memory.provider`
+# below ACTIVATES it (without it Hermes shows `provider: none` and captures nothing).
+# NOTE: this is the memory-provider system, NOT the general `plugins.enabled` hook
+# system — don't add agentmemory there.
 memory:
-  # `plugins.enabled` only LOADS the plugin (registers the provider); this line
-  # ACTIVATES agentmemory as the active memory backend so its session hooks fire.
-  # Without it Hermes shows `memory: provider (none)` and captures nothing.
   provider: agentmemory
   auto_migrate: true
 


### PR DESCRIPTION
Follow-up to #964. `memory.provider: agentmemory` was set, but `hermes memory status` reported **Plugin: NOT installed**. The memory-provider loader (`/opt/hermes/plugins/memory/__init__.py`) scans only: bundled `/opt/hermes/plugins/memory/<name>` (mem0, byterover, …) and user-installed `$HERMES_HOME/plugins/<name>` (= `/opt/data/plugins/agentmemory`). We'd mounted the plugin at the **general** `/opt/hermes/plugins/agentmemory`, which the memory loader ignores.

Fix: move the mount to `/opt/data/plugins/agentmemory` (matches joryirving) and drop `plugins.enabled: [agentmemory]` (that's the separate hook-plugin system, not used for memory providers). Our plugin already implements the same `MemoryProvider` interface as the bundled mem0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)