### PR TITLE
feat(downloads): grow sabnzbd-incomplete scratch 500Gi -> 1.5Ti

### DIFF
--- a/kubernetes/apps/downloads/pvc/app/sabnzbd-incomplete.yaml
+++ b/kubernetes/apps/downloads/pvc/app/sabnzbd-incomplete.yaml
@@ -16,5 +16,8 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 500Gi
+      # 1.5Ti: 500Gi filled during large UHD batches (par2 + multi-file assembly),
+      # pausing downloads on low free space. ceph-blockpool has the headroom and the
+      # scratch is transient, so the reservation only consumes space when actually used.
+      storage: 1500Gi
   storageClassName: ceph-block


### PR DESCRIPTION
## What
Raise the `sabnzbd-incomplete` PVC (SABnzbd article-assembly scratch / `download_dir`) from **500Gi → 1.5Ti** on `ceph-block`.

## Why
500Gi was filling during large UHD batches (par2 set + multi-file assembly), tripping SABnzbd's low-free-space guard so downloads **constantly paused** for "not enough space."

## Safety
- `ceph-blockpool` has **2.1Ti MAX AVAIL** (replication-adjusted) — plenty of headroom.
- Scratch is **transient + thin-provisioned**: the reservation only consumes space when actually written.
- `ceph-block` has `allowVolumeExpansion: true`; RBD online expansion is a lightweight metadata + filesystem-resize op (**no backfill**), safe even under the current slow-ops state.

Flux reconcile after merge triggers the online resize on the live PVC (pod stays running).

🤖 Generated with [Claude Code](https://claude.com/claude-code)