### PR TITLE
fix(agentgateway): bump to v1.3.0 (standalone line) + pin renovate off v2.x

### DIFF
--- a/.renovate/overrides.json5
+++ b/.renovate/overrides.json5
@@ -46,5 +46,20 @@
       ],
       allowedVersions: "<1.13.3",
     },
+    {
+      // This registry hosts TWO distinct lineages under the same repo, and
+      // Renovate's OCI datasource picks the numerically-highest tag across both:
+      //   - standalone agentgateway (1.x, agentgateway.dev/v1alpha1 CRDs) -> what we run
+      //   - kgateway-bundled distribution (v2.2.x) -> different control plane,
+      //     namespace agentgateway-system, requires a full TrafficPolicy migration.
+      // The v2.2.x bump (#946/#947) would swap out the whole gateway. Stay on the
+      // standalone 1.x line (latest v1.3.0); upgrade across lineages by hand only.
+      description: "Pin agentgateway to the standalone 1.x lineage (<2.0.0)",
+      matchPackageNames: [
+        "cr.agentgateway.dev/charts/agentgateway",
+        "cr.agentgateway.dev/charts/agentgateway-crds",
+      ],
+      allowedVersions: "<2.0.0",
+    },
   ],
 }

--- a/kubernetes/apps/ai/agentgateway/app/ocirepository.yaml
+++ b/kubernetes/apps/ai/agentgateway/app/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 1.2.1
+    tag: v1.3.0
   url: oci://cr.agentgateway.dev/charts/agentgateway

--- a/kubernetes/apps/ai/agentgateway/crds/ocirepository.yaml
+++ b/kubernetes/apps/ai/agentgateway/crds/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 1.2.1
+    tag: v1.3.0
   url: oci://cr.agentgateway.dev/charts/agentgateway-crds


### PR DESCRIPTION
## What

- Bump `agentgateway` + `agentgateway-crds` OCIRepository tags `1.2.1` → `v1.3.0`.
- Pin Renovate to `<2.0.0` for both charts in `.renovate/overrides.json5`.

## Why — supersedes #946 / #947

Renovate's OCI datasource sees two **different product lineages** under the same registry repo and picked the numerically-highest tag (`v2.2.1`):

| Lineage | Tags | What it is |
| --- | --- | --- |
| **Standalone agentgateway** (what we run) | `1.2.1`, `v1.3.0` | `agentgateway.dev/v1alpha1` CRDs (`AgentgatewayBackend`/`Policy`/`Parameters`) |
| **kgateway-bundled** | `v2.2.x` | Different control plane: namespace `agentgateway-system`, controller `agentgateway.dev/agentgateway`, requires a full `TrafficPolicy` migration |

Merging #946/#947 (`→ v2.2.1`) would swap our gateway for a different distribution and almost certainly break the whole `ai` stack (hermes, agentmemory, open-webui, the external `llm-api`, and linkwarden's AI tagging all route through it). The correct upgrade on our line is **v1.3.0** (agentgateway project's latest; there is no v2.2.1 in that project). The `<2.0.0` pin stops Renovate from crossing lineages again.

## Validation

- v1.3.0 CRD chart pulls cleanly (`helm pull … --version v1.3.0`).
- All **25** `AgentgatewayBackend`/`Policy`/`Parameters` CRs are **kubeconform-clean** against the v1.3.0 CRD schemas (Valid: 26, Invalid: 0).
- v1.3.0 changelog is additive-only — no removed Helm values or CRD fields. The one behavioral change ("do not evict when health is configured without eviction") doesn't affect us: our `llm-chat-failover-health` policy has eviction configured.

## Follow-up

Closes #946 and #947 (will close explicitly after merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)