### PR TITLE
feat(ai): migrate clients to the unified /v1 endpoint + groq fix

### DIFF
--- a/kubernetes/apps/ai/agentgateway/app/httproute-unified.yaml
+++ b/kubernetes/apps/ai/agentgateway/app/httproute-unified.yaml
@@ -116,7 +116,10 @@ spec:
         - name: mistral
           group: agentgateway.dev
           kind: AgentgatewayBackend
-    # --- Groq (open-weight families hosted on Groq) ---
+    # --- Groq (open-weight families hosted on Groq). Groq's OpenAI-compatible
+    #     API lives at api.groq.com/openai/v1/... so prepend the /openai prefix
+    #     here — the unified route forwards /v1/... unchanged, whereas the legacy
+    #     /groq route injects /openai via its own ReplacePrefixMatch. ---
     - matches:
         - path:
             type: PathPrefix
@@ -125,6 +128,12 @@ spec:
             - type: RegularExpression
               name: x-model
               value: "^(llama|mixtral|gemma|moonshotai|allam|compound).*"
+      filters:
+        - type: URLRewrite
+          urlRewrite:
+            path:
+              type: ReplacePrefixMatch
+              replacePrefixMatch: /openai/v1/chat/completions
       backendRefs:
         - name: groq
           group: agentgateway.dev

--- a/kubernetes/apps/ai/open-notebook/app/externalsecret.yaml
+++ b/kubernetes/apps/ai/open-notebook/app/externalsecret.yaml
@@ -35,8 +35,12 @@ spec:
         # Optional: Security
         OPEN_NOTEBOOK_PASSWORD: "{{ .OPEN_NOTEBOOK_PASSWORD }}"
         # Application settings
-        # OpenAI via agentgateway (path-per-provider; client appends /v1/...)
-        OPENAI_COMPATIBLE_BASE_URL: "http://internal-noauth.ai.svc.cluster.local/openai"
+        # Unified model-routing endpoint via agentgateway (root base URL; the
+        # client appends /v1/...). One endpoint serves every provider — the
+        # gateway routes by the request `model` field, so set Open-Notebook's
+        # models (in-app) to routable ids: gpt-*/claude-*/gemini-*/grok-*/
+        # deepseek-*/qwen3.6-35b-a3b/llama-*.
+        OPENAI_COMPATIBLE_BASE_URL: "http://internal-noauth.ai.svc.cluster.local"
         LOG_LEVEL: "INFO"
         MAX_UPLOAD_SIZE: "100MB"
         ENABLE_ANALYTICS: "false"

--- a/kubernetes/apps/ai/open-webui/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/open-webui/app/helmrelease.yaml
@@ -47,14 +47,16 @@ spec:
               ENABLE_FORWARD_USER_INFO_HEADERS: true
               ENABLE_OLLAMA_API: false
               ENABLE_OPENAI_API: true
-              # internal-noauth gateway requires no auth — it injects real provider keys
-              OPENAI_API_BASE_URLS: >-
-                http://internal-noauth.ai.svc.cluster.local/vllm/v1;
-                http://internal-noauth.ai.svc.cluster.local/openai/v1;
-                http://internal-noauth.ai.svc.cluster.local/anthropic/v1;
-                http://internal-noauth.ai.svc.cluster.local/groq/v1;
-                http://internal-noauth.ai.svc.cluster.local/gemini/v1
-              OPENAI_API_KEYS: "nokey;nokey;nokey;nokey;nokey"
+              # Single unified model-routing endpoint (keyless internal-noauth
+              # gateway injects real provider keys). One connection now serves
+              # every provider — the gateway routes by the request `model` field.
+              # NOTE: OPENAI_API_BASE_URLS is a PersistentConfig var, so this env
+              # value applies on a FRESH deploy; on the running instance update it
+              # once via Settings -> Admin -> Connections (and add the model ids
+              # you want in the picker, since /v1/models lists only the local
+              # model — agentgateway does not aggregate model lists).
+              OPENAI_API_BASE_URLS: http://internal-noauth.ai.svc.cluster.local/v1
+              OPENAI_API_KEYS: nokey
               ENABLE_RAG_WEB_SEARCH: true
               ENABLE_SEARCH_QUERY: true
               # RAG_EMBEDDING_ENGINE: sentence-transformers

--- a/kubernetes/apps/ai/perplexica/app/externalsecret.yaml
+++ b/kubernetes/apps/ai/perplexica/app/externalsecret.yaml
@@ -30,11 +30,16 @@ spec:
           API_KEY = ""
 
           [MODELS.CUSTOM_OPENAI]
-          # agentgateway internal-noauth injects the real provider key; the
-          # client just needs a non-empty placeholder.
+          # Unified model-routing endpoint (keyless internal-noauth gateway
+          # injects the real provider key). Root base URL — Perplexica appends
+          # /v1/chat/completions itself. The gateway routes by MODEL_NAME, and it
+          # does NOT aggregate /v1/models, so pin a routable model rather than
+          # relying on discovery. Any unified id works: gpt-*/claude-*/gemini-*/
+          # grok-*/deepseek-*/qwen3.6-35b-a3b/llama-*. Default kept on OpenAI
+          # (Perplexica's prior CUSTOM_OPENAI provider) — change to taste.
           API_KEY = "agentgateway-noauth"
-          API_URL = "http://internal-noauth.ai.svc.cluster.local/openai"
-          MODEL_NAME = ""
+          API_URL = "http://internal-noauth.ai.svc.cluster.local"
+          MODEL_NAME = "gpt-4o-mini"
 
           [MODELS.OLLAMA]
           API_URL = "" # Ollama API URL - http://ollama.${SECRET_DOMAIN}:11434


### PR DESCRIPTION
## What & why

Phase 3 follow-up to #1065. Moves the flexible AI clients off the per-provider paths onto the single unified model-routing endpoint, and fixes Groq on that endpoint.

## Changes (2 commits)

1. **`fix` — Groq on the unified endpoint.** Groq's OpenAI API is at `api.groq.com/openai/v1/...`; the unified route forwarded `/v1/...` straight through, so groq-hosted models 404'd (`Unknown request URL`). Added a `URLRewrite` filter to the groq rule that prepends `/openai`, mirroring the legacy `/groq` route. (Found during the #1065 live test — every other family already routed correctly.)
2. **`feat` — point clients at `/v1`.**
   - **open-webui**: 5 base URLs → 1 (`…/v1`).
   - **perplexica**: `CUSTOM_OPENAI` → root base URL, `MODEL_NAME` pinned to `gpt-4o-mini`.
   - **open-notebook**: `OPENAI_COMPATIBLE_BASE_URL` → root base URL.

   **Unchanged:** Hermes (deliberate `/vllm` + `/opencodego` failover split) and agentmemory (already subsumed by the unified route).

## ⚠️ Manual step required for Open-WebUI
`OPENAI_API_BASE_URLS` is a **PersistentConfig** var — Open-WebUI stores it in its DB and ignores the env on restart. So after merge:
1. Open-WebUI → **Settings → Admin → Connections** → set the single OpenAI connection to `http://internal-noauth.ai.svc.cluster.local/v1` (key: any non-empty, e.g. `nokey`); remove the other 4.
2. Add the model ids you want in the picker (e.g. `qwen3.6-35b-a3b`, `gpt-4o`, `claude-sonnet-4-6`, `gemini-2.5-flash`, `grok-4`, `deepseek-chat`, `llama-3.3-70b-versatile`) — the unified endpoint can't auto-list them (no `/v1/models` aggregation).

The Git env value takes effect on a fresh deploy / config reset.

## Verify after merge
- Groq on unified (was the only broken family): `curl …/v1/chat/completions -d '{"model":"llama-3.3-70b-versatile","messages":[{"role":"user","content":"hi"}],"max_tokens":5}'` → 200.
- Perplexica search returns answers; Open-Notebook chat works (set its in-app model to a routable id).
- agentmemory / Hermes unaffected.

## Notes / follow-ups
- Perplexica & Open-Notebook are single-model clients, so their model is pinned/in-app rather than discovered.
- **Phase 5** (retire `/openai`,`/anthropic`,`/groq`,`/gemini` once nothing uses them) can proceed after this soaks — but only once the Open-WebUI admin-UI step above is done (it's the last consumer of those paths).

🤖 Generated with [Claude Code](https://claude.com/claude-code)