### PR TITLE
feat(ai): deploy vLLM on the Arc Pro B70 (Qwen3.6-35B-A3B + Qwen3-VL-Embedding-2B)

### DIFF
--- a/kubernetes/apps/ai/agentgateway/app/backends/kustomization.yaml
+++ b/kubernetes/apps/ai/agentgateway/app/backends/kustomization.yaml
@@ -16,4 +16,5 @@ resources:
   - ./perplexity.yaml
   - ./opencodeai.yaml
   - ./opencodego.yaml
+  - ./vllm.yaml
   - ./zai.yaml

--- a/kubernetes/apps/ai/agentgateway/app/backends/vllm.yaml
+++ b/kubernetes/apps/ai/agentgateway/app/backends/vllm.yaml
@@ -1,0 +1,78 @@
+---
+# Local vLLM on the Arc Pro B70 (talos-3) — llm-scaler, OpenAI-compatible.
+# In-cluster service: no TLS, no auth secret.
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayBackend
+metadata:
+  name: vllm
+spec:
+  ai:
+    provider:
+      openai: {}
+      host: vllm-app.ai.svc.cluster.local
+      port: 8000
+
+  policies:
+    ai:
+      routes:
+        "/v1/chat/completions": Completions
+        "/v1/embeddings": Passthrough
+        "/v1/models": Passthrough
+        "*": Passthrough
+---
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayBackend
+metadata:
+  name: vllm-embed
+spec:
+  ai:
+    provider:
+      openai: {}
+      host: vllm-embed.ai.svc.cluster.local
+      port: 8000
+
+  policies:
+    ai:
+      routes:
+        "/v1/embeddings": Passthrough
+        "/v1/models": Passthrough
+        "*": Passthrough
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: vllm
+spec:
+  parentRefs:
+    - name: internal
+    - name: internal-noauth
+    - name: public
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /vllm-embed
+      filters:
+        - type: URLRewrite
+          urlRewrite:
+            path:
+              type: ReplacePrefixMatch
+              replacePrefixMatch: /
+      backendRefs:
+        - name: vllm-embed
+          group: agentgateway.dev
+          kind: AgentgatewayBackend
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /vllm
+      filters:
+        - type: URLRewrite
+          urlRewrite:
+            path:
+              type: ReplacePrefixMatch
+              replacePrefixMatch: /
+      backendRefs:
+        - name: vllm
+          group: agentgateway.dev
+          kind: AgentgatewayBackend

--- a/kubernetes/apps/ai/kustomization.yaml
+++ b/kubernetes/apps/ai/kustomization.yaml
@@ -24,3 +24,4 @@ resources:
   # - ./open-webui/ks.yaml
   - ./qdrant/ks.yaml
   - ./searxng/ks.yaml
+  - ./vllm/ks.yaml

--- a/kubernetes/apps/ai/vllm/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/vllm/app/helmrelease.yaml
@@ -1,0 +1,156 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: vllm
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  maxHistory: 2
+  install:
+    createNamespace: true
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  uninstall:
+    keepHistory: false
+  values:
+    controllers:
+      vllm:
+        strategy: Recreate
+        pod:
+          terminationGracePeriodSeconds: 60
+        containers:
+          app:
+            image: &image
+              repository: docker.io/intel/llm-scaler-vllm
+              tag: 0.14.0-b8.3.1
+            command:
+              - vllm
+              - serve
+              - palmfuture/Qwen3.6-35B-A3B-GPTQ-Int4
+              - --served-model-name=qwen3.6-35b-a3b
+              - --host=0.0.0.0
+              - --port=8000
+              - --dtype=float16
+              - --gpu-memory-utilization=0.72
+              - --max-model-len=32768
+            env: &env
+              HF_HOME: /models
+              VLLM_ALLOW_LONG_MAX_MODEL_LEN: "1"
+              VLLM_WORKER_MULTIPROC_METHOD: spawn
+              ZES_ENABLE_SYSMAN: "1"
+            resources:
+              requests:
+                cpu: "2"
+                memory: 16Gi
+                gpu.intel.com/xe: 1
+              limits:
+                memory: 48Gi
+                gpu.intel.com/xe: 1
+            probes:
+              # First boot downloads ~20GB of weights + JIT compile; allow 30 min
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: 8000
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 60
+              readiness: &probe
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: 8000
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+              liveness: *probe
+
+      vllm-embed:
+        strategy: Recreate
+        containers:
+          app:
+            image: *image
+            command:
+              - vllm
+              - serve
+              - Qwen/Qwen3-VL-Embedding-2B
+              - --task=embed
+              - --served-model-name=qwen3-vl-embedding-2b
+              - --host=0.0.0.0
+              - --port=8000
+              - --dtype=float16
+              - --gpu-memory-utilization=0.15
+            env: *env
+            resources:
+              requests:
+                cpu: "1"
+                memory: 4Gi
+                gpu.intel.com/xe: 1
+              limits:
+                memory: 16Gi
+                gpu.intel.com/xe: 1
+            probes:
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: 8000
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 20
+              readiness: *probe
+              liveness: *probe
+
+    service:
+      app:
+        controller: vllm
+        ports:
+          http:
+            port: 8000
+      embed:
+        controller: vllm-embed
+        ports:
+          http:
+            port: 8000
+
+    persistence:
+      models:
+        type: persistentVolumeClaim
+        accessMode: ReadWriteOnce
+        storageClass: ceph-block
+        size: 50Gi
+        advancedMounts:
+          vllm:
+            app:
+              - path: /models
+      embed-models:
+        type: persistentVolumeClaim
+        accessMode: ReadWriteOnce
+        storageClass: ceph-block
+        size: 20Gi
+        advancedMounts:
+          vllm-embed:
+            app:
+              - path: /models
+      shm:
+        type: emptyDir
+        medium: Memory
+        sizeLimit: 16Gi
+        advancedMounts:
+          vllm:
+            app:
+              - path: /dev/shm

--- a/kubernetes/apps/ai/vllm/app/kustomization.yaml
+++ b/kubernetes/apps/ai/vllm/app/kustomization.yaml
@@ -1,0 +1,31 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: ai
+patches:
+- patch: |-
+    apiVersion: helm.toolkit.fluxcd.io/v2
+    kind: HelmRelease
+    metadata:
+      name: _
+    spec:
+      install:
+        crds: CreateReplace
+        strategy:
+          name: RetryOnFailure
+      rollback:
+        cleanupOnFail: true
+        recreate: true
+      upgrade:
+        cleanupOnFail: true
+        crds: CreateReplace
+        strategy:
+          name: RemediateOnFailure
+        remediation:
+          remediateLastFailure: true
+          retries: 2
+  target:
+    group: helm.toolkit.fluxcd.io
+    kind: HelmRelease
+resources:
+- ./helmrelease.yaml
+- ./servicemonitor.yaml

--- a/kubernetes/apps/ai/vllm/app/servicemonitor.yaml
+++ b/kubernetes/apps/ai/vllm/app/servicemonitor.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/monitoring.coreos.com/servicemonitor_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: vllm
+spec:
+  endpoints:
+    - port: http
+      path: /metrics
+      interval: 30s
+      scrapeTimeout: 10s
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: vllm
+  namespaceSelector:
+    matchNames:
+      - ai

--- a/kubernetes/apps/ai/vllm/ks.yaml
+++ b/kubernetes/apps/ai/vllm/ks.yaml
@@ -1,0 +1,31 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app vllm
+  namespace: &namespace ai
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: rook-ceph
+      namespace: rook-ceph
+  interval: 1h
+  path: "./kubernetes/apps/ai/vllm/app"
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 5m
+  wait: false
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+    substitute:
+      APP: *app
+      GATUS_GROUP: ai


### PR DESCRIPTION
## Phase 5: local LLM serving on the B70

Deploys Intel **llm-scaler vLLM** (`0.14.0-b8.3.1`) on the Arc Pro B70 (talos-3, 32GB, xe driver), exposed through agentgateway.

### Workloads (new app `ai/vllm`)
| Controller | Model | Quant | gpu-mem-util | ~VRAM |
|---|---|---|---|---|
| `vllm` | `palmfuture/Qwen3.6-35B-A3B-GPTQ-Int4` (served as `qwen3.6-35b-a3b`) | GPTQ-Int4 (~20GB) | 0.72 | ~23GB |
| `vllm-embed` | `Qwen/Qwen3-VL-Embedding-2B` (`--task embed`) | fp16 | 0.15 | ~5GB |

Both pods pin to talos-3 via `gpu.intel.com/xe: 1` (shared device plugin, no nodeSelector). PVCs: `vllm-models` 50Gi / `vllm-embed-models` 20Gi (HF cache). 16Gi `/dev/shm` for the 35B. Startup probe allows 30 min for first-boot model download + JIT.

### Gateway wiring
- `AgentgatewayBackend` `vllm` → `vllm-app.ai.svc:8000`, `vllm-embed` → `vllm-embed.ai.svc:8000` (in-cluster, no TLS/auth)
- `HTTPRoute /vllm` and `/vllm-embed` on internal, internal-noauth, public gateways
- ServiceMonitor for native vLLM Prometheus metrics

### Notes
- Official FP8 (~35GB) does not fit a single 32GB card; GPTQ-Int4 community checkpoint chosen. Fallback: official BF16 + online `sym_int4` (needs ~100Gi PVC).
- agentmemory stays on Ollama embeddings for now (dim change needs re-index) — follow-up.
- Validated via `helm template` against app-template 5.0.1 + kustomize builds (flux-local has a Windows tempfile bug locally; CI will run it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)