### PR TITLE
chore(agentgateway): retire internal per-provider paths (keep external)

### DIFF
--- a/kubernetes/apps/ai/agentgateway/app/backends/anthropic.yaml
+++ b/kubernetes/apps/ai/agentgateway/app/backends/anthropic.yaml
@@ -18,11 +18,10 @@ spec:
     - extract:
         key: ai-keys
 ---
-# Single passthrough backend (no model pinned → the client's request-body
-# `model` is forwarded). `Completions` on the /v1/chat/completions suffix makes
-# agentgateway translate OpenAI Chat Completions → Anthropic Messages, so
-# OpenAI-compatible clients (open-webui, the unified /v1 endpoint) work; the
-# native /v1/messages suffix is kept for any native-Anthropic client.
+# Reached via the unified /v1 endpoint (../httproute-unified.yaml) by model name
+# (claude-*). `Completions` on /v1/chat/completions makes agentgateway translate
+# OpenAI Chat Completions -> Anthropic Messages; /v1/messages stays native. The
+# explicit /anthropic path route was retired.
 apiVersion: agentgateway.dev/v1alpha1
 kind: AgentgatewayBackend
 metadata:
@@ -41,28 +40,3 @@ spec:
     auth:
       secretRef:
         name: anthropic-secret
----
-apiVersion: gateway.networking.k8s.io/v1
-kind: HTTPRoute
-metadata:
-  name: anthropic
-spec:
-  parentRefs:
-    - name: internal
-    - name: internal-noauth
-    - name: public
-  rules:
-    - matches:
-        - path:
-            type: PathPrefix
-            value: /anthropic
-      filters:
-        - type: URLRewrite
-          urlRewrite:
-            path:
-              type: ReplacePrefixMatch
-              replacePrefixMatch: /
-      backendRefs:
-        - name: anthropic
-          group: agentgateway.dev
-          kind: AgentgatewayBackend

--- a/kubernetes/apps/ai/agentgateway/app/backends/anthropic.yaml
+++ b/kubernetes/apps/ai/agentgateway/app/backends/anthropic.yaml
@@ -18,10 +18,11 @@ spec:
     - extract:
         key: ai-keys
 ---
-# Reached via the unified /v1 endpoint (../httproute-unified.yaml) by model name
-# (claude-*). `Completions` on /v1/chat/completions makes agentgateway translate
-# OpenAI Chat Completions -> Anthropic Messages; /v1/messages stays native. The
-# explicit /anthropic path route was retired.
+# Internal clients reach this via the unified /v1 endpoint by model name
+# (claude-*); `Completions` translates OpenAI Chat Completions -> Anthropic
+# Messages, /v1/messages stays native. The explicit /anthropic path route is
+# retired from internal/internal-noauth and kept ONLY on the public gateway for
+# the external llm-api.* API.
 apiVersion: agentgateway.dev/v1alpha1
 kind: AgentgatewayBackend
 metadata:
@@ -40,3 +41,26 @@ spec:
     auth:
       secretRef:
         name: anthropic-secret
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: anthropic
+spec:
+  parentRefs:
+    - name: public
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /anthropic
+      filters:
+        - type: URLRewrite
+          urlRewrite:
+            path:
+              type: ReplacePrefixMatch
+              replacePrefixMatch: /
+      backendRefs:
+        - name: anthropic
+          group: agentgateway.dev
+          kind: AgentgatewayBackend

--- a/kubernetes/apps/ai/agentgateway/app/backends/deepseek.yaml
+++ b/kubernetes/apps/ai/agentgateway/app/backends/deepseek.yaml
@@ -18,9 +18,10 @@ spec:
     - extract:
         key: ai-keys
 ---
-# deepseek AgentgatewayBackend (OpenAI-compatible). Reached via the unified /v1
-# endpoint (../httproute-unified.yaml) by model name (deepseek-chat/reasoner).
-# The explicit /deepseek path route was retired.
+# deepseek AgentgatewayBackend (OpenAI-compatible). Internal clients reach this
+# via the unified /v1 endpoint by model name (deepseek-chat/reasoner). The
+# explicit /deepseek path route is retired from internal/internal-noauth and kept
+# ONLY on the public gateway for the external llm-api.* API.
 apiVersion: agentgateway.dev/v1alpha1
 kind: AgentgatewayBackend
 metadata:
@@ -42,3 +43,26 @@ spec:
         "/v1/embeddings": Passthrough
         "/v1/models": Passthrough
         "*": Passthrough
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: deepseek
+spec:
+  parentRefs:
+    - name: public
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /deepseek
+      filters:
+        - type: URLRewrite
+          urlRewrite:
+            path:
+              type: ReplacePrefixMatch
+              replacePrefixMatch: /
+      backendRefs:
+        - name: deepseek
+          group: agentgateway.dev
+          kind: AgentgatewayBackend

--- a/kubernetes/apps/ai/agentgateway/app/backends/deepseek.yaml
+++ b/kubernetes/apps/ai/agentgateway/app/backends/deepseek.yaml
@@ -18,7 +18,9 @@ spec:
     - extract:
         key: ai-keys
 ---
-# deepseek BAgentgatewayBackend (OpenAI-compatible)
+# deepseek AgentgatewayBackend (OpenAI-compatible). Reached via the unified /v1
+# endpoint (../httproute-unified.yaml) by model name (deepseek-chat/reasoner).
+# The explicit /deepseek path route was retired.
 apiVersion: agentgateway.dev/v1alpha1
 kind: AgentgatewayBackend
 metadata:
@@ -40,28 +42,3 @@ spec:
         "/v1/embeddings": Passthrough
         "/v1/models": Passthrough
         "*": Passthrough
----
-apiVersion: gateway.networking.k8s.io/v1
-kind: HTTPRoute
-metadata:
-  name: deepseek
-spec:
-  parentRefs:
-    - name: internal
-    - name: internal-noauth
-    - name: public
-  rules:
-    - matches:
-        - path:
-            type: PathPrefix
-            value: /deepseek
-      filters:
-        - type: URLRewrite
-          urlRewrite:
-            path:
-              type: ReplacePrefixMatch
-              replacePrefixMatch: /
-      backendRefs:
-        - name: deepseek
-          group: agentgateway.dev
-          kind: AgentgatewayBackend

--- a/kubernetes/apps/ai/agentgateway/app/backends/gemini.yaml
+++ b/kubernetes/apps/ai/agentgateway/app/backends/gemini.yaml
@@ -18,6 +18,8 @@ spec:
     - extract:
         key: ai-keys
 ---
+# Reached via the unified /v1 endpoint (../httproute-unified.yaml) by model name
+# (gemini-*). The explicit /gemini path route was retired.
 apiVersion: agentgateway.dev/v1alpha1
 kind: AgentgatewayBackend
 metadata:
@@ -36,28 +38,3 @@ spec:
         "/v1/embeddings": Passthrough
         "/v1/models": Passthrough
         "*": Passthrough
----
-apiVersion: gateway.networking.k8s.io/v1
-kind: HTTPRoute
-metadata:
-  name: gemini
-spec:
-  parentRefs:
-    - name: internal
-    - name: internal-noauth
-    - name: public
-  rules:
-  - matches:
-    - path:
-        type: PathPrefix
-        value: /gemini
-    filters:
-    - type: URLRewrite
-      urlRewrite:
-        path:
-          type: ReplacePrefixMatch
-          replacePrefixMatch: /
-    backendRefs:
-    - name: gemini
-      group: agentgateway.dev
-      kind: AgentgatewayBackend

--- a/kubernetes/apps/ai/agentgateway/app/backends/gemini.yaml
+++ b/kubernetes/apps/ai/agentgateway/app/backends/gemini.yaml
@@ -18,8 +18,10 @@ spec:
     - extract:
         key: ai-keys
 ---
-# Reached via the unified /v1 endpoint (../httproute-unified.yaml) by model name
-# (gemini-*). The explicit /gemini path route was retired.
+# Internal clients reach this via the unified /v1 endpoint by model name
+# (gemini-*). The explicit /gemini path route is retired from
+# internal/internal-noauth and kept ONLY on the public gateway for the external
+# llm-api.* API.
 apiVersion: agentgateway.dev/v1alpha1
 kind: AgentgatewayBackend
 metadata:
@@ -38,3 +40,26 @@ spec:
         "/v1/embeddings": Passthrough
         "/v1/models": Passthrough
         "*": Passthrough
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: gemini
+spec:
+  parentRefs:
+    - name: public
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /gemini
+      filters:
+        - type: URLRewrite
+          urlRewrite:
+            path:
+              type: ReplacePrefixMatch
+              replacePrefixMatch: /
+      backendRefs:
+        - name: gemini
+          group: agentgateway.dev
+          kind: AgentgatewayBackend

--- a/kubernetes/apps/ai/agentgateway/app/backends/groq.yaml
+++ b/kubernetes/apps/ai/agentgateway/app/backends/groq.yaml
@@ -18,10 +18,11 @@ spec:
     - extract:
         key: ai-keys
 ---
-# Groq AgentgatewayBackend (OpenAI-compatible). Reached via the unified /v1
-# endpoint (../httproute-unified.yaml) by model name (llama*/mixtral*/gemma*/...);
-# the unified groq rule prepends /openai (Groq serves at api.groq.com/openai/v1).
-# The explicit /groq path route was retired.
+# Groq AgentgatewayBackend (OpenAI-compatible). Internal clients reach this via
+# the unified /v1 endpoint by model name (llama*/mixtral*/gemma*/...); the
+# unified groq rule prepends /openai (Groq serves at api.groq.com/openai/v1). The
+# explicit /groq path route is retired from internal/internal-noauth and kept
+# ONLY on the public gateway for the external llm-api.* API.
 apiVersion: agentgateway.dev/v1alpha1
 kind: AgentgatewayBackend
 metadata:
@@ -43,3 +44,26 @@ spec:
         "/v1/embeddings": Passthrough
         "/v1/models": Passthrough
         "*": Passthrough
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: groq
+spec:
+  parentRefs:
+    - name: public
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /groq
+      filters:
+        - type: URLRewrite
+          urlRewrite:
+            path:
+              type: ReplacePrefixMatch
+              replacePrefixMatch: /openai
+      backendRefs:
+        - name: groq
+          group: agentgateway.dev
+          kind: AgentgatewayBackend

--- a/kubernetes/apps/ai/agentgateway/app/backends/groq.yaml
+++ b/kubernetes/apps/ai/agentgateway/app/backends/groq.yaml
@@ -18,7 +18,10 @@ spec:
     - extract:
         key: ai-keys
 ---
-# Groq BAgentgatewayBackend (OpenAI-compatible)
+# Groq AgentgatewayBackend (OpenAI-compatible). Reached via the unified /v1
+# endpoint (../httproute-unified.yaml) by model name (llama*/mixtral*/gemma*/...);
+# the unified groq rule prepends /openai (Groq serves at api.groq.com/openai/v1).
+# The explicit /groq path route was retired.
 apiVersion: agentgateway.dev/v1alpha1
 kind: AgentgatewayBackend
 metadata:
@@ -40,28 +43,3 @@ spec:
         "/v1/embeddings": Passthrough
         "/v1/models": Passthrough
         "*": Passthrough
----
-apiVersion: gateway.networking.k8s.io/v1
-kind: HTTPRoute
-metadata:
-  name: groq
-spec:
-  parentRefs:
-    - name: internal
-    - name: internal-noauth
-    - name: public
-  rules:
-  - matches:
-    - path:
-        type: PathPrefix
-        value: /groq
-    filters:
-    - type: URLRewrite
-      urlRewrite:
-        path:
-          type: ReplacePrefixMatch
-          replacePrefixMatch: /openai
-    backendRefs:
-    - name: groq
-      group: agentgateway.dev
-      kind: AgentgatewayBackend

--- a/kubernetes/apps/ai/agentgateway/app/backends/mistral.yaml
+++ b/kubernetes/apps/ai/agentgateway/app/backends/mistral.yaml
@@ -18,10 +18,11 @@ spec:
     - extract:
         key: ai-keys
 ---
-# mistral AgentgatewayBackend (OpenAI-compatible). Reached via the unified /v1
-# endpoint (../httproute-unified.yaml) by model name (mistral-*/magistral/
-# ministral/codestral/pixtral/devstral/open-mi*). The explicit /mistral path
-# route was retired.
+# mistral AgentgatewayBackend (OpenAI-compatible). Internal clients reach this
+# via the unified /v1 endpoint by model name (mistral-*/magistral/ministral/
+# codestral/pixtral/devstral/open-mi*). The explicit /mistral path route is
+# retired from internal/internal-noauth and kept ONLY on the public gateway for
+# the external llm-api.* API.
 apiVersion: agentgateway.dev/v1alpha1
 kind: AgentgatewayBackend
 metadata:
@@ -43,3 +44,26 @@ spec:
         "/v1/embeddings": Passthrough
         "/v1/models": Passthrough
         "*": Passthrough
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: mistral
+spec:
+  parentRefs:
+    - name: public
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /mistral
+      filters:
+        - type: URLRewrite
+          urlRewrite:
+            path:
+              type: ReplacePrefixMatch
+              replacePrefixMatch: /
+      backendRefs:
+        - name: mistral
+          group: agentgateway.dev
+          kind: AgentgatewayBackend

--- a/kubernetes/apps/ai/agentgateway/app/backends/mistral.yaml
+++ b/kubernetes/apps/ai/agentgateway/app/backends/mistral.yaml
@@ -18,7 +18,10 @@ spec:
     - extract:
         key: ai-keys
 ---
-# mistral BAgentgatewayBackend (OpenAI-compatible)
+# mistral AgentgatewayBackend (OpenAI-compatible). Reached via the unified /v1
+# endpoint (../httproute-unified.yaml) by model name (mistral-*/magistral/
+# ministral/codestral/pixtral/devstral/open-mi*). The explicit /mistral path
+# route was retired.
 apiVersion: agentgateway.dev/v1alpha1
 kind: AgentgatewayBackend
 metadata:
@@ -40,28 +43,3 @@ spec:
         "/v1/embeddings": Passthrough
         "/v1/models": Passthrough
         "*": Passthrough
----
-apiVersion: gateway.networking.k8s.io/v1
-kind: HTTPRoute
-metadata:
-  name: mistral
-spec:
-  parentRefs:
-    - name: internal
-    - name: internal-noauth
-    - name: public
-  rules:
-    - matches:
-        - path:
-            type: PathPrefix
-            value: /mistral
-      filters:
-        - type: URLRewrite
-          urlRewrite:
-            path:
-              type: ReplacePrefixMatch
-              replacePrefixMatch: /
-      backendRefs:
-        - name: mistral
-          group: agentgateway.dev
-          kind: AgentgatewayBackend

--- a/kubernetes/apps/ai/agentgateway/app/backends/openai.yaml
+++ b/kubernetes/apps/ai/agentgateway/app/backends/openai.yaml
@@ -18,6 +18,9 @@ spec:
     - extract:
         key: ai-keys
 ---
+# Reached via the unified /v1 endpoint (../httproute-unified.yaml) by model name
+# (gpt-*/o[0-9]*/chatgpt* + the catch-all default). The explicit /openai path
+# route was retired.
 apiVersion: agentgateway.dev/v1alpha1
 kind: AgentgatewayBackend
 metadata:
@@ -26,7 +29,6 @@ spec:
   ai:
     provider:
       openai: {}
-
   policies:
     auth:
       secretRef:
@@ -37,28 +39,3 @@ spec:
         "/v1/embeddings": Passthrough
         "/v1/models": Passthrough
         "*": Passthrough
----
-apiVersion: gateway.networking.k8s.io/v1
-kind: HTTPRoute
-metadata:
-  name: openai
-spec:
-  parentRefs:
-    - name: internal
-    - name: internal-noauth
-    - name: public
-  rules:
-  - matches:
-    - path:
-        type: PathPrefix
-        value: /openai
-    filters:
-    - type: URLRewrite
-      urlRewrite:
-        path:
-          type: ReplacePrefixMatch
-          replacePrefixMatch: /
-    backendRefs:
-    - name: openai
-      group: agentgateway.dev
-      kind: AgentgatewayBackend

--- a/kubernetes/apps/ai/agentgateway/app/backends/openai.yaml
+++ b/kubernetes/apps/ai/agentgateway/app/backends/openai.yaml
@@ -18,9 +18,10 @@ spec:
     - extract:
         key: ai-keys
 ---
-# Reached via the unified /v1 endpoint (../httproute-unified.yaml) by model name
-# (gpt-*/o[0-9]*/chatgpt* + the catch-all default). The explicit /openai path
-# route was retired.
+# Internal clients reach this via the unified /v1 endpoint
+# (../httproute-unified.yaml) by model name (gpt-*/o[0-9]*/chatgpt* + default).
+# The explicit /openai path route is retired from internal/internal-noauth and
+# kept ONLY on the public gateway for the external llm-api.* API.
 apiVersion: agentgateway.dev/v1alpha1
 kind: AgentgatewayBackend
 metadata:
@@ -39,3 +40,26 @@ spec:
         "/v1/embeddings": Passthrough
         "/v1/models": Passthrough
         "*": Passthrough
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: openai
+spec:
+  parentRefs:
+    - name: public
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /openai
+      filters:
+        - type: URLRewrite
+          urlRewrite:
+            path:
+              type: ReplacePrefixMatch
+              replacePrefixMatch: /
+      backendRefs:
+        - name: openai
+          group: agentgateway.dev
+          kind: AgentgatewayBackend

--- a/kubernetes/apps/ai/agentgateway/app/backends/xai.yaml
+++ b/kubernetes/apps/ai/agentgateway/app/backends/xai.yaml
@@ -18,7 +18,9 @@ spec:
     - extract:
         key: ai-keys
 ---
-# xai BAgentgatewayBackend (OpenAI-compatible)
+# xai AgentgatewayBackend (OpenAI-compatible). Reached via the unified /v1
+# endpoint (../httproute-unified.yaml) by model name (grok-*). The explicit /xai
+# path route was retired.
 apiVersion: agentgateway.dev/v1alpha1
 kind: AgentgatewayBackend
 metadata:
@@ -40,28 +42,3 @@ spec:
         "/v1/embeddings": Passthrough
         "/v1/models": Passthrough
         "*": Passthrough
----
-apiVersion: gateway.networking.k8s.io/v1
-kind: HTTPRoute
-metadata:
-  name: xai
-spec:
-  parentRefs:
-    - name: internal
-    - name: internal-noauth
-    - name: public
-  rules:
-  - matches:
-    - path:
-        type: PathPrefix
-        value: /xai
-    filters:
-    - type: URLRewrite
-      urlRewrite:
-        path:
-          type: ReplacePrefixMatch
-          replacePrefixMatch: /
-    backendRefs:
-    - name: xai
-      group: agentgateway.dev
-      kind: AgentgatewayBackend

--- a/kubernetes/apps/ai/agentgateway/app/backends/xai.yaml
+++ b/kubernetes/apps/ai/agentgateway/app/backends/xai.yaml
@@ -18,9 +18,10 @@ spec:
     - extract:
         key: ai-keys
 ---
-# xai AgentgatewayBackend (OpenAI-compatible). Reached via the unified /v1
-# endpoint (../httproute-unified.yaml) by model name (grok-*). The explicit /xai
-# path route was retired.
+# xai AgentgatewayBackend (OpenAI-compatible). Internal clients reach this via
+# the unified /v1 endpoint by model name (grok-*). The explicit /xai path route
+# is retired from internal/internal-noauth and kept ONLY on the public gateway
+# for the external llm-api.* API.
 apiVersion: agentgateway.dev/v1alpha1
 kind: AgentgatewayBackend
 metadata:
@@ -42,3 +43,26 @@ spec:
         "/v1/embeddings": Passthrough
         "/v1/models": Passthrough
         "*": Passthrough
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: xai
+spec:
+  parentRefs:
+    - name: public
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /xai
+      filters:
+        - type: URLRewrite
+          urlRewrite:
+            path:
+              type: ReplacePrefixMatch
+              replacePrefixMatch: /
+      backendRefs:
+        - name: xai
+          group: agentgateway.dev
+          kind: AgentgatewayBackend

--- a/kubernetes/apps/ai/open-webui/README.md
+++ b/kubernetes/apps/ai/open-webui/README.md
@@ -8,18 +8,21 @@ Open-WebUI stores API connections in its database (PersistentConfig), so they
 are **not** managed by GitOps. Configure them once in
 **Admin Settings → Connections → OpenAI API**.
 
-All LLM traffic goes through **agentgateway** (the single model gateway).
-agentgateway has no aggregated `/v1/models`, so add **one connection per
-provider path** — each connection contributes its own model list:
+All LLM traffic goes through **agentgateway** (the single model gateway). Use
+**one** connection pointed at the unified endpoint — it routes to every provider
+by the request `model` field:
 
-| Provider   | API Base URL                                                          | API Key       |
-| ---------- | --------------------------------------------------------------------- | ------------- |
-| OpenAI     | `http://internal-noauth.ai.svc.cluster.local/openai/v1`        | any non-empty |
-| Anthropic  | `http://internal-noauth.ai.svc.cluster.local/anthropic/v1`     | any non-empty |
-| Groq       | `http://internal-noauth.ai.svc.cluster.local/groq/v1`          | any non-empty |
-| Gemini     | `http://internal-noauth.ai.svc.cluster.local/gemini/v1`        | any non-empty |
-| DeepSeek   | `http://internal-noauth.ai.svc.cluster.local/deepseek/v1`      | any non-empty |
-| OpenRouter | `http://internal-noauth.ai.svc.cluster.local/openrouter/v1`    | any non-empty |
+| API Base URL                                       | API Key       |
+| -------------------------------------------------- | ------------- |
+| `http://internal-noauth.ai.svc.cluster.local/v1`   | any non-empty |
+
+agentgateway does **not** aggregate `/v1/models` across providers, so the model
+dropdown will not auto-populate. Add the model ids you want under the connection
+(or **Admin Settings → Models**), for example:
+
+`qwen3.6-35b-a3b` (local), `gpt-4o`, `gpt-5`, `claude-sonnet-4-6`,
+`claude-opus-4-6`, `gemini-2.5-flash`, `grok-4`, `deepseek-chat`,
+`llama-3.3-70b-versatile`.
 
 Notes:
 
@@ -27,9 +30,12 @@ Notes:
   (per-provider `AgentgatewayBackend` + ExternalSecret from the 1Password
   `ai-keys` item). The key entered in Open-WebUI is a placeholder — it just
   has to be non-empty.
-- Provider passthrough model lists are unfiltered; disable unwanted models
-  under **Admin Settings → Models**.
 - agentgateway lives in the `ai` namespace (consolidated from `ai-system`).
-- Backend definitions live in
-  `kubernetes/apps/ai/agentgateway/app/backends/` — adding a Backend
-  there (GitOps) and a matching connection here exposes a new provider.
+- Model→provider routing rules live in
+  `kubernetes/apps/ai/agentgateway/app/httproute-unified.yaml`; backend
+  definitions in `kubernetes/apps/ai/agentgateway/app/backends/`. Adding a model
+  family there (GitOps) exposes it on the same unified connection.
+- Aggregators with colliding model names (OpenRouter, Together AI, Z.AI,
+  OpenCode, Perplexity) keep their own `/<provider>` paths — point a separate
+  connection at e.g. `http://internal-noauth.ai.svc.cluster.local/openrouter/v1`
+  if you need them.


### PR DESCRIPTION
## Summary

Final consolidation step (after #1065, #1066). Retires the first-party per-provider path routes from the **internal** gateways, where the unified `/v1` model-routing endpoint now replaces them — while **keeping them on the `public` gateway** so the external `llm-api.*` API and gatus health check are untouched.

## What changes
- `openai`/`anthropic`/`groq`/`gemini`/`deepseek`/`mistral`/`xai` HTTPRoutes: `parentRefs` reduced from `[internal, internal-noauth, public]` → `[public]`. Backends + ExternalSecrets unchanged (the unified route targets them by model name).
- Open-WebUI README updated to the single unified `/v1` connection.

## What is preserved
- **External API** (`llm-api.${SECRET_DOMAIN}` via `envoy-external` → `public`) keeps all per-provider paths + the gatus `/openai/v1/models` 401 check. **Verified live:** `llm-api.sklab.dev/openai/v1/models` → 401.
- **Unified `/v1` endpoint** (internal-noauth) — **verified live**, all 7 families route: qwen→local, gpt-4o→openai, claude→anthropic, gemini→gemini, grok→xai, deepseek→deepseek, llama→groq; embeddings 2048-dim; bodyless GET safe.
- Hermes (`/vllm`,`/opencodego`), Linkwarden (`/vllm`), agentmemory (root `/v1`), and the aggregators (`/openrouter`,`/togetherai`,`/zai`,`/opencodeai`,`/perplexity`) — all unchanged.

## Only affected: internal Open-WebUI
Its DB-persisted config still uses `/openai`,`/anthropic`,`/groq`,`/gemini` on **internal-noauth** → those 4 connections will 404 after merge until the one-time admin-UI step (move to a single `http://internal-noauth.ai.svc.cluster.local/v1` connection + add model ids). This is accepted/known.

🤖 Generated with [Claude Code](https://claude.com/claude-code)