### PR TITLE
fix(comfyui): raise helm timeout to 20m for multi-GB image pull

### DIFF
--- a/kubernetes/apps/ai/comfyui/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/comfyui/app/helmrelease.yaml
@@ -6,6 +6,9 @@ metadata:
   name: &app comfyui
 spec:
   interval: 1h
+  # intel/llm-scaler-omni is a multi-GB image; the default 5m helm timeout fires
+  # mid-pull and rolls back, killing the pull in a loop. Allow time for the pull.
+  timeout: 20m
   chartRef:
     kind: OCIRepository
     name: app-template

--- a/kubernetes/apps/ai/comfyui/ks.yaml
+++ b/kubernetes/apps/ai/comfyui/ks.yaml
@@ -23,6 +23,7 @@ spec:
         kind: Secret
     substitute:
       APP: *app
-  # Large image pull (intel/llm-scaler-omni) + GPU schedule on first boot.
-  timeout: 15m
+  # Large image pull (intel/llm-scaler-omni, multi-GB) + GPU schedule on first
+  # boot; must exceed the HelmRelease timeout (20m).
+  timeout: 30m
   wait: true


### PR DESCRIPTION
## Why

ComfyUI scheduled fine onto talos-3 (PVC now `ceph-block` RWO from #975), but the **`intel/llm-scaler-omni:0.1.0-b7` image is multi-GB** and the pull exceeds the HelmRelease's default **5m** timeout:

```
Helm upgrade failed: timeout waiting for: [Deployment/ai/comfyui status: 'InProgress']
```

helm then rolls back and **deletes the deployment**, killing the pod mid-pull — an infinite loop where the image never finishes.

## What

- `comfyui` HelmRelease: `spec.timeout: 20m`
- `comfyui` ks: `timeout: 15m → 30m` (must exceed the HR timeout)

Pulled layers are cached on talos-3 now, so the next attempt should complete well within 20m.

🤖 Generated with [Claude Code](https://claude.com/claude-code)