### PR TITLE
feat(hermes): use local B70 Qwen as primary LLM, cloud as fallback

### DIFF
--- a/kubernetes/apps/ai/hermes/README.md
+++ b/kubernetes/apps/ai/hermes/README.md
@@ -36,15 +36,18 @@ are overwritten on the next restart.
 
 | Provider | Routing | Auth |
 | -------- | ------- | ---- |
-| `xai-oauth` (native, **default** `grok-4.3`) | direct to xAI, bypassing the gateway | OAuth (Grok subscription, see below) |
+| `custom:local` (**default** `qwen3.6-35b-a3b`) | agentgateway `internal-noauth` → `/vllm/v1` (llama.cpp on the B70) | keyless (LAN-only gateway) |
 | `custom:gateway` (`kimi-k2.6`) | agentgateway `internal-noauth` → `/opencodego/v1` | keyless (gateway injects the key) |
+| `xai-oauth` (native, `grok-4.3`) | direct to xAI, bypassing the gateway | OAuth (Grok subscription, see below) |
 
 `config.yaml` also sets:
-- **Fallback chain** — `grok-4.3` → `custom:gateway/kimi-k2.6`, so a 429/outage on
-  the Grok subscription (or the OpenCode-Go `GoUsageLimitError`) doesn't kill the
-  session.
-- **Auxiliary routing** — compression / web_extract / session_search / title go to
-  the cheap gateway model instead of burning the Grok subscription.
+- **Fallback chain** — `custom:local/qwen3.6-35b-a3b` → `custom:gateway/kimi-k2.6` →
+  `xai-oauth/grok-4.3`, so a local outage (e.g. ComfyUI scaling `vllm` to 0 under the
+  Dedicated-VRAM runbook) doesn't kill the session. The local default is free and
+  rate-limit-proof, so long tasks don't hit the xAI throttle or OpenCode-Go limits.
+- **Auxiliary routing** — compression / web_extract / session_search / title run on the
+  local model too (the single-slot llama-server serializes them behind the main task);
+  `vision` is pinned to Grok (`xai-oauth`) since the local 35B is text-only.
 - **Web search** — `web.search_backend: searxng`, wired to the in-cluster SearXNG
   via `SEARXNG_URL`.
 
@@ -172,8 +175,9 @@ PAT or account SSH key would expose every repo; don't use those.)
   removed without touching the rest — see the disable note in `helmrelease.yaml`.
 - **Runs as root then drops** to UID 10000 (s6-overlay), so no `runAsNonRoot` on the
   `app` container — `fsGroup: 10000` makes the PVC writable for the dropped user.
-- **Cost tracking:** the default `xai-oauth` Grok path talks to xAI **directly**,
-  bypassing the gateway, so it isn't in gateway cost/Tempo tracking (flat subscription
-  anyway). Only the `custom:gateway` path is metered.
+- **Cost tracking:** the default `custom:local` and the `custom:gateway` paths go
+  through the agentgateway, so they're in gateway cost/Tempo tracking. The `xai-oauth`
+  Grok path (now fallback + `vision`) talks to xAI **directly**, bypassing the gateway,
+  so it isn't tracked (flat subscription anyway).
 - **Ports:** `9119` dashboard, `8642` OpenAI-compatible API, `8787` webui, `12321`
   code-server.

--- a/kubernetes/apps/ai/hermes/app/resources/config.yaml
+++ b/kubernetes/apps/ai/hermes/app/resources/config.yaml
@@ -19,39 +19,44 @@ custom_providers:
     base_url: http://internal-noauth.ai.svc.cluster.local/vllm/v1
     api_mode: chat_completions
 
-# Default serving model: Grok via the native xai-oauth provider (subscription;
-# creds added once with `hermes auth add xai-oauth --manual-paste`, kept in
-# /opt/data/auth.json). To serve kimi through the gateway instead, set:
-#   model: { default: kimi-k2.6, provider: custom:gateway }
+# Default serving model: the local Qwen3.6-35B-A3B on the B70 (custom:local ->
+# /vllm route). Free and rate-limit-proof, so long-running tasks never hit the
+# xAI subscription throttle or the OpenCode-Go GoUsageLimitError. To serve a
+# cloud model instead, set e.g. model: { default: grok-4.3, provider: xai-oauth }.
 model:
-  default: grok-4.3
-  provider: xai-oauth
+  default: qwen3.6-35b-a3b
+  provider: custom:local
 
-# Fail-over chain: if the default provider 429s/errors (the Grok subscription, or
-# the OpenCode-Go GoUsageLimitError), fall back to kimi via the gateway, then to
-# the local 35B on the B70 (never rate-limited, always on).
+# Fail-over chain: if the local B70 model errors or is unavailable (e.g. ComfyUI
+# scaled vllm to 0 under the Dedicated-VRAM runbook), fall back to kimi via the
+# gateway, then to Grok (xai-oauth subscription; creds added once with
+# `hermes auth add xai-oauth --manual-paste`, kept in /opt/data/auth.json).
 fallback_providers:
   - provider: custom:gateway
     model: kimi-k2.6
-  - provider: custom:local
-    model: qwen3.6-35b-a3b
+  - provider: xai-oauth
+    model: grok-4.3
 
-# Route heavy, frequent context chores to the cheap gateway model so they don't
-# burn the Grok subscription. `vision` is left on the default (grok-4.3) unless
-# kimi-k2.6 gains vision support.
+# Heavy, frequent context chores run on the local model too, so they don't burn
+# the cloud limits either (the llama-server is single-slot, so these serialize
+# behind the main task). `vision` is the exception: the local 35B is text-only,
+# so image inputs are pinned to Grok (the only vision-capable provider here).
 auxiliary:
   compression:
-    provider: custom:gateway
-    model: kimi-k2.6
+    provider: custom:local
+    model: qwen3.6-35b-a3b
   web_extract:
-    provider: custom:gateway
-    model: kimi-k2.6
+    provider: custom:local
+    model: qwen3.6-35b-a3b
   session_search:
-    provider: custom:gateway
-    model: kimi-k2.6
+    provider: custom:local
+    model: qwen3.6-35b-a3b
   title_generator:
-    provider: custom:gateway
-    model: kimi-k2.6
+    provider: custom:local
+    model: qwen3.6-35b-a3b
+  vision:
+    provider: xai-oauth
+    model: grok-4.3
 
 # Web search via the SearXNG instance already running in ns ai.
 web:


### PR DESCRIPTION
## Why

Long-running Hermes tasks blow through both cloud paths fast — the xAI subscription throttles and OpenCode-Go returns `GoUsageLimitError` — which interrupts the work.

## What

Make the **local B70 Qwen3.6-35B-A3B** (`custom:local` → `/vllm/v1`, llama.cpp SYCL, free + rate-limit-proof) the **primary** model, and demote the cloud paths to a fallback safety net.

In `kubernetes/apps/ai/hermes/app/resources/config.yaml`:
- **Primary** → `qwen3.6-35b-a3b` / `custom:local`
- **Fallback chain** → `custom:gateway` (kimi-k2.6) → `xai-oauth` (grok-4.3). Cloud only kicks in when the local model errors or is unavailable (e.g. ComfyUI scales `vllm`→0 under the Dedicated-VRAM runbook).
- **Auxiliary chores** (compression / web_extract / session_search / title_generator) → all moved to `custom:local`. The single-slot llama-server serializes them behind the main task, but they no longer burn cloud limits.
- **`vision`** → pinned to `xai-oauth` (grok-4.3) since the local 35B is text-only.

`SUMMARY_LLM_*` for the commit-watcher skill is intentionally left on kimi (low-frequency background cron, keeps the single B70 slot free). README "LLM backend" section updated to match.

## Verify after merge
- `kubectl -n ai exec deploy/hermes -c app -- hermes config` → `default: qwen3.6-35b-a3b`, `provider: custom:local`, `memory.provider: agentmemory`.
- Send a chat; confirm the request lands on the local server (`kubectl -n ai logs deploy/vllm-app`).
- Confirm a long task no longer hits xAI/Go rate limits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)