### PR TITLE
fix(ai): correct toolhive arr secret keys + deactivate talos-mcp

### DIFF
--- a/kubernetes/apps/ai/toolhive/mcp-servers/arr-mcp/externalsecret.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/arr-mcp/externalsecret.yaml
@@ -11,7 +11,7 @@ spec:
     name: *name
     template:
       data:
-        SONARR_API_KEY: "{{ .SONARR__AUTH__APIKEY }}"
+        SONARR_API_KEY: "{{ .SONARR_API_KEY }}"
   dataFrom:
     - extract:
         key: sonarr
@@ -29,7 +29,7 @@ spec:
     name: *name
     template:
       data:
-        RADARR_API_KEY: "{{ .RADARR__AUTH__APIKEY }}"
+        RADARR_API_KEY: "{{ .RADARR_API_KEY }}"
   dataFrom:
     - extract:
         key: radarr
@@ -47,7 +47,7 @@ spec:
     name: *name
     template:
       data:
-        PROWLARR_API_KEY: "{{ .PROWLARR__AUTH__APIKEY }}"
+        PROWLARR_API_KEY: "{{ .PROWLARR_API_KEY }}"
   dataFrom:
     - extract:
         key: prowlarr

--- a/kubernetes/apps/ai/toolhive/mcp-servers/kustomization.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/kustomization.yaml
@@ -8,7 +8,6 @@ resources:
   - ./github-mcp
   - ./kubectl-mcp
   - ./memory-mcp
-  - ./talos-mcp
   # Deactivated pending 1Password secrets (files kept — re-enable once the
   # listed fields exist):
   #   garmin-connect-mcp -> item `garmin` fields `username` + `password`
@@ -17,5 +16,11 @@ resources:
   # - ./garmin-connect-mcp
   # - ./ha-mcp
   # - ./seerr-mcp
+  # Deactivated: the Talos ServiceAccount controller rejects ns `ai`
+  # (ErrNamespaceNotAllowed). To re-enable, add `ai` to
+  # features.kubernetesTalosAPIAccess.allowedKubernetesNamespaces (and `os:reader`
+  # to allowedRoles) in talos/machineconfig.yaml.j2, then re-apply Talos config
+  # to all 3 nodes.
+  # - ./talos-mcp
   # grafana-mcp intentionally omitted: its MCPServerEntry targets
   # mcp-grafana.observability:8000, which does not exist in this cluster.


### PR DESCRIPTION
Resolves two deploy issues found after #987 landed.

### 1. arr ExternalSecrets failing
ESO errored: `map has no entry for key "SONARR__AUTH__APIKEY"` (and radarr/prowlarr). Those are the *app* env-var names; the real 1Password fields are `SONARR_API_KEY` / `RADARR_API_KEY` / `PROWLARR_API_KEY`. Reverted to the correct field names.

### 2. talos-mcp namespace-blocked
The Talos ServiceAccount controller rejects ns `ai` (`ErrNamespaceNotAllowed`) — only `actions-runner-system` and `system-upgrade` are in `allowedKubernetesNamespaces`. Deactivated talos-mcp (files kept). Re-enable = add `ai` to `features.kubernetesTalosAPIAccess.allowedKubernetesNamespaces` (+ `os:reader` to `allowedRoles`) in `talos/machineconfig.yaml.j2` and re-apply Talos config to all nodes.

Active MCPs after this: arr, comfyui, flux, github, kubectl, memory.

Note: the proxyrunner/embedding image-pull delay seen during rollout was transient ghcr.io slowness (now recovered) compounded by Talos serialized pulls — not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)