### PR TITLE
feat(ai): add toolhive MCP operator + servers, wire into hermes

### DIFF
--- a/kubernetes/apps/ai/hermes/app/resources/config.yaml
+++ b/kubernetes/apps/ai/hermes/app/resources/config.yaml
@@ -57,6 +57,18 @@ auxiliary:
 web:
   search_backend: searxng
 
+# Aggregated MCP tools via the ToolHive VirtualMCPServer (ns ai). The vmcp
+# "mcp-gateway-internal" federates every MCPServer in the `mcp-tools` group
+# (arr, comfyui, flux, github, kubectl, memory, talos) behind one streamable-
+# http endpoint at /mcp; incomingAuth is anonymous so no header is needed. Tool
+# names are prefixed per backend ({workload}_). Deployed by
+# kubernetes/apps/ai/toolhive. (joryirving routes this through litellm /mcp;
+# litellm is retired here, so connect straight to the vmcp service.)
+mcp_servers:
+  toolhive:
+    url: http://vmcp-mcp-gateway-internal.ai.svc.cluster.local:4483/mcp
+    enabled: true
+
 # Persistent cross-session memory via the agentmemory service (ns ai). The memory-
 # provider plugin is mounted at $HERMES_HOME/plugins/agentmemory (=/opt/data/plugins/
 # agentmemory, see helmrelease.yaml) — the user-installed dir the memory loader scans;

--- a/kubernetes/apps/ai/kustomization.yaml
+++ b/kubernetes/apps/ai/kustomization.yaml
@@ -25,4 +25,5 @@ resources:
   - ./open-webui/ks.yaml
   - ./qdrant/ks.yaml
   - ./searxng/ks.yaml
+  - ./toolhive/ks.yaml
   - ./vllm/ks.yaml

--- a/kubernetes/apps/ai/toolhive/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/toolhive/app/helmrelease.yaml
@@ -1,0 +1,37 @@
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: toolhive-operator
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.29.3
+  url: oci://ghcr.io/stacklok/toolhive/toolhive-operator
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: toolhive-operator
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: toolhive-operator
+  interval: 30m
+  values:
+    operator:
+      replicaCount: 1
+      resources:
+        requests:
+          cpu: 50m
+          memory: 256Mi
+        limits:
+          cpu: 500m
+          memory: 1Gi
+      gc:
+        gomemlimit: 450MiB
+        gogc: 75

--- a/kubernetes/apps/ai/toolhive/app/kustomization.yaml
+++ b/kubernetes/apps/ai/toolhive/app/kustomization.yaml
@@ -1,0 +1,5 @@
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml

--- a/kubernetes/apps/ai/toolhive/config/dashboard/grafanadashboard.yaml
+++ b/kubernetes/apps/ai/toolhive/config/dashboard/grafanadashboard.yaml
@@ -1,0 +1,11 @@
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/grafana.integreatly.org/grafanadashboard_v1beta1.json
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: toolhive-mcp-gateway
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  url: https://raw.githubusercontent.com/stacklok/toolhive/main/examples/otel/grafana-dashboards/toolhive-mcp-grafana-dashboard-otel-scrape.json

--- a/kubernetes/apps/ai/toolhive/config/dashboard/kustomization.yaml
+++ b/kubernetes/apps/ai/toolhive/config/dashboard/kustomization.yaml
@@ -1,0 +1,5 @@
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./grafanadashboard.yaml

--- a/kubernetes/apps/ai/toolhive/config/embeddingserver.yaml
+++ b/kubernetes/apps/ai/toolhive/config/embeddingserver.yaml
@@ -1,0 +1,11 @@
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/toolhive.stacklok.dev/embeddingserver_v1alpha1.json
+apiVersion: toolhive.stacklok.dev/v1alpha1
+kind: EmbeddingServer
+metadata:
+  name: mcp-tools-embedding
+spec:
+  model: sentence-transformers/all-MiniLM-L6-v2
+  image: ghcr.io/huggingface/text-embeddings-inference:cpu-latest@sha256:492506e6a76ce6d0fd834a49f69bee4134f5b37de06052519d358a3d5387434d
+  env:
+    - name: HOSTNAME
+      value: "::"

--- a/kubernetes/apps/ai/toolhive/config/httproute.yaml
+++ b/kubernetes/apps/ai/toolhive/config/httproute.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/gateway.networking.k8s.io/httproute_v1.json
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: mcp-gateway
+  annotations:
+    external-dns.alpha.kubernetes.io/target: "internal.${SECRET_DOMAIN}"
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/group: AI
+    gethomepage.dev/name: ToolHive MCP
+    gethomepage.dev/description: "Aggregated MCP tool gateway"
+spec:
+  hostnames:
+    - "mcp.${SECRET_DOMAIN}"
+  parentRefs:
+    - name: envoy-internal
+      namespace: network
+      sectionName: https
+  rules:
+    - backendRefs:
+        - name: vmcp-mcp-gateway-internal
+          port: 4483

--- a/kubernetes/apps/ai/toolhive/config/kustomization.yaml
+++ b/kubernetes/apps/ai/toolhive/config/kustomization.yaml
@@ -1,0 +1,11 @@
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./embeddingserver.yaml
+  - ./httproute.yaml
+  - ./mcp-telemetry.yaml
+  - ./mcpgroup.yaml
+  - ./podmonitor.yaml
+  - ./virtualmcpserver.yaml
+  - ./dashboard/

--- a/kubernetes/apps/ai/toolhive/config/mcp-telemetry.yaml
+++ b/kubernetes/apps/ai/toolhive/config/mcp-telemetry.yaml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/toolhive.stacklok.dev/mcptelemetryconfig_v1alpha1.json
+apiVersion: toolhive.stacklok.dev/v1alpha1
+kind: MCPTelemetryConfig
+metadata:
+  name: prometheus
+  namespace: ai
+spec:
+  prometheus:
+    enabled: true

--- a/kubernetes/apps/ai/toolhive/config/mcpgroup.yaml
+++ b/kubernetes/apps/ai/toolhive/config/mcpgroup.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/toolhive.stacklok.dev/mcpgroup_v1alpha1.json
+apiVersion: toolhive.stacklok.dev/v1alpha1
+kind: MCPGroup
+metadata:
+  name: mcp-tools
+spec:
+  description: Optimized MCP tools for AI assistants

--- a/kubernetes/apps/ai/toolhive/config/podmonitor.yaml
+++ b/kubernetes/apps/ai/toolhive/config/podmonitor.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/monitoring.coreos.com/podmonitor_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: mcp-gateway-internal
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: virtualmcpserver
+      app.kubernetes.io/instance: mcp-gateway-internal
+  namespaceSelector:
+    matchNames:
+      - ai
+  podMetricsEndpoints:
+    - port: "8080"
+      path: /metrics
+      interval: 15s

--- a/kubernetes/apps/ai/toolhive/config/virtualmcpserver.yaml
+++ b/kubernetes/apps/ai/toolhive/config/virtualmcpserver.yaml
@@ -1,0 +1,27 @@
+apiVersion: toolhive.stacklok.dev/v1alpha1
+kind: VirtualMCPServer
+metadata:
+  name: mcp-gateway-internal
+spec:
+  groupRef:
+    name: mcp-tools
+  config:
+    aggregation:
+      conflictResolution: prefix
+      conflictResolutionConfig:
+        prefixFormat: "{workload}_"
+  embeddingServerRef:
+    name: mcp-tools-embedding
+  incomingAuth:
+    type: anonymous
+  outgoingAuth:
+    source: discovered
+  podTemplateSpec:
+    spec:
+      containers:
+        - name: vmcp
+          resources:
+            requests:
+              memory: 256Mi
+            limits:
+              memory: 1Gi

--- a/kubernetes/apps/ai/toolhive/crds/helmrelease.yaml
+++ b/kubernetes/apps/ai/toolhive/crds/helmrelease.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: toolhive-operator-crds
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.29.3
+  url: oci://ghcr.io/stacklok/toolhive/toolhive-operator-crds
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: toolhive-operator-crds
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: toolhive-operator-crds
+  interval: 30m

--- a/kubernetes/apps/ai/toolhive/crds/kustomization.yaml
+++ b/kubernetes/apps/ai/toolhive/crds/kustomization.yaml
@@ -1,0 +1,5 @@
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml

--- a/kubernetes/apps/ai/toolhive/ks.yaml
+++ b/kubernetes/apps/ai/toolhive/ks.yaml
@@ -1,0 +1,103 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app toolhive-crds
+  namespace: &namespace ai
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  targetNamespace: *namespace
+  interval: 1h
+  retryInterval: 1m
+  timeout: 5m
+  path: "./kubernetes/apps/ai/toolhive/crds"
+  prune: true
+  wait: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app toolhive
+  namespace: &namespace ai
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  targetNamespace: *namespace
+  interval: 1h
+  retryInterval: 1m
+  timeout: 5m
+  path: "./kubernetes/apps/ai/toolhive/app"
+  prune: true
+  wait: true
+  dependsOn:
+    - name: toolhive-crds
+      namespace: *namespace
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app toolhive-config
+  namespace: &namespace ai
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  targetNamespace: *namespace
+  interval: 1h
+  retryInterval: 1m
+  timeout: 5m
+  path: "./kubernetes/apps/ai/toolhive/config"
+  prune: true
+  wait: false
+  dependsOn:
+    - name: toolhive
+      namespace: *namespace
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app toolhive-mcp-servers
+  namespace: &namespace ai
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  targetNamespace: *namespace
+  interval: 1h
+  retryInterval: 1m
+  timeout: 5m
+  path: "./kubernetes/apps/ai/toolhive/mcp-servers"
+  prune: true
+  wait: false
+  dependsOn:
+    - name: toolhive-config
+      namespace: *namespace
+    - name: onepassword-store
+      namespace: security
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/ai/toolhive/mcp-servers/arr-mcp/externalsecret.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/arr-mcp/externalsecret.yaml
@@ -1,0 +1,53 @@
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name toolhive-sonarr
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: *name
+    template:
+      data:
+        SONARR_API_KEY: "{{ .SONARR__AUTH__APIKEY }}"
+  dataFrom:
+    - extract:
+        key: sonarr
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name toolhive-radarr
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: *name
+    template:
+      data:
+        RADARR_API_KEY: "{{ .RADARR__AUTH__APIKEY }}"
+  dataFrom:
+    - extract:
+        key: radarr
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name toolhive-prowlarr
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: *name
+    template:
+      data:
+        PROWLARR_API_KEY: "{{ .PROWLARR__AUTH__APIKEY }}"
+  dataFrom:
+    - extract:
+        key: prowlarr

--- a/kubernetes/apps/ai/toolhive/mcp-servers/arr-mcp/kustomization.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/arr-mcp/kustomization.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./mcpserver.yaml

--- a/kubernetes/apps/ai/toolhive/mcp-servers/arr-mcp/mcpserver.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/arr-mcp/mcpserver.yaml
@@ -1,0 +1,55 @@
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/toolhive.stacklok.dev/mcpserver_v1alpha1.json
+apiVersion: toolhive.stacklok.dev/v1alpha1
+kind: MCPServer
+metadata:
+  name: arr
+spec:
+  image: docker.io/node:24-alpine
+  transport: stdio
+  proxyMode: streamable-http
+  proxyPort: 8080
+  env:
+    - name: HOME
+      value: /tmp
+    - name: NPM_CONFIG_CACHE
+      value: /tmp/.npm
+    - name: SONARR_URL
+      value: http://sonarr.downloads
+    - name: RADARR_URL
+      value: http://radarr.downloads
+    - name: PROWLARR_URL
+      value: http://prowlarr.downloads
+  secrets:
+    - name: toolhive-sonarr
+      key: SONARR_API_KEY
+      targetEnvName: SONARR_API_KEY
+    - name: toolhive-radarr
+      key: RADARR_API_KEY
+      targetEnvName: RADARR_API_KEY
+    - name: toolhive-prowlarr
+      key: PROWLARR_API_KEY
+      targetEnvName: PROWLARR_API_KEY
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits:
+      memory: 256Mi
+  podTemplateSpec:
+    spec:
+      containers:
+        - name: mcp
+          image: docker.io/node:24-alpine
+          command:
+            - npx
+          args:
+            - -y
+            - mcp-arr-server@1.5.4
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}
+  groupRef:
+    name: mcp-tools

--- a/kubernetes/apps/ai/toolhive/mcp-servers/comfyui-mcp/kustomization.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/comfyui-mcp/kustomization.yaml
@@ -1,0 +1,5 @@
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./mcpserver.yaml

--- a/kubernetes/apps/ai/toolhive/mcp-servers/comfyui-mcp/mcpserver.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/comfyui-mcp/mcpserver.yaml
@@ -1,0 +1,44 @@
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/toolhive.stacklok.dev/mcpserver_v1alpha1.json
+apiVersion: toolhive.stacklok.dev/v1alpha1
+kind: MCPServer
+metadata:
+  name: &name comfyui-mcp
+spec:
+  image: docker.io/node:24-alpine
+  transport: stdio
+  proxyMode: streamable-http
+  groupRef:
+    name: mcp-tools
+  env:
+    - name: HOME
+      value: /tmp
+    - name: NPM_CONFIG_CACHE
+      value: /tmp/.npm
+    - name: COMFYUI_HOST
+      value: comfyui.ai
+    - name: COMFYUI_PATH
+      value: /root/ComfyUI
+    - name: COMFYUI_PORT
+      value: "8188"
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits:
+      memory: 256Mi
+  podTemplateSpec:
+    spec:
+      containers:
+        - name: mcp
+          image: docker.io/node:24-alpine
+          command:
+            - npx
+          args:
+            - -y
+            - comfyui-mcp@0.3.2
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}

--- a/kubernetes/apps/ai/toolhive/mcp-servers/flux-mcp/kustomization.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/flux-mcp/kustomization.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./rbac.yaml
+  - ./mcpserver.yaml

--- a/kubernetes/apps/ai/toolhive/mcp-servers/flux-mcp/mcpserver.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/flux-mcp/mcpserver.yaml
@@ -1,0 +1,35 @@
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/toolhive.stacklok.dev/mcpserver_v1alpha1.json
+apiVersion: toolhive.stacklok.dev/v1alpha1
+kind: MCPServer
+metadata:
+  name: flux
+spec:
+  image: ghcr.io/controlplaneio-fluxcd/flux-operator-mcp:v0.52.0@sha256:50b6b5f346642591e63e7a70a38e60ed5336163d34966bb63e6fbd709ad8a0dd
+  transport: streamable-http
+  proxyMode: streamable-http
+  proxyPort: 8080
+  mcpPort: 8000
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+  serviceAccount: flux-mcp
+  podTemplateSpec:
+    spec:
+      containers:
+        - name: mcp
+          args:
+            - serve
+            - --transport=http
+            - --port=8000
+          env:
+            # In-cluster mode: no KUBECONFIG; uses the pod service account.
+            - name: RUNTIME_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+  groupRef:
+    name: mcp-tools

--- a/kubernetes/apps/ai/toolhive/mcp-servers/flux-mcp/rbac.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/flux-mcp/rbac.yaml
@@ -1,0 +1,55 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: flux-mcp
+---
+# Reuses the broad read-only ClusterRole from kubectl-mcp (secrets excluded).
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: flux-mcp-readonly
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kubectl-mcp-readonly
+subjects:
+  - kind: ServiceAccount
+    name: flux-mcp
+    namespace: ai
+---
+# Write access limited to Flux API groups: enables the MCP
+# reconcile/suspend/resume tools (annotation/spec patches) and
+# apply/delete of Flux objects, but nothing outside Flux CRDs.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: flux-mcp-write
+rules:
+  - apiGroups:
+      - fluxcd.controlplane.io
+      - helm.toolkit.fluxcd.io
+      - image.toolkit.fluxcd.io
+      - kustomize.toolkit.fluxcd.io
+      - notification.toolkit.fluxcd.io
+      - source.toolkit.fluxcd.io
+    resources:
+      - "*"
+    verbs:
+      - create
+      - patch
+      - update
+      - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: flux-mcp-write
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: flux-mcp-write
+subjects:
+  - kind: ServiceAccount
+    name: flux-mcp
+    namespace: ai

--- a/kubernetes/apps/ai/toolhive/mcp-servers/garmin-connect-mcp/externalsecret.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/garmin-connect-mcp/externalsecret.yaml
@@ -1,0 +1,37 @@
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+# Requires a 1Password item `garmin` with fields `username` + `password`
+# (Garmin Connect login). Create it before this MCP can become Ready.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name toolhive-garmin-username
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: *name
+    template:
+      data:
+        GARMIN_EMAIL: "{{ .username }}"
+  dataFrom:
+    - extract:
+        key: garmin
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name toolhive-garmin-password
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: *name
+    template:
+      data:
+        GARMIN_PASSWORD: "{{ .password }}"
+  dataFrom:
+    - extract:
+        key: garmin

--- a/kubernetes/apps/ai/toolhive/mcp-servers/garmin-connect-mcp/kustomization.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/garmin-connect-mcp/kustomization.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./mcpserver.yaml

--- a/kubernetes/apps/ai/toolhive/mcp-servers/garmin-connect-mcp/mcpserver.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/garmin-connect-mcp/mcpserver.yaml
@@ -1,0 +1,46 @@
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/toolhive.stacklok.dev/mcpserver_v1alpha1.json
+apiVersion: toolhive.stacklok.dev/v1alpha1
+kind: MCPServer
+metadata:
+  name: garmin-connect
+spec:
+  image: docker.io/node:24-alpine
+  transport: stdio
+  proxyMode: streamable-http
+  proxyPort: 8080
+  env:
+    - name: HOME
+      value: /tmp
+    - name: NPM_CONFIG_CACHE
+      value: /tmp/.npm
+  secrets:
+    - name: toolhive-garmin-username
+      key: GARMIN_EMAIL
+      targetEnvName: GARMIN_EMAIL
+    - name: toolhive-garmin-password
+      key: GARMIN_PASSWORD
+      targetEnvName: GARMIN_PASSWORD
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits:
+      memory: 256Mi
+  podTemplateSpec:
+    spec:
+      containers:
+        - name: mcp
+          image: docker.io/node:24-alpine
+          command:
+            - npx
+          args:
+            - -y
+            - "@nicolasvegam/garmin-connect-mcp@1.1.1"
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}
+  groupRef:
+    name: mcp-tools

--- a/kubernetes/apps/ai/toolhive/mcp-servers/github-mcp/externalsecret.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/github-mcp/externalsecret.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+# Reuses the existing `hermes` 1Password item's HOMELAB_GH_TOKEN (public_repo
+# scope). Swap to a dedicated/broader GitHub PAT here if the MCP needs more than
+# public-repo read access.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name toolhive-github
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: *name
+    template:
+      data:
+        token: "{{ .HOMELAB_GH_TOKEN }}"
+  dataFrom:
+    - extract:
+        key: hermes

--- a/kubernetes/apps/ai/toolhive/mcp-servers/github-mcp/kustomization.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/github-mcp/kustomization.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./mcpserver.yaml

--- a/kubernetes/apps/ai/toolhive/mcp-servers/github-mcp/mcpserver.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/github-mcp/mcpserver.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/toolhive.stacklok.dev/mcpserver_v1alpha1.json
+apiVersion: toolhive.stacklok.dev/v1alpha1
+kind: MCPServer
+metadata:
+  name: github
+spec:
+  image: ghcr.io/github/github-mcp-server
+  transport: stdio
+  proxyMode: streamable-http
+  proxyPort: 8080
+  env:
+    - name: GITHUB_API_URL
+      value: https://api.github.com
+    - name: LOG_LEVEL
+      value: info
+  secrets:
+    - name: toolhive-github
+      key: token
+      targetEnvName: GITHUB_PERSONAL_ACCESS_TOKEN
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 200m
+      memory: 256Mi
+  groupRef:
+    name: mcp-tools

--- a/kubernetes/apps/ai/toolhive/mcp-servers/ha-mcp/externalsecret.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/ha-mcp/externalsecret.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+# Requires the 1Password item `home-assistant` to carry a HOMEASSISTANT_TOKEN
+# field (a Home Assistant long-lived access token). Add it before this MCP can
+# become Ready.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name toolhive-home-assistant
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: *name
+    template:
+      data:
+        HOMEASSISTANT_TOKEN: "{{ .HOMEASSISTANT_TOKEN }}"
+  dataFrom:
+    - extract:
+        key: home-assistant

--- a/kubernetes/apps/ai/toolhive/mcp-servers/ha-mcp/kustomization.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/ha-mcp/kustomization.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./mcpserver.yaml

--- a/kubernetes/apps/ai/toolhive/mcp-servers/ha-mcp/mcpserver.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/ha-mcp/mcpserver.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/toolhive.stacklok.dev/mcpserver_v1alpha1.json
+apiVersion: toolhive.stacklok.dev/v1alpha1
+kind: MCPServer
+metadata:
+  name: ha-mcp
+spec:
+  image: ghcr.io/homeassistant-ai/ha-mcp:7.7.0
+  transport: streamable-http
+  groupRef:
+    name: mcp-tools
+  env:
+    - name: HOMEASSISTANT_URL
+      value: http://home-assistant.home-automation:8123
+  secrets:
+    - name: toolhive-home-assistant
+      key: HOMEASSISTANT_TOKEN
+  podTemplateSpec:
+    spec:
+      containers:
+        - name: mcp
+          command:
+            - ha-mcp-web
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}

--- a/kubernetes/apps/ai/toolhive/mcp-servers/kubectl-mcp/kustomization.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/kubectl-mcp/kustomization.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./rbac.yaml
+  - ./mcpserver.yaml

--- a/kubernetes/apps/ai/toolhive/mcp-servers/kubectl-mcp/mcpserver.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/kubectl-mcp/mcpserver.yaml
@@ -1,0 +1,38 @@
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/toolhive.stacklok.dev/mcpserver_v1alpha1.json
+apiVersion: toolhive.stacklok.dev/v1alpha1
+kind: MCPServer
+metadata:
+  name: kubectl
+spec:
+  image: docker.io/rohitghumare64/kubectl-mcp-server:1.24.0@sha256:17134e36a3e1d3a5e457c12d61e8c7f7c52a7927c6ae4250131dfd95a74a2331
+  transport: streamable-http
+  proxyMode: streamable-http
+  proxyPort: 8080
+  mcpPort: 8000
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+  serviceAccount: kubectl-mcp-readonly
+  podTemplateSpec:
+    spec:
+      containers:
+        - name: mcp
+          args:
+            - --transport
+            - streamable-http
+            - --host
+            - 0.0.0.0
+            - --port
+            - "8000"
+            - --read-only
+          env:
+            - name: MCP_K8S_PROVIDER
+              value: in-cluster
+            - name: PYTHONUNBUFFERED
+              value: "1"
+  groupRef:
+    name: mcp-tools

--- a/kubernetes/apps/ai/toolhive/mcp-servers/kubectl-mcp/rbac.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/kubectl-mcp/rbac.yaml
@@ -1,0 +1,150 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kubectl-mcp-readonly
+---
+# Broad read-only access for kubectl MCP. Kubernetes Secrets (core v1) are excluded.
+#
+# - aggregationRule: same selector as built-in "view" — expands with operators that ship
+#   rbac.authorization.k8s.io/aggregate-to-view ClusterRoles (CRDs, etc.).
+# - Non-core apiGroups: resources "*" is safe for Secret *objects* (they only exist in group "").
+# - Core group "": explicit resource list — secrets omitted; exec/proxy-style subresources omitted.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubectl-mcp-readonly
+aggregationRule:
+  clusterRoleSelectors:
+    - matchLabels:
+        rbac.authorization.k8s.io/aggregate-to-view: "true"
+rules:
+  - nonResourceURLs:
+      - /api
+      - /api/*
+      - /apis
+      - /apis/*
+      - /healthz
+      - /livez
+      - /openapi
+      - /openapi/*
+      - /readyz
+      - /version
+      - /version/
+    verbs:
+      - get
+  # Core v1 — everything except secrets (and without exec/proxy attach paths).
+  - apiGroups:
+      - ""
+    resources:
+      - bindings
+      - componentstatuses
+      - configmaps
+      - endpoints
+      - events
+      - limitranges
+      - namespaces
+      - namespaces/status
+      - nodes
+      - nodes/status
+      - persistentvolumeclaims
+      - persistentvolumeclaims/status
+      - persistentvolumes
+      - persistentvolumes/status
+      - pods
+      - pods/log
+      - pods/status
+      - podtemplates
+      - replicationcontrollers
+      - replicationcontrollers/scale
+      - replicationcontrollers/status
+      - resourcequotas
+      - resourcequotas/status
+      - serviceaccounts
+      - services
+      - services/status
+    verbs:
+      - get
+      - list
+      - watch
+  # All non-core API groups: full resource read (Secret objects are not in these groups).
+  # Includes built-in API groups plus every CRD group reported from the cluster (minus "").
+  # CRDs whose operators ship aggregate-to-view ClusterRoles are also covered by aggregationRule above.
+  - apiGroups:
+      - acme.cert-manager.io
+      - actions.github.com
+      - admissionregistration.k8s.io
+      - aigateway.envoyproxy.io
+      - apiextensions.k8s.io
+      - apiregistration.k8s.io
+      - apps
+      - autoscaling
+      - batch
+      - ceph.rook.io
+      - cert-manager.io
+      - certificates.k8s.io
+      - cilium.io
+      - coordination.k8s.io
+      - csi.ceph.io
+      - deviceplugin.intel.com
+      - discovery.k8s.io
+      - dragonflydb.io
+      - events.k8s.io
+      - extensions
+      - external-secrets.io
+      - externaldns.k8s.io
+      - flowcontrol.apiserver.k8s.io
+      - fluxcd.controlplane.io
+      - fpga.intel.com
+      - gateway.envoyproxy.io
+      - gateway.networking.k8s.io
+      - gateway.networking.x-k8s.io
+      - generators.external-secrets.io
+      - grafana.integreatly.org
+      - groupsnapshot.storage.k8s.io
+      - helm.toolkit.fluxcd.io
+      - image.toolkit.fluxcd.io
+      - k8s.cni.cncf.io
+      - keda.sh
+      - kustomize.toolkit.fluxcd.io
+      - metrics.k8s.io
+      - monitoring.coreos.com
+      - monitoring.giantswarm.io
+      - networking.k8s.io
+      - node.k8s.io
+      - notification.toolkit.fluxcd.io
+      - objectbucket.io
+      - observability.giantswarm.io
+      - policy
+      - postgresql.cnpg.io
+      - rbac.authorization.k8s.io
+      - renovate-operator.mogenius.com
+      - resource.k8s.io
+      - scheduling.k8s.io
+      - snapshot.storage.k8s.io
+      - source.toolkit.fluxcd.io
+      - storage.k8s.io
+      - talos.dev
+      - toolhive.stacklok.dev
+      - tuppr.home-operations.com
+      - upgrade.cattle.io
+      - volsync.backube
+    resources:
+      - "*"
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kubectl-mcp-readonly
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kubectl-mcp-readonly
+subjects:
+  - kind: ServiceAccount
+    name: kubectl-mcp-readonly
+    namespace: ai

--- a/kubernetes/apps/ai/toolhive/mcp-servers/kustomization.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/kustomization.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./arr-mcp
+  - ./comfyui-mcp
+  - ./flux-mcp
+  - ./github-mcp
+  - ./kubectl-mcp
+  - ./memory-mcp
+  - ./talos-mcp
+  # Deactivated pending 1Password secrets (files kept — re-enable once the
+  # listed fields exist):
+  #   garmin-connect-mcp -> item `garmin` fields `username` + `password`
+  #   ha-mcp             -> item `home-assistant` field `HOMEASSISTANT_TOKEN`
+  #   seerr-mcp          -> item `seerr` field `SEERR_API_KEY`
+  # - ./garmin-connect-mcp
+  # - ./ha-mcp
+  # - ./seerr-mcp
+  # grafana-mcp intentionally omitted: its MCPServerEntry targets
+  # mcp-grafana.observability:8000, which does not exist in this cluster.

--- a/kubernetes/apps/ai/toolhive/mcp-servers/memory-mcp/kustomization.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/memory-mcp/kustomization.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./pvc.yaml
+  - ./mcpserver.yaml

--- a/kubernetes/apps/ai/toolhive/mcp-servers/memory-mcp/mcpserver.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/memory-mcp/mcpserver.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/toolhive.stacklok.dev/mcpserver_v1alpha1.json
+apiVersion: toolhive.stacklok.dev/v1alpha1
+kind: MCPServer
+metadata:
+  name: &name memory-mcp
+spec:
+  image: ghcr.io/bjw-s-labs/mcp-memory:2026.1.26@sha256:df4a7e3709dfe363cd9048df13b2aed7f13ee135f07d07cd318d69f7e058abd8
+  transport: stdio
+  groupRef:
+    name: mcp-tools
+  podTemplateSpec:
+    spec:
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: *name
+      containers:
+        - name: mcp
+          volumeMounts:
+            - name: data
+              mountPath: /data

--- a/kubernetes/apps/ai/toolhive/mcp-servers/memory-mcp/pvc.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/memory-mcp/pvc.yaml
@@ -1,0 +1,14 @@
+---
+# Persistent store for the memory MCP. The upstream MCPServer references an
+# existing PVC named `memory-mcp` but ships no PVC manifest, so define one here.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: memory-mcp
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: ceph-block
+  resources:
+    requests:
+      storage: 1Gi

--- a/kubernetes/apps/ai/toolhive/mcp-servers/seerr-mcp/externalsecret.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/seerr-mcp/externalsecret.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+# Requires the 1Password item `seerr` to carry a SEERR_API_KEY field
+# (Overseerr/Jellyseerr API key from its settings). Add it before this MCP can
+# become Ready.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name toolhive-seerr
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: *name
+    template:
+      data:
+        SEERR_API_KEY: "{{ .SEERR_API_KEY }}"
+  dataFrom:
+    - extract:
+        key: seerr

--- a/kubernetes/apps/ai/toolhive/mcp-servers/seerr-mcp/kustomization.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/seerr-mcp/kustomization.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./mcpserver.yaml

--- a/kubernetes/apps/ai/toolhive/mcp-servers/seerr-mcp/mcpserver.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/seerr-mcp/mcpserver.yaml
@@ -1,0 +1,45 @@
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/toolhive.stacklok.dev/mcpserver_v1alpha1.json
+apiVersion: toolhive.stacklok.dev/v1alpha1
+kind: MCPServer
+metadata:
+  name: seerr-mcp
+spec:
+  image: docker.io/node:24-alpine
+  transport: stdio
+  proxyMode: streamable-http
+  proxyPort: 8080
+  env:
+    - name: HOME
+      value: /tmp
+    - name: NPM_CONFIG_CACHE
+      value: /tmp/.npm
+    - name: SEERR_URL
+      value: http://seerr.media
+  secrets:
+    - name: toolhive-seerr
+      key: SEERR_API_KEY
+      targetEnvName: SEERR_API_KEY
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits:
+      memory: 256Mi
+  podTemplateSpec:
+    spec:
+      containers:
+        - name: mcp
+          image: docker.io/node:24-alpine
+          command:
+            - npx
+          args:
+            - -y
+            - "@jhomen368/overseerr-mcp"
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}
+  groupRef:
+    name: mcp-tools

--- a/kubernetes/apps/ai/toolhive/mcp-servers/talos-mcp/kustomization.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/talos-mcp/kustomization.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./mcpserver.yaml
+  - ./talosserviceaccount.yaml

--- a/kubernetes/apps/ai/toolhive/mcp-servers/talos-mcp/mcpserver.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/talos-mcp/mcpserver.yaml
@@ -1,0 +1,32 @@
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/toolhive.stacklok.dev/mcpserver_v1alpha1.json
+apiVersion: toolhive.stacklok.dev/v1alpha1
+kind: MCPServer
+metadata:
+  name: talos-mcp
+spec:
+  image: registry.erwanleboucher.dev/eleboucher/talos-mcp:0.0.2
+  transport: streamable-http
+  mcpPort: 8080
+  groupRef:
+    name: mcp-tools
+  permissionProfile:
+    type: builtin
+    name: network
+  env:
+    - name: TALOS_MCP_TRANSPORT
+      value: http
+    - name: TALOS_MCP_HTTP_ADDR
+      value: ":8080"
+  podTemplateSpec:
+    spec:
+      containers:
+        - name: mcp
+          volumeMounts:
+            - name: talosconfig
+              mountPath: /var/run/secrets/talos.dev
+              readOnly: true
+      volumes:
+        - name: talosconfig
+          secret:
+            secretName: talos-mcp-talosconfig
+            defaultMode: 0400

--- a/kubernetes/apps/ai/toolhive/mcp-servers/talos-mcp/talosserviceaccount.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/talos-mcp/talosserviceaccount.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/talos.dev/serviceaccount_v1alpha1.json
+apiVersion: talos.dev/v1alpha1
+kind: ServiceAccount
+metadata:
+  name: talos-mcp-talosconfig
+spec:
+  roles:
+    - os:reader


### PR DESCRIPTION
## What

Merges the Stacklok **ToolHive** MCP stack into the `ai` namespace (adapted from `joryirving/home-ops` → `kubernetes/apps/base/llm/toolhive`) and wires the aggregated MCP gateway into the **Hermes** agent.

### ToolHive (`kubernetes/apps/ai/toolhive/`)
- Operator + CRDs HelmReleases (OCI, v0.29.3), `mcp-tools` MCPGroup, VirtualMCPServer aggregator, embedding server, telemetry, PodMonitor, HTTPRoute (`mcp.${SECRET_DOMAIN}`), Grafana dashboard.
- 4 Flux Kustomizations following the repo's CRD-split pattern: `toolhive-crds` (wait) → `toolhive` → `toolhive-config` → `toolhive-mcp-servers` (depends on `onepassword-store`).

### Cluster rewiring vs upstream
- Namespace `llm` → `ai`; DNS `comfyui.ai`, HA internal svc; domain `mcp.${SECRET_DOMAIN}`, `sectionName: https`.
- *arr keys mapped to existing `*__AUTH__APIKEY` 1P fields; github reuses the existing `hermes` token.
- Grafana `instanceSelector` + schema URLs aligned to repo conventions.
- Added a PVC for `memory-mcp` (upstream referenced one but shipped none).

### Active vs deactivated MCPs
- **Active (7):** `arr`, `comfyui`, `flux`, `github`, `kubectl`, `memory`, `talos` — all backed by secrets that already exist.
- **Deactivated** (commented out in `mcp-servers/kustomization.yaml`, files kept) pending 1P fields we don't have yet:
  - `garmin-connect` → item `garmin` (`username` + `password`)
  - `ha-mcp` → item `home-assistant` (`HOMEASSISTANT_TOKEN`)
  - `seerr-mcp` → item `seerr` (`SEERR_API_KEY`)
- **Omitted:** `grafana` (its MCPServerEntry targets `mcp-grafana.observability`, absent here).

### Hermes
- Adds `mcp_servers.toolhive` → `http://vmcp-mcp-gateway-internal.ai.svc.cluster.local:4483/mcp` (streamable-http, anonymous). joryirving routes via litellm `/mcp`; litellm is retired here, so Hermes connects straight to the vmcp.

## Validation
`kustomize build` passes for all toolhive subdirs + the `ai` overlay + hermes; kubeconform clean (CRD kinds skipped). No leftover `llm`/`jory.dev`/`comfyui.llm` references.

## Post-merge test plan
- `toolhive-operator(-crds)` HelmReleases Ready; operator pod up
- each active MCPServer → Running; `VirtualMCPServer` up; vmcp `/mcp` returns aggregated tools
- Hermes reloads and lists the `toolhive` MCP tools
- verify `talos-mcp` gets its `talos-mcp-talosconfig` secret from the Talos ServiceAccount controller

🤖 Generated with [Claude Code](https://claude.com/claude-code)