### PR TITLE
fix(talos): set kubelet imageGC thresholds (70/55) to reclaim image cruft

### DIFF
--- a/talos/machineconfig.yaml.j2
+++ b/talos/machineconfig.yaml.j2
@@ -69,6 +69,12 @@ machine:
     extraConfig:
       serializeImagePulls: false
       maxPods: 250
+      # Reclaim accumulated container-image layers. The kubelet prunes unused
+      # images when the imagefs (/var) hits 70% full, down to 55%. Default is
+      # 85/80, which let ~600G of old image versions pile up on this
+      # image-churn-heavy cluster (Renovate bumps + redeploys).
+      imageGCHighThresholdPercent: 70
+      imageGCLowThresholdPercent: 55
       featureGates:
         ImageVolume: true
     nodeIP:


### PR DESCRIPTION
Lowers kubelet `imageGCHighThresholdPercent` to 70 / low to 55 so unused container images are pruned automatically (default 85/80 let ~600G of old image layers pile up per node). No-reboot change; applied manually via `just talos apply-node`. 🤖