### PR TITLE
fix(linkwarden): point auto-tagging to local B70 model + raise monolith buffer

### DIFF
--- a/kubernetes/apps/selfhosted/linkwarden/app/helmrelease.yaml
+++ b/kubernetes/apps/selfhosted/linkwarden/app/helmrelease.yaml
@@ -46,9 +46,14 @@ spec:
               NEXTAUTH_URL: "https://links.${SECRET_DOMAIN}"
               NEXT_PUBLIC_DISABLE_REGISTRATION: "true"
               NEXT_PUBLIC_CREDENTIALS_ENABLED: "true"
-              # AI tagging via AgentGateway -> OpenRouter
-              CUSTOM_OPENAI_BASE_URL: "http://internal-noauth.ai.svc.cluster.local/openrouter/v1"
-              OPENAI_MODEL: "google/gemini-2.0-flash-lite-001"
+              # Full-page Monolith archive: raise output buffer above the 100MB
+              # default (one image-heavy page overflowed it -> partial archive).
+              MONOLITH_MAX_BUFFER: "256"
+              # AI auto-tagging via AgentGateway -> local B70 model (llama.cpp, /vllm).
+              # OPENAI_API_KEY (= OpenRouter key) is ignored by the keyless LAN gateway,
+              # but the OpenAI SDK still requires a non-empty value to be present.
+              CUSTOM_OPENAI_BASE_URL: "http://internal-noauth.ai.svc.cluster.local/vllm/v1"
+              OPENAI_MODEL: "qwen3.6-35b-a3b"
             envFrom: *envFrom
             ports:
               - name: http


### PR DESCRIPTION
Follow-up to #1060. Two non-fatal issues surfaced in the linkwarden worker logs once the OOM loop was fixed:

## 1. AI auto-tagging → local model
The worker hit `No endpoints found for google/gemini-2.0-flash-lite-001` (OpenRouter 404). Repointed to our own B70 model:

| env | before | after |
|---|---|---|
| `CUSTOM_OPENAI_BASE_URL` | `…/openrouter/v1` | `http://internal-noauth.ai.svc.cluster.local/vllm/v1` |
| `OPENAI_MODEL` | `google/gemini-2.0-flash-lite-001` | `qwen3.6-35b-a3b` |

`/vllm/v1` is the keyless LAN agentgateway route to the local llama.cpp model on the B70 (same path Hermes uses as `custom:local`). Free, no external dependency. `OPENAI_API_KEY` is left set (OpenRouter key) purely because the OpenAI SDK requires a non-empty key; the LAN gateway ignores it.

## 2. Monolith archive buffer
`Error: Monolith output exceeded buffer limit` — one image-heavy page overflowed the **100MB** default, leaving a partial full-page archive. Raised `MONOLITH_MAX_BUFFER` `100 → 256` (MB). Comfortably within the 4Gi container limit from #1060.

## Verification (post-merge)
- `kubectl -n selfhosted logs deploy/linkwarden | grep -iE "auto-tagging|monolith"` → auto-tagging succeeds (no 404), no monolith buffer error.
- Tags appear on newly-processed links in the UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)