### PR TITLE
fix(agentmemory): disable auto-compress (LLM-per-observation storm)

### DIFF
--- a/kubernetes/apps/ai/agentmemory/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/agentmemory/app/helmrelease.yaml
@@ -87,9 +87,13 @@ spec:
               # memory (required for recall). Graph extraction adds the entity/
               # relation knowledge graph (the graph leg of hybrid recall); both run
               # per-session — the local 35B on the B70 (~74 t/s) handles them.
-              # AGENTMEMORY_AUTO_COMPRESS stays OFF (default synthetic compression):
-              # it runs the LLM on EVERY observation — llama-server is single-slot,
-              # so keep per-observation LLM load off it.
+              # AGENTMEMORY_AUTO_COMPRESS stays OFF (default synthetic compression).
+              # It runs the LLM on EVERY observation; the local 35B on the B70
+              # (~15-20 t/s under concurrent load) can't keep up, so enabling it
+              # (bcf0f292) made ~95% of compressions time out at 120s and trip
+              # agentmemory's circuit breaker — which also starved summarize /
+              # graph-extraction / reflect. Reverted 2026-06-23. Do NOT re-enable
+              # against the local model; keep per-observation LLM load off it.
               CONSOLIDATION_ENABLED: "true"
               GRAPH_EXTRACTION_ENABLED: "true"
               # Generous LLM timeout: llama-server queues concurrent requests.
@@ -103,7 +107,6 @@ spec:
               # shutdown-flush bug (upstream #843, fixed in 0.9.27).
               SNAPSHOT_ENABLED: "true"
               SNAPSHOT_DIR: /data/snapshots
-              AGENTMEMORY_AUTO_COMPRESS: true
               # Periodic lesson synthesis on the local 35B — tokens are free.
               AGENTMEMORY_REFLECT: "true"
               # Homelab context stays relevant longer than the 30-day default.


### PR DESCRIPTION
## Problem

`agentmemory` is failing ~95% of its `mem:compress` operations (and dragging `mem:summarize` / graph-extraction / reflect down with it).

In the last ~2000 log lines:

| event | count |
|---|---|
| Observation captured (`compress: llm`) | 926 |
| **Compression failed** | **878** |
| → `timed out after 120000ms` | 493 |
| → `circuit_breaker_open` | 489 |
| Observation *compressed* (success) | 42 |
| Summarize failed | 61 |
| Graph extraction failed | 35 |

## Root cause

Not a model-quality issue — every failure is a **120 s client-side timeout**. `AGENTMEMORY_AUTO_COMPRESS: true` (added in bcf0f292) fires an LLM compression call on **every observation** from every agent. The local `Qwen3.6-35B-A3B` on the B70 runs ~4 slots at only ~10–20 t/s each under concurrent load; a 700–1400 token compression takes 50–140 s + queue wait, routinely blowing the 120 s bound. agentmemory's circuit breaker then trips and fast-fails everything, including the session-boundary summarize/graph/reflect work. The same 35B also serves interactive chat, so this flood degrades Hermes/open-webui too.

This directly contradicted the existing in-file comment, which already documented that auto-compress must stay OFF on the single local model.

## Fix

Revert to the default **synthetic (non-LLM) per-observation compression**. The LLM still runs where it matters — at session boundaries (consolidate / summarize / graph / reflect). Comment updated to record the incident so it isn't re-enabled against the local model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)