### PR TITLE
feat(kube-system): disable MGLRU via DaemonSet (kernel-6.18.3 OOM regression)

### DIFF
--- a/kubernetes/apps/kube-system/kustomization.yaml
+++ b/kubernetes/apps/kube-system/kustomization.yaml
@@ -13,6 +13,7 @@ resources:
   - ./coredns/ks.yaml
   - ./descheduler/ks.yaml
   - ./metrics-server/ks.yaml
+  - ./mglru-disable/ks.yaml
   - ./multus/ks.yaml
   - ./reloader/ks.yaml
   - ./snapshot-controller/ks.yaml

--- a/kubernetes/apps/kube-system/mglru-disable/app/daemonset.yaml
+++ b/kubernetes/apps/kube-system/mglru-disable/app/daemonset.yaml
@@ -1,0 +1,62 @@
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: mglru-disable
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/name: mglru-disable
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mglru-disable
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: mglru-disable
+    spec:
+      # Node-level kernel tuning: disable Multi-Gen LRU (MGLRU) to avoid the
+      # kernel-6.18.3 MGLRU OOM-kill regression (false OOM with reclaimable memory
+      # free) that took down talos-3's OSDs on 2026-06-17 under the B70/vLLM host-RAM
+      # load. /sys/kernel/mm/lru_gen/enabled is sysfs (not a sysctl), so it must be
+      # written from a privileged pod; the loop re-applies on boot + periodically.
+      # Remove this once on a kernel that carries the MGLRU fix (post 6.18.3).
+      # See docs/ceph-cluster-changelog.md [2026-06-17].
+      priorityClassName: system-node-critical
+      automountServiceAccountToken: false
+      hostPID: false
+      tolerations:
+        - operator: Exists
+      containers:
+        - name: mglru-disable
+          image: docker.io/library/busybox:1.36
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -eu
+              while true; do
+                if [ -w /host-sys/kernel/mm/lru_gen/enabled ]; then
+                  echo 0 > /host-sys/kernel/mm/lru_gen/enabled 2>/dev/null || true
+                fi
+                sleep 300
+              done
+          securityContext:
+            privileged: true
+            runAsUser: 0
+          resources:
+            requests:
+              cpu: 1m
+              memory: 16Mi
+            limits:
+              memory: 32Mi
+          volumeMounts:
+            - name: sys
+              mountPath: /host-sys
+      volumes:
+        - name: sys
+          hostPath:
+            path: /sys
+            type: Directory

--- a/kubernetes/apps/kube-system/mglru-disable/app/kustomization.yaml
+++ b/kubernetes/apps/kube-system/mglru-disable/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./daemonset.yaml

--- a/kubernetes/apps/kube-system/mglru-disable/ks.yaml
+++ b/kubernetes/apps/kube-system/mglru-disable/ks.yaml
@@ -1,0 +1,20 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app mglru-disable
+  namespace: &namespace kube-system
+spec:
+  interval: 1h
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/kube-system/mglru-disable/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  wait: false


### PR DESCRIPTION
Persistent, **no-reboot** mitigation for the confirmed **kernel-6.18.3 MGLRU OOM-kill regression** that took down talos-3's OSDs on 2026-06-17 (false OOM while reclaimable memory is free, under the B70/vLLM host-RAM load).

A small privileged DaemonSet writes `/sys/kernel/mm/lru_gen/enabled=0` on every node at boot + every 5 min. `lru_gen/enabled` is sysfs (not a sysctl), so a privileged pod is required. This replaces the ephemeral runtime disable I applied during recovery (which resets on reboot).

**Remove** once on a kernel carrying the MGLRU fix (post 6.18.3). Context: `docs/ceph-cluster-changelog.md` [2026-06-17].

- kustomize build validated; Flux Kustomization wired into the kube-system namespace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)