### PR TITLE
fix(sabnzbd): keep off memory-starved talos-1 until RAM RMA

### DIFF
--- a/kubernetes/apps/downloads/sabnzbd/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/sabnzbd/app/helmrelease.yaml
@@ -125,6 +125,20 @@ spec:
                   - ALL
 
     defaultPodOptions:
+      # TEMPORARY: talos-1 is running on ~47Gi (single stick) pending the bad-RAM
+      # (Stick B) RMA. Under memory-PSI pressure Talos's runtime.OOMController
+      # repeatedly SIGKILLs sabnzbd's cgroup (par2/post-processing is the largest
+      # growing consumer there). Pin away from talos-1 until full RAM is restored,
+      # then REMOVE this affinity block. See docs/hardware-incidents.md (2026-06-19/20).
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/hostname
+                    operator: NotIn
+                    values:
+                      - talos-1
       topologySpreadConstraints:
         - maxSkew: 2
           topologyKey: kubernetes.io/hostname


### PR DESCRIPTION
## Problem

sabnzbd has been in `CrashLoopBackOff` (48+ restarts, ~4.5h). The app starts and connects to Usenet, then is `SIGKILL`'d (exit 137, reason `Error`) every ~5 minutes.

**Root cause is not PR #1057** (the `sabnzbd-incomplete` 500Gi→1.5Ti grow applied correctly — PVC bound at 1500Gi on `ceph-block` RWO). The kills come from **Talos''s userspace `runtime.OOMController`** firing on memory-PSI pressure and SIGKILLing the sabnzbd pod cgroup (`pod95a730ea…`, UID confirmed). No K8s `OOMKilling` event is emitted because Talos kills the cgroup out-of-band.

talos-1 is currently running on **~47 GiB** (`MemTotal 49,029,504 Ki`) vs **~94 GiB** on talos-2/talos-3 — the reduced-RAM state pending the bad-RAM (Stick B) RMA. On that densely-packed, memory-starved node, sabnzbd (whose memory grows during par2/post-processing) is the cgroup the OOMController keeps selecting.

## Change

Add a hard node anti-affinity to keep sabnzbd off talos-1 until full RAM is restored. talos-2/talos-3 have ~65–80 GiB free, so a hard exclusion is safe. Matches the `affinity.nodeAffinity` idiom already used by `kube-system/coredns`.

## Cleanup

**Remove the `affinity` block once talos-1 is back to full RAM** after the Stick B RMA. See `docs/hardware-incidents.md` (2026-06-19/20).

## Verification (post-merge)

- `kubectl -n downloads get pods -l app.kubernetes.io/name=sabnzbd -o wide` → Running 1/1 on talos-2 or talos-3, restarts flat.
- `talosctl -n 10.10.10.11 dmesg | grep "Sending SIGKILL to cgroup"` → no new entries for the new pod UID.

🤖 Generated with [Claude Code](https://claude.com/claude-code)