### PR TITLE
fix(comfyui): use ceph-block RWO output (CephFS RWX broken post-Tentacle)

### DIFF
--- a/kubernetes/apps/ai/comfyui/app/pvc.yaml
+++ b/kubernetes/apps/ai/comfyui/app/pvc.yaml
@@ -4,10 +4,14 @@ kind: PersistentVolumeClaim
 metadata:
   name: comfyui-output
 spec:
-  # RWX so ComfyUI (writer) and miso-gallery (reader, possibly another node) can
-  # both mount it.
-  accessModes: ["ReadWriteMany"]
+  # RWO ceph-block instead of CephFS RWX: CephFS subvolume provisioning is broken
+  # cluster-wide after the Ceph v20.2.1 (Tentacle) upgrade mis-marked the `csi`
+  # subvolumegroup (ceph.dir.subvolume=1). ComfyUI (writer) and miso-gallery
+  # (reader) share this RWO volume by co-scheduling both pods onto talos-3
+  # (ComfyUI is GPU-pinned there; miso-gallery has a matching nodeSelector).
+  # Revert to ceph-filesystem RWX once CephFS provisioning is repaired.
+  accessModes: ["ReadWriteOnce"]
   resources:
     requests:
       storage: 25Gi
-  storageClassName: ceph-filesystem
+  storageClassName: ceph-block

--- a/kubernetes/apps/ai/miso-gallery/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/miso-gallery/app/helmrelease.yaml
@@ -70,8 +70,12 @@ spec:
               limits:
                 memory: 1Gi
     defaultPodOptions:
+      # The shared comfyui-output PVC is RWO ceph-block, so this pod must run on
+      # the same node as ComfyUI (talos-3, where ComfyUI's GPU pins it).
+      nodeSelector:
+        kubernetes.io/hostname: talos-3
       securityContext:
-        # Non-root; fsGroup lets it read the ceph-filesystem output volume.
+        # Non-root; fsGroup lets it read the shared output volume.
         runAsUser: 1000
         runAsGroup: 1000
         fsGroup: 100


### PR DESCRIPTION
## Why

ComfyUI is stuck at **503**: its `comfyui-output` PVC (ceph-filesystem RWX) is `Pending`, so the pod can't schedule.

**Root cause (cluster-wide, not ComfyUI-specific):** the Ceph **v20.2.1 (Tentacle)** upgrade's subvolumegroup migration mis-marked `/volumes/csi` with `ceph.dir.subvolume=1`. That makes the MDS reject every new CephFS subvolume:
```
rados: ret=-22, Invalid argument: "invalid value specified for ceph.dir.subvolume"
```
The documented `setfattr ceph.dir.subvolume=0` repair is blocked on Tentacle (the MDS only lets the mgr write that vxattr; even `mds allow *` clients get EACCES, and Talos has no `ceph.ko` for a kernel mount). That's tracked as a separate storage-maintenance/upstream item.

## What

Unblock ComfyUI independently of the CephFS bug:
- `comfyui-output`: **ceph-filesystem RWX → ceph-block RWO** (ceph-block provisioning is confirmed healthy).
- **miso-gallery pinned to `talos-3`** (nodeSelector) so it shares the RWO volume on the same node where ComfyUI is GPU-pinned. It still mounts `/data` read-only.

Both changes carry a comment to **revert to ceph-filesystem RWX once CephFS provisioning is repaired**.

## Follow-up

The CephFS RWX corruption still blocks all *new* RWX PVCs cluster-wide (existing ones are fine). Needs a Ceph point release / upstream-supported procedure or an off-host `setfattr` from a real kernel mount.

🤖 Generated with [Claude Code](https://claude.com/claude-code)