### PR TITLE
fix(hermes): use glm-5.1 as the gateway fallback tool-caller

### DIFF
--- a/kubernetes/apps/ai/hermes/README.md
+++ b/kubernetes/apps/ai/hermes/README.md
@@ -41,10 +41,12 @@ are overwritten on the next restart.
 | `xai-oauth` (native, `grok-4.3`) | direct to xAI, bypassing the gateway | OAuth (Grok subscription, see below) |
 
 `config.yaml` also sets:
-- **Fallback chain** — `custom:local/qwen3.6-35b-a3b` → `custom:gateway/kimi-k2.6` →
+- **Fallback chain** — `custom:local/qwen3.6-35b-a3b` → `custom:gateway/glm-5.1` →
   `xai-oauth/grok-4.3`, so a local outage (e.g. ComfyUI scaling `vllm` to 0 under the
   Dedicated-VRAM runbook) doesn't kill the session. The local default is free and
   rate-limit-proof, so long tasks don't hit the xAI throttle or OpenCode-Go limits.
+  The gateway fallback uses `glm-5.1` (strongest tool-caller on the Go sub) rather than
+  kimi, since the fallback runs the full agentic tool-calling loop.
 - **Auxiliary routing** — compression / web_extract / session_search / title run on kimi
   via the gateway, **not** the local model: `web_extract` fires N parallel LLM calls (one
   per page) that the single-slot local server can't serve concurrently (they time out).

--- a/kubernetes/apps/ai/hermes/app/resources/config.yaml
+++ b/kubernetes/apps/ai/hermes/app/resources/config.yaml
@@ -39,13 +39,17 @@ model:
   default: qwen3.6-35b-a3b
   provider: custom:local
 
-# Fail-over chain: if the local B70 model errors or is unavailable (e.g. ComfyUI
-# scaled vllm to 0 under the Dedicated-VRAM runbook), fall back to kimi via the
-# gateway, then to Grok (xai-oauth subscription; creds added once with
-# `hermes auth add xai-oauth --manual-paste`, kept in /opt/data/auth.json).
+# Fail-over chain for the MAIN agentic loop: if the local B70 model errors or is
+# unavailable (e.g. ComfyUI scaled vllm to 0 under the Dedicated-VRAM runbook),
+# fall back to glm-5.1 via the gateway, then to Grok (xai-oauth subscription;
+# creds added once with `hermes auth add xai-oauth --manual-paste`, kept in
+# /opt/data/auth.json). glm-5.1 is the strongest tool-caller on the OpenCode-Go
+# sub (tops τ²-bench / BFCL agentic vs kimi/deepseek/qwen), which matters because
+# this fallback runs the full tool-calling loop. The aux chores below stay on
+# kimi-k2.6 — they only summarise content, they don't tool-call.
 fallback_providers:
   - provider: custom:gateway
-    model: kimi-k2.6
+    model: glm-5.1
   - provider: xai-oauth
     model: grok-4.3
 


### PR DESCRIPTION
## Why

The main agentic loop runs on the local B70 model (`custom:local`). The OpenCode-Go gateway model only takes over on the **fallback** path — and there it runs Hermes' full **tool-calling** loop. So the gateway fallback should be the strongest *tool-caller* available on the Go sub.

Per current (June 2026) agentic/tool-calling benchmarks, **glm-5.1** edges the field (τ²-bench / BFCL agentic, native function calling, "agentic engineering" focus) ahead of kimi/deepseek/qwen. Aux chores (`web_extract`/`compression`/…) only summarise content — they don't tool-call — so they **stay on kimi-k2.6**.

## What
- `fallback_providers[0]`: `kimi-k2.6` → **`glm-5.1`** (gateway). Chain is now local → glm-5.1 → grok.
- Aux routing unchanged (kimi-k2.6).
- README fallback bullet updated.

Verified `glm-5.1` routes via the gateway (HTTP 200, served as `frank/GLM-5.1`, `$0` marginal on the Go sub).

## Note
These are post-cutoff model versions, so the ranking leans on third-party leaderboards + vendor numbers — glm-5.1 ≈ kimi-k2.6, both top-tier; glm edges per-call tool accuracy, kimi edges long-horizon stability. Trivially reversible if glm-5.1 underperforms in practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)