### PR TITLE
fix(linkwarden): raise app limits 1536Mi/1cpu -> 4Gi/2cpu (Chromium archive OOM loop)

### DIFF
--- a/kubernetes/apps/selfhosted/linkwarden/app/helmrelease.yaml
+++ b/kubernetes/apps/selfhosted/linkwarden/app/helmrelease.yaml
@@ -58,8 +58,8 @@ spec:
                 cpu: 250m
                 memory: 512Mi
               limits:
-                cpu: "1"
-                memory: 1536Mi
+                cpu: "2"
+                memory: 4Gi
             probes:
               liveness: &probes
                 enabled: true


### PR DESCRIPTION
## Problem
`selfhosted/linkwarden` has been in CrashLoopBackOff for ~8 days (**481 restarts**). Root cause is a deterministic **poison-link OOM**, confirmed from logs:

- Every boot the worker picks up the **same single unpreserved link** (`https://countryboycomputersbg.com/instinct-mi50-32gb-vs-radeon-pro-v620-32gb/`), launches headless Chromium (Playwright) to archive it, and the container cgroup exceeds the **1536Mi** memory limit → kernel **OOMKilled** (exit 137) ~40s after start.
- The Next.js web frontend (`[0]`) and the archival worker (`[1]`) run in the **same `app` container/cgroup**, so the worker OOM takes down the whole pod — the UI is down, not just archiving.
- It can't self-heal: the failing job is retried indefinitely (poison pill).

## Change
`kubernetes/apps/selfhosted/linkwarden/app/helmrelease.yaml` — container `app` `resources.limits`:

| | before | after |
|---|---|---|
| `memory` | `1536Mi` | **`4Gi`** |
| `cpu` | `"1"` | **`"2"`** |

`requests` unchanged (`250m` / `512Mi`) — idle footprint and scheduler reservation stay the same; only the burst ceiling rises. 1536Mi is too tight for Chromium-based page archiving; with real headroom the archive job should complete and **clear the stuck link on its own**, ending the loop.

## Verification (post-merge)
- New pod goes `1/1 Running` and restart count **stops climbing**.
- `kubectl -n selfhosted logs deploy/linkwarden | grep countryboycomputers` → appears once, followed by normal operation (no SIGKILL).
- `lastState` no longer shows `reason: OOMKilled`.
- `https://links.${SECRET_DOMAIN}/` returns 200/307.

## Fallback
If it still OOMs at 4Gi, that page is genuinely pathological (infinite-scroll/huge media) — delete just that one link via the Linkwarden API to unblock the queue instead of raising memory further.

🤖 Generated with [Claude Code](https://claude.com/claude-code)