### PR TITLE
feat(comfyui): add ComfyUI + miso-gallery on shared Intel Arc B70

### DIFF
--- a/kubernetes/apps/ai/comfyui/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/comfyui/app/helmrelease.yaml
@@ -1,0 +1,165 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app comfyui
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  maxHistory: 2
+  install:
+    createNamespace: true
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  uninstall:
+    keepHistory: false
+  values:
+    controllers:
+      comfyui:
+        # Single GPU + RWO model/input PVCs -> never run two pods at once.
+        strategy: Recreate
+        pod:
+          terminationGracePeriodSeconds: 60
+        containers:
+          app:
+            image:
+              repository: intel/llm-scaler-omni
+              tag: 0.1.0-b7
+            # The llm-scaler-omni entrypoint is NOT ComfyUI. Override it: ComfyUI
+            # lives at /llm/ComfyUI and serves on 8188. Runs with full VRAM
+            # (Dedicated mode) — when a large model needs the whole 32GB B70,
+            # scale the vllm HelmRelease down first:
+            #   flux -n ai suspend hr vllm
+            #   kubectl -n ai scale deploy vllm vllm-embed --replicas=0
+            #   ... generate ... then: flux -n ai resume hr vllm
+            command: ["/bin/bash", "-c"]
+            args:
+              - |
+                cd /llm/ComfyUI && exec python3 main.py --listen 0.0.0.0 --port 8188
+            env:
+              ONEAPI_DEVICE_SELECTOR: level_zero:0
+              ZES_ENABLE_SYSMAN: "1"
+            resources:
+              requests:
+                cpu: "1"
+                memory: 8Gi
+                gpu.intel.com/xe: 1
+              limits:
+                memory: 32Gi
+                gpu.intel.com/xe: 1
+            probes:
+              # No model loads until a workflow runs; startup is just process boot.
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  tcpSocket:
+                    port: &port 8188
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 60
+              readiness: &probe
+                enabled: true
+                custom: true
+                spec:
+                  tcpSocket:
+                    port: *port
+                  periodSeconds: 15
+                  timeoutSeconds: 5
+                  failureThreshold: 4
+              liveness: *probe
+            securityContext:
+              # Image runs as root and the device plugin injects /dev/dri without
+              # privileged (vllm proves this). Do NOT add runAsNonRoot here.
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: false
+              capabilities: { drop: ["ALL"] }
+    service:
+      app:
+        ports:
+          http:
+            port: *port
+    route:
+      app:
+        annotations:
+          gethomepage.dev/enabled: "true"
+          gethomepage.dev/group: LLM/Ai
+          gethomepage.dev/name: ComfyUI
+          gethomepage.dev/description: Intel Arc image generation (ComfyUI)
+          gatus.home-operations.com/endpoint: |-
+            url: https://comfyui.${SECRET_DOMAIN}/
+            conditions:
+              - "[STATUS] == 200"
+            group: ai
+        hostnames:
+          - "{{ .Release.Name }}.${SECRET_DOMAIN}"
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+            sectionName: https
+    persistence:
+      # Big, re-downloadable checkpoints/loras/vae. Starts empty — download models
+      # via the ComfyUI UI/Manager or kubectl cp after first boot.
+      models:
+        type: persistentVolumeClaim
+        accessMode: ReadWriteOnce
+        storageClass: ceph-block
+        size: 100Gi
+        advancedMounts:
+          comfyui:
+            app:
+              - path: /llm/ComfyUI/models
+      # Shared RWX output so miso-gallery (possibly another node) can read it.
+      output:
+        existingClaim: comfyui-output
+        advancedMounts:
+          comfyui:
+            app:
+              - path: /llm/ComfyUI/output
+      input:
+        type: persistentVolumeClaim
+        accessMode: ReadWriteOnce
+        storageClass: ceph-block
+        size: 5Gi
+        advancedMounts:
+          comfyui:
+            app:
+              - path: /llm/ComfyUI/input
+      # Persist installed custom nodes across restarts. NOTE: if the image ships
+      # default nodes (e.g. ComfyUI-Manager) this empty PVC shadows them on first
+      # boot — verify with `ls /llm/ComfyUI/custom_nodes` and seed if needed.
+      custom-nodes:
+        type: persistentVolumeClaim
+        accessMode: ReadWriteOnce
+        storageClass: ceph-block
+        size: 10Gi
+        advancedMounts:
+          comfyui:
+            app:
+              - path: /llm/ComfyUI/custom_nodes
+      user:
+        type: persistentVolumeClaim
+        accessMode: ReadWriteOnce
+        storageClass: ceph-block
+        size: 2Gi
+        advancedMounts:
+          comfyui:
+            app:
+              - path: /llm/ComfyUI/user
+      # ComfyUI/PyTorch shared memory (replaces docker --shm-size). Counts against
+      # the pod memory limit, so the 32Gi limit accounts for it.
+      dshm:
+        type: emptyDir
+        medium: Memory
+        sizeLimit: 16Gi
+        advancedMounts:
+          comfyui:
+            app:
+              - path: /dev/shm

--- a/kubernetes/apps/ai/comfyui/app/kustomization.yaml
+++ b/kubernetes/apps/ai/comfyui/app/kustomization.yaml
@@ -1,0 +1,31 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: ai
+patches:
+  - patch: |-
+      apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      metadata:
+        name: _
+      spec:
+        install:
+          crds: CreateReplace
+          strategy:
+            name: RetryOnFailure
+        rollback:
+          cleanupOnFail: true
+          recreate: true
+        upgrade:
+          cleanupOnFail: true
+          crds: CreateReplace
+          strategy:
+            name: RemediateOnFailure
+          remediation:
+            remediateLastFailure: true
+            retries: 2
+    target:
+      group: helm.toolkit.fluxcd.io
+      kind: HelmRelease
+resources:
+  - ./pvc.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/ai/comfyui/app/pvc.yaml
+++ b/kubernetes/apps/ai/comfyui/app/pvc.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: comfyui-output
+spec:
+  # RWX so ComfyUI (writer) and miso-gallery (reader, possibly another node) can
+  # both mount it.
+  accessModes: ["ReadWriteMany"]
+  resources:
+    requests:
+      storage: 25Gi
+  storageClassName: ceph-filesystem

--- a/kubernetes/apps/ai/comfyui/ks.yaml
+++ b/kubernetes/apps/ai/comfyui/ks.yaml
@@ -1,0 +1,28 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app comfyui
+  namespace: &namespace ai
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  interval: 1h
+  path: "./kubernetes/apps/ai/comfyui/app"
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+    substitute:
+      APP: *app
+  # Large image pull (intel/llm-scaler-omni) + GPU schedule on first boot.
+  timeout: 15m
+  wait: true

--- a/kubernetes/apps/ai/kustomization.yaml
+++ b/kubernetes/apps/ai/kustomization.yaml
@@ -12,8 +12,10 @@ resources:
   - ./agentgateway/ks.yaml
   - ./agentgateway-dashboards/ks.yaml
   - ./agentmemory/ks.yaml
+  - ./comfyui/ks.yaml
   - ./hermes/ks.yaml
   - ./kokoro/ks.yaml
+  - ./miso-gallery/ks.yaml
   - ./perplexica/ks.yaml
   # Temporarily removed (2026-06-07) - workloads/PVCs pruned, but manifests,
   # postgres open-webui DB, surrealdb open_notebook ns, 1P items and volsync

--- a/kubernetes/apps/ai/miso-gallery/app/externalsecret.yaml
+++ b/kubernetes/apps/ai/miso-gallery/app/externalsecret.yaml
@@ -1,0 +1,20 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name miso-gallery
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: *name
+    template:
+      data:
+        SECRET_KEY: "{{ .SECRET_KEY }}"
+        ADMIN_PASSWORD: "{{ .ADMIN_PASSWORD }}"
+  dataFrom:
+    - extract:
+        key: miso-gallery

--- a/kubernetes/apps/ai/miso-gallery/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/miso-gallery/app/helmrelease.yaml
@@ -1,0 +1,108 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app miso-gallery
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  maxHistory: 2
+  install:
+    createNamespace: true
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  uninstall:
+    keepHistory: false
+  values:
+    controllers:
+      miso-gallery:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: ghcr.io/misospace/miso-gallery
+              tag: 0.1.16
+            env:
+              DATA_FOLDER: /data
+              IMAGE_BASE_URL: "https://miso-gallery.${SECRET_DOMAIN}"
+              AUTH_TYPE: local
+            envFrom:
+              - secretRef:
+                  name: *app
+            probes:
+              liveness: &probe
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /
+                    port: &port 5000
+                  initialDelaySeconds: 10
+                  periodSeconds: 15
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+              readiness: *probe
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /
+                    port: *port
+                  periodSeconds: 10
+                  failureThreshold: 30
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: false
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 25m
+                memory: 256Mi
+              limits:
+                memory: 1Gi
+    defaultPodOptions:
+      securityContext:
+        # Non-root; fsGroup lets it read the ceph-filesystem output volume.
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 100
+        fsGroupChangePolicy: OnRootMismatch
+    service:
+      app:
+        ports:
+          http:
+            port: *port
+    route:
+      app:
+        annotations:
+          gethomepage.dev/enabled: "true"
+          gethomepage.dev/group: LLM/Ai
+          gethomepage.dev/name: Miso Gallery
+          gethomepage.dev/description: Web gallery for ComfyUI outputs
+          gatus.home-operations.com/endpoint: |-
+            url: https://miso-gallery.${SECRET_DOMAIN}/
+            conditions:
+              - "[STATUS] == 200"
+            group: ai
+        hostnames:
+          - "{{ .Release.Name }}.${SECRET_DOMAIN}"
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+            sectionName: https
+    persistence:
+      # Shared ComfyUI output, read-only (gallery only reads).
+      data:
+        existingClaim: comfyui-output
+        globalMounts:
+          - path: /data
+            readOnly: true

--- a/kubernetes/apps/ai/miso-gallery/app/kustomization.yaml
+++ b/kubernetes/apps/ai/miso-gallery/app/kustomization.yaml
@@ -1,0 +1,31 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: ai
+patches:
+  - patch: |-
+      apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      metadata:
+        name: _
+      spec:
+        install:
+          crds: CreateReplace
+          strategy:
+            name: RetryOnFailure
+        rollback:
+          cleanupOnFail: true
+          recreate: true
+        upgrade:
+          cleanupOnFail: true
+          crds: CreateReplace
+          strategy:
+            name: RemediateOnFailure
+          remediation:
+            remediateLastFailure: true
+            retries: 2
+    target:
+      group: helm.toolkit.fluxcd.io
+      kind: HelmRelease
+resources:
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/ai/miso-gallery/ks.yaml
+++ b/kubernetes/apps/ai/miso-gallery/ks.yaml
@@ -1,0 +1,32 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app miso-gallery
+  namespace: &namespace ai
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    # comfyui owns the comfyui-output PVC this app mounts read-only.
+    - name: comfyui
+    - name: onepassword-store
+      namespace: security
+  interval: 1h
+  path: "./kubernetes/apps/ai/miso-gallery/app"
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+    substitute:
+      APP: *app
+  timeout: 5m
+  wait: true


### PR DESCRIPTION
## What

Adds **ComfyUI** (AI image generation) and **miso-gallery** (output viewer) to the `ai` namespace, modeled on the [joryirving/home-ops comfyui app](https://github.com/joryirving/home-ops/tree/main/kubernetes/apps/base/llm/comfyui) but adapted from **AMD ROCm → Intel Arc B70** (Battlemage, `xe` driver).

## Why the reference isn't a straight copy

The reference targets an AMD GPU (`yanwk/comfyui-boot:rocm7`, `/dev/kfd`, `HIP_*`, `privileged`). Our card is the Intel Arc B70, so this uses the vendor-correct image **`intel/llm-scaler-omni:0.1.0-b7`** — the same `intel/llm-scaler` family already powering vLLM — with ComfyUI at `/llm/ComfyUI:8188`.

## Key decisions

| | |
| --- | --- |
| GPU | `gpu.intel.com/xe: 1` via the existing device plugin (`sharedDevNum: 99`); **no privileged/hostPath** |
| VRAM | Dedicated — full card; scale-down-LLM runbook baked into the HelmRelease comment |
| Output sharing | RWX `ceph-filesystem` PVC `comfyui-output` (ComfyUI writes, gallery reads read-only) |
| Gallery exposure | Internal only (`envoy-internal`) |
| Gallery auth | Local password (`AUTH_TYPE: local`) |

## Manual prerequisites before Flux deploys

1. **1Password item `miso-gallery`** with fields `SECRET_KEY` (random) + `ADMIN_PASSWORD`.
2. Download checkpoints into the `models` PVC after first boot (starts empty).

## Verify on first deploy

- **Empty `models`/`custom_nodes` PVCs shadow any image-baked content** — check `ls /llm/ComfyUI/custom_nodes` and seed via initContainer if it ships ComfyUI-Manager.
- ComfyUI XPU detected; pod lands on talos-3; gallery reads `/data` after first generation.

## Validation

`kustomize build` ✓ (both apps), namespace picks up both Kustomizations ✓, `kubeconform` ✓ (PVC valid; CRDs skipped). `flux-local` couldn't run locally due to a Windows temp-file bug in the tool itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)