### PR TITLE
fix(hermes): use api_key that survives the providers migration

### DIFF
--- a/kubernetes/apps/ai/hermes/app/resources/config.yaml
+++ b/kubernetes/apps/ai/hermes/app/resources/config.yaml
@@ -8,23 +8,27 @@
 custom_providers:
   # OpenCode Go (open models) via the internal agentgateway. The keyless
   # internal-noauth gateway injects the real opencodego key upstream, so the
-  # `api_key` below is a dummy placeholder — it's never sent on the wire (the
-  # gateway overrides Authorization). It exists only so the auxiliary client can
-  # resolve a credential: without it Hermes logs "no resolvable api_key" warnings
-  # and its fallback credential check fails. Referenced elsewhere as `custom:gateway`.
+  # `api_key` below is a dummy — it's never sent on the wire (the gateway
+  # overrides Authorization). It exists only so the auxiliary client can resolve
+  # a credential: without it Hermes logs "no resolvable api_key" warnings.
+  # NOTE: the value must NOT be `no-key-required`/`no-key`/`` — Hermes' v11→12
+  # config migration (custom_providers→providers dict) drops exactly those
+  # sentinels, so the key would vanish and the warning return. `no-auth` survives.
+  # Referenced elsewhere as `custom:gateway`.
   - name: gateway
     base_url: http://internal-noauth.ai.svc.cluster.local/opencodego/v1
-    api_key: no-key-required
+    api_key: no-auth
     api_mode: chat_completions
   # Local Qwen3.6-35B-A3B on the B70 (llama.cpp SYCL, ~74 t/s) via the gateway's
   # /vllm route. Free and rate-limit-proof; llama-server is single-slot, so
   # concurrent requests queue. The keyless internal-noauth route needs no auth;
   # `api_key` is a dummy to satisfy the auxiliary client's credential resolution
   # (silences the no-key warning, no 401 since the route is unauthenticated).
+  # Same migration caveat as above — `no-auth`, never the `no-key-required` sentinel.
   # Referenced as `custom:local`.
   - name: local
     base_url: http://internal-noauth.ai.svc.cluster.local/vllm/v1
-    api_key: no-key-required
+    api_key: no-auth
     api_mode: chat_completions
 
 # Default serving model: the local Qwen3.6-35B-A3B on the B70 (custom:local ->


### PR DESCRIPTION
## Why

The `api_key: no-key-required` I added in #990 to silence the auxiliary client's `no resolvable api_key` warnings was **silently dropped** by Hermes' config migration. `migrate_config()` (v11→12, `custom_providers:` list → `providers:` dict) copies the key only when:

```python
if old_key and old_key not in {"no-key", "no-key-required", ""}:
    new_entry["api_key"] = old_key
```

`no-key-required` is exactly one of the stripped sentinels, so it never reached the post-migration `providers:` dict — I confirmed the live `/opt/data/config.yaml` had `gateway`/`local` with no `api_key`, meaning the warning would return on the next aux call. (The migration also doesn't carry `key_env`, so that's not an alternative.)

## What

Use `api_key: no-auth` on both custom providers — not in the drop-set, so it survives migration and satisfies the runtime credential check. The value is never sent upstream: the agentgateway injects the real opencodego key for `/opencodego` (which is why the placeholder worked at all), and `/vllm` is keyless. Comment added warning future editors off the `no-key-required` sentinel.

## Verify after merge
- Migrated config keeps the key: `kubectl -n ai exec deploy/hermes -c app -- sh -c "sed -n '1,15p' /opt/data/config.yaml"` shows `api_key: no-auth` under `providers.gateway` and `providers.local`.
- Trigger an aux task (web search) → `kubectl -n ai logs deploy/hermes -c app --since=5m | grep -c "no resolvable api_key"` → `0`.
- kimi aux + local main both still respond.

🤖 Generated with [Claude Code](https://claude.com/claude-code)