### PR TITLE
fix(ai): vllm 0.14 arg changes for ipex quant and embed task

### DIFF
--- a/kubernetes/apps/ai/vllm/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/vllm/app/helmrelease.yaml
@@ -40,6 +40,8 @@ spec:
               - --dtype=float16
               - --gpu-memory-utilization=0.72
               - --max-model-len=32768
+              # Intel fork maps GPTQ to its 'ipex' method, deprecated upstream
+              - --allow-deprecated-quantization
             env: &env
               HF_HOME: /models
               VLLM_ALLOW_LONG_MAX_MODEL_LEN: "1"
@@ -86,7 +88,8 @@ spec:
               - vllm
               - serve
               - Qwen/Qwen3-VL-Embedding-2B
-              - --task=embed
+              # --task was removed in vLLM 0.14; --convert embed is the replacement
+              - --convert=embed
               - --served-model-name=qwen3-vl-embedding-2b
               - --host=0.0.0.0
               - --port=8000


### PR DESCRIPTION
Fixes the CrashLoopBackOff from PR #967: vLLM 0.14.1 in llm-scaler rejects the ipex quant method without --allow-deprecated-quantization, and removed --task (replaced by --convert embed). Flags verified against EngineArgs in the running image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)