### PR TITLE
fix(agentgateway): redirect / to /ui after v1.3.0 dashboard move

### DIFF
--- a/kubernetes/apps/ai/agentgateway/app/httproute-internal.yaml
+++ b/kubernetes/apps/ai/agentgateway/app/httproute-internal.yaml
@@ -22,6 +22,20 @@ spec:
       namespace: network
       sectionName: https
   rules:
+    # agentgateway v1.3.0 serves the dashboard at /ui (the backend 308-redirects
+    # bare / to an http:// URL, which dead-ends behind the TLS gateway). Issue a
+    # clean same-scheme redirect to /ui/ at the gateway so the hostname works.
+    - matches:
+        - path:
+            type: Exact
+            value: /
+      filters:
+        - type: RequestRedirect
+          requestRedirect:
+            path:
+              type: ReplaceFullPath
+              replaceFullPath: /ui/
+            statusCode: 302
     - backendRefs:
         - name: agentgateway-admin-ui
           namespace: ai

--- a/kubernetes/apps/ai/agentgateway/app/httproute.yaml
+++ b/kubernetes/apps/ai/agentgateway/app/httproute.yaml
@@ -22,6 +22,20 @@ spec:
       namespace: network
       sectionName: https
   rules:
+    # agentgateway v1.3.0 serves the dashboard at /ui (the backend 308-redirects
+    # bare / to an http:// URL, which dead-ends behind the TLS gateway). Issue a
+    # clean same-scheme redirect to /ui/ at the gateway so the hostname works.
+    - matches:
+        - path:
+            type: Exact
+            value: /
+      filters:
+        - type: RequestRedirect
+          requestRedirect:
+            path:
+              type: ReplaceFullPath
+              replaceFullPath: /ui/
+            statusCode: 302
     - backendRefs:
         - name: agentgateway-admin-ui
           port: 15000


### PR DESCRIPTION
## Problem

After the v1.3.0 bump (#1062), the AgentGateway dashboard became unreachable at `agentgateway.${SECRET_DOMAIN}` and `llm.${SECRET_DOMAIN}`.

**Cause:** v1.3.0 serves its "purpose-built UI" at **`/ui`** (was `/` in v1.2.x). The admin server 308-redirects bare `/` to an **`http://`** URL; behind the `envoy-internal` TLS gateway that scheme downgrade dead-ends. Verified via port-forward: `GET /` → `308 → http://…/ui`, `GET /ui` → `200`.

## Fix

Add a gateway-level **Exact-`/` `RequestRedirect` (302) → `/ui/`** on both admin-UI HTTPRoutes (`httproute.yaml`, `httproute-internal.yaml`). Scheme/host are preserved, so the bare hostname now lands on the dashboard. All other paths still proxy to `agentgateway-admin-ui:15000` (so `/ui` and its assets keep working).

The Gatus health-checks already target `/ui/`, so monitoring was unaffected.

## Validation

- `kustomize build` + `kubeconform` (Gateway API schema): 71/71 valid.
- Both routes now render 2 rules with `filters[0].type: RequestRedirect`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)