### PR TITLE
fix(hermes): route aux chores to kimi + add provider api_key

### DIFF
--- a/kubernetes/apps/ai/hermes/README.md
+++ b/kubernetes/apps/ai/hermes/README.md
@@ -45,9 +45,13 @@ are overwritten on the next restart.
   `xai-oauth/grok-4.3`, so a local outage (e.g. ComfyUI scaling `vllm` to 0 under the
   Dedicated-VRAM runbook) doesn't kill the session. The local default is free and
   rate-limit-proof, so long tasks don't hit the xAI throttle or OpenCode-Go limits.
-- **Auxiliary routing** — compression / web_extract / session_search / title run on the
-  local model too (the single-slot llama-server serializes them behind the main task);
-  `vision` is pinned to Grok (`xai-oauth`) since the local 35B is text-only.
+- **Auxiliary routing** — compression / web_extract / session_search / title run on kimi
+  via the gateway, **not** the local model: `web_extract` fires N parallel LLM calls (one
+  per page) that the single-slot local server can't serve concurrently (they time out).
+  Aux volume is low/bursty so it won't hit the cloud limits the main loop did. Aux fallback
+  uses a **per-task `fallback_chain`** (the global `fallback_providers` is main-loop only),
+  so the heavy chores pin a Grok fallback. `vision` is pinned to Grok (`xai-oauth`) since
+  the local 35B is text-only.
 - **Web search** — `web.search_backend: searxng`, wired to the in-cluster SearXNG
   via `SEARXNG_URL`.
 

--- a/kubernetes/apps/ai/hermes/app/resources/config.yaml
+++ b/kubernetes/apps/ai/hermes/app/resources/config.yaml
@@ -7,16 +7,24 @@
 # wiped on the next restart.
 custom_providers:
   # OpenCode Go (open models) via the internal agentgateway. The keyless
-  # internal-noauth gateway injects the real opencodego key, so no api_key here.
-  # Referenced elsewhere as `custom:gateway`.
+  # internal-noauth gateway injects the real opencodego key upstream, so the
+  # `api_key` below is a dummy placeholder — it's never sent on the wire (the
+  # gateway overrides Authorization). It exists only so the auxiliary client can
+  # resolve a credential: without it Hermes logs "no resolvable api_key" warnings
+  # and its fallback credential check fails. Referenced elsewhere as `custom:gateway`.
   - name: gateway
     base_url: http://internal-noauth.ai.svc.cluster.local/opencodego/v1
+    api_key: no-key-required
     api_mode: chat_completions
   # Local Qwen3.6-35B-A3B on the B70 (llama.cpp SYCL, ~74 t/s) via the gateway's
   # /vllm route. Free and rate-limit-proof; llama-server is single-slot, so
-  # concurrent requests queue. Referenced as `custom:local`.
+  # concurrent requests queue. The keyless internal-noauth route needs no auth;
+  # `api_key` is a dummy to satisfy the auxiliary client's credential resolution
+  # (silences the no-key warning, no 401 since the route is unauthenticated).
+  # Referenced as `custom:local`.
   - name: local
     base_url: http://internal-noauth.ai.svc.cluster.local/vllm/v1
+    api_key: no-key-required
     api_mode: chat_completions
 
 # Default serving model: the local Qwen3.6-35B-A3B on the B70 (custom:local ->
@@ -37,23 +45,34 @@ fallback_providers:
   - provider: xai-oauth
     model: grok-4.3
 
-# Heavy, frequent context chores run on the local model too, so they don't burn
-# the cloud limits either (the llama-server is single-slot, so these serialize
-# behind the main task). `vision` is the exception: the local 35B is text-only,
-# so image inputs are pinned to Grok (the only vision-capable provider here).
+# Auxiliary context chores run on kimi via the gateway, NOT the local model:
+# web_extract fires N parallel LLM calls (one per fetched page) on large content,
+# and the single-slot local llama-server serialized them until they timed out.
+# kimi handles concurrency, and aux volume is low (bursty, per-task) so it won't
+# burn the cloud limits the way the continuous main loop did. IMPORTANT: aux
+# fallback uses the PER-TASK `fallback_chain`, NOT the global `fallback_providers`
+# above — without it Hermes falls back to the main model (=custom:local) and
+# re-times-out, so the heavy chores pin a Grok fallback (also parallel-capable).
+# `vision` is pinned to Grok because the local 35B is text-only.
 auxiliary:
-  compression:
-    provider: custom:local
-    model: qwen3.6-35b-a3b
   web_extract:
-    provider: custom:local
-    model: qwen3.6-35b-a3b
+    provider: custom:gateway
+    model: kimi-k2.6
+    fallback_chain:
+      - provider: xai-oauth
+        model: grok-4.3
+  compression:
+    provider: custom:gateway
+    model: kimi-k2.6
+    fallback_chain:
+      - provider: xai-oauth
+        model: grok-4.3
   session_search:
-    provider: custom:local
-    model: qwen3.6-35b-a3b
+    provider: custom:gateway
+    model: kimi-k2.6
   title_generator:
-    provider: custom:local
-    model: qwen3.6-35b-a3b
+    provider: custom:gateway
+    model: kimi-k2.6
   vision:
     provider: xai-oauth
     model: grok-4.3


### PR DESCRIPTION
## Why

After #989 repointed Hermes' primary model to the local B70 Qwen, the **auxiliary** path started failing:

1. **`web_extract` timeouts (the real bug).** `web_extract` fires **N parallel** LLM calls (one per fetched page, `asyncio.gather` in `tools/web_tools.py`) on 13k–28k-char inputs. The single-slot local llama-server serializes them until they exceed the timeout.
2. **Circular/broken fallback.** Auxiliary tasks do **not** use the global `fallback_providers` — they use a per-task `auxiliary.<task>.fallback_chain`. With none configured, Hermes fell back to the "main agent model" (= `custom:local`, the thing that just timed out) via a path that couldn't resolve credentials → `custom/main … no endpoint credentials found` → "all fallbacks exhausted".
3. **`no resolvable api_key` warnings** (spam). The custom providers had no `api_key`/`key_env`, so the auxiliary client used the `no-key-required` placeholder and warned.

## What

All in `kubernetes/apps/ai/hermes/app/resources/config.yaml`:
- Add `api_key: no-key-required` to both custom providers (`gateway` injects the real key upstream so the literal is never sent; `local`'s `internal-noauth` route is keyless). Silences the warning and satisfies fallback credential resolution.
- Route **all** aux chores (`web_extract` / `compression` / `session_search` / `title_generator`) to **kimi** via the gateway — handles concurrency, low per-task volume. `web_extract` + `compression` get a per-task `fallback_chain` to Grok (also parallel-capable).
- `vision` stays on Grok (local 35B is text-only).

**Unchanged:** main loop stays on `custom:local`; global `fallback_providers` (kimi → grok) is the main-loop fallback; `memory.provider: agentmemory`, MCP/toolhive, SearXNG, and `SUMMARY_LLM_*` all untouched.

Source for the root-cause analysis: read live from the running image — `agent/auxiliary_client.py` (`resolve_provider_client`, `_try_configured_fallback_chain`, `_try_main_agent_model_fallback`), `tools/web_tools.py`, `hermes_cli/config.py` (`_KNOWN_KEYS` includes `api_key`).

## Verify after merge
- `kubectl -n ai logs deploy/hermes -c app --since=5m | grep -i "no resolvable api_key"` → empty.
- Trigger a web-research turn → `tools.web_tools: Content processed …` with no `connection error on custom:local` / `all fallbacks exhausted`; aux calls land on the gateway, not the local llama.cpp pod.
- A normal chat still generates on the local model (~60 t/s) — only aux moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)