### PR TITLE
fix(sabnzbd): move incomplete dir to ceph-block RWO

### DIFF
--- a/kubernetes/apps/downloads/pvc/app/kustomization.yaml
+++ b/kubernetes/apps/downloads/pvc/app/kustomization.yaml
@@ -4,3 +4,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./shared-downloads.yaml
+  - ./sabnzbd-incomplete.yaml

--- a/kubernetes/apps/downloads/pvc/app/sabnzbd-incomplete.yaml
+++ b/kubernetes/apps/downloads/pvc/app/sabnzbd-incomplete.yaml
@@ -1,0 +1,20 @@
+---
+# SABnzbd article-assembly scratch (the "incomplete"/download_dir). Lives on
+# `ceph-block` (RWO, block) NOT CephFS RWX on purpose: during assembly SABnzbd
+# writes thousands of tiny `SABnzbd_article_*` files, which storm the CephFS MDS
+# metadata journal and can stall the entire filesystem (2026-06-14 incident).
+# Block keeps that tiny-file churn inside the RBD ext4/xfs — Ceph only ever sees
+# 4MB RBD objects, never MDS metadata ops. The finished media is moved to
+# `complete` on `shared-downloads` (CephFS RWX) so the *arr hardlink/atomic-import
+# flow is unchanged. Disposable scratch → no volsync backup.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: sabnzbd-incomplete
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 500Gi
+  storageClassName: ceph-block

--- a/kubernetes/apps/downloads/sabnzbd/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/sabnzbd/app/helmrelease.yaml
@@ -19,6 +19,11 @@ spec:
         annotations:
           reloader.stakater.com/auto: "true"
 
+        # Single replica with RWO PVCs (config + incomplete). Recreate avoids a
+        # RollingUpdate Multi-Attach deadlock where the new pod can't attach the
+        # RWO volume while the old pod still holds it.
+        strategy: Recreate
+
         pod:
           securityContext:
             runAsUser: 2000
@@ -151,6 +156,21 @@ spec:
               - path: /data/downloads
             app:
               - path: /data/downloads
+
+      # Article-assembly scratch (download_dir) on ceph-block (RWO, block) instead
+      # of CephFS RWX, to keep the thousands of tiny SABnzbd_article_* files off the
+      # MDS metadata journal (2026-06-14 storm stalled the whole filesystem). Mounts
+      # over the usenet/incomplete subpath of the shared-downloads CephFS mount;
+      # `complete` stays on shared-downloads (CephFS RWX) for *arr hardlinks. Path
+      # matches download_dir in sabnzbd.ini so no SABnzbd setting change is needed.
+      incomplete:
+        existingClaim: sabnzbd-incomplete
+        advancedMounts:
+          sabnzbd:
+            init-dirs:
+              - path: /data/downloads/usenet/incomplete
+            app:
+              - path: /data/downloads/usenet/incomplete
 
       temp:
         type: emptyDir


### PR DESCRIPTION
## Why

On **2026-06-14** the Ceph cluster suffered a ~70-minute CephFS stall (HEALTH_WARN → cluster-wide slow ops, 800+ MDS requests blocked at `journal_and_reply`). Root cause: **SABnzbd's `incomplete` dir was on the `shared-downloads` CephFS RWX volume** (migrated there in #977). During article assembly SABnzbd writes **thousands of tiny `SABnzbd_article_*` files**, which storm the MDS metadata journal and wedge the metadata-pool OSDs.

## What

Move only the **incomplete / article-assembly scratch** to a dedicated `ceph-block` (RWO) PVC. Block storage keeps the tiny-file inode churn inside the RBD ext4/xfs — Ceph only ever sees 4 MB RBD objects, never MDS metadata ops. `complete` stays on `shared-downloads` (CephFS RWX) so the *arr hardlink / atomic-import flow is unchanged.

- **New** `sabnzbd-incomplete` PVC — `ceph-block`, RWO, **500Gi** (thin-provisioned; disposable scratch, no volsync backup).
- Mounted at `/data/downloads/usenet/incomplete`, which matches `download_dir` in `sabnzbd.ini` → **no SABnzbd setting change needed**.
- `strategy: Recreate` added so the RWO incomplete (+ RWO config) mounts don't deadlock on a RollingUpdate Multi-Attach.

## Deploy notes

- SABnzbd is currently **scaled to 0** (manual, to stop the flood). On merge, Flux creates the PVC and the HR reconcile restores it to 1 replica **with incomplete already on block**, so it returns without re-flooding.
- Old `usenet/incomplete` data on the CephFS vol gets shadowed by the new mount (the flood + 1 abandoned download) — safe to delete later.
- Unrelated follow-up still open: OSD device-path drift on talos-2/3 (don't reboot/restart OSDs until hardened).

🤖 Generated with [Claude Code](https://claude.com/claude-code)