### PR TITLE
feat(envoy-gateway): alert on control-plane disconnect + fix ignored controller resources

### DIFF
--- a/kubernetes/apps/network/envoy-gateway/app/helmrelease.yaml
+++ b/kubernetes/apps/network/envoy-gateway/app/helmrelease.yaml
@@ -12,6 +12,20 @@ spec:
   values:
     global:
       imageRegistry: mirror.gcr.io
+    # Controller deployment resources MUST live under `deployment.envoyGateway`.
+    # A `resources:` block under `config.envoyGateway` (where it was before) is part
+    # of the EnvoyGateway *config file* schema and is silently IGNORED, so the
+    # controller ran on chart defaults. 1Gi is ample — it idles ~160Mi and the
+    # 2026-06-23 exit-137 crashloop was a liveness-kill from a GatewayNamespaceMode
+    # SA-token auth storm (stale proxies), NOT an OOM. See prometheusrule.yaml.
+    deployment:
+      envoyGateway:
+        resources:
+          requests:
+            cpu: 100m
+            memory: 256Mi
+          limits:
+            memory: 1Gi
     config:
       envoyGateway:
         provider:
@@ -19,9 +33,3 @@ spec:
           kubernetes:
             deploy:
               type: GatewayNamespace
-        resources:
-          requests:
-            cpu: 100m
-            memory: 256Mi
-          limits:
-            memory: 512Mi

--- a/kubernetes/apps/network/envoy-gateway/app/kustomization.yaml
+++ b/kubernetes/apps/network/envoy-gateway/app/kustomization.yaml
@@ -9,3 +9,4 @@ resources:
   - ./observability.yaml
   - ./ocirepository.yaml
   - ./pdb.yaml
+  - ./prometheusrule.yaml

--- a/kubernetes/apps/network/envoy-gateway/app/prometheusrule.yaml
+++ b/kubernetes/apps/network/envoy-gateway/app/prometheusrule.yaml
@@ -1,0 +1,42 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/monitoring.coreos.com/prometheusrule_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: envoy-gateway-rules
+spec:
+  groups:
+    - name: envoy-gateway.rules
+      rules:
+        # An Envoy proxy lost its xDS connection to the envoy-gateway controller and
+        # can no longer receive route/endpoint (EDS) updates — it serves FROZEN config.
+        # This is the exact condition behind the 2026-06-23 outage: the controller
+        # crash-looped, the proxies' GatewayNamespaceMode SA tokens expired, xDS auth
+        # failed, and envoy-internal stayed pinned to a dead agentmemory pod IP.
+        # Runbook: kubectl -n network rollout restart deploy envoy-gateway, then
+        # envoy-internal + envoy-external (fresh token → xDS resync). 10m absorbs the
+        # brief reconnect during a normal controller roll.
+        - alert: EnvoyProxyControlPlaneDisconnected
+          expr: envoy_control_plane_connected_state{namespace="network"} == 0
+          for: 10m
+          annotations:
+            summary: >-
+              Envoy proxy {{ $labels.pod }} has been disconnected from the
+              envoy-gateway control plane for 10m and is serving stale config —
+              rollout restart envoy-gateway then envoy-internal/envoy-external.
+          labels:
+            severity: critical
+        # The controller is crash-looping. On 2026-06-23 this was a liveness-kill
+        # (exit 137, reason=Error, NOT OOM — it idles ~160Mi) driven by stale proxies
+        # flooding the kubejwt auth interceptor with expired tokens. A crash-looping
+        # controller stops pushing xDS, which is what freezes the proxies above.
+        - alert: EnvoyGatewayControllerCrashLooping
+          expr: increase(kube_pod_container_status_restarts_total{namespace="network", pod=~"envoy-gateway-.*"}[15m]) >= 2
+          for: 5m
+          annotations:
+            summary: >-
+              envoy-gateway controller {{ $labels.pod }} restarted
+              {{ $value | printf "%.0f" }}x in 15m — check controller logs for a
+              kubejwt 'service account token has expired' storm from stale proxies.
+          labels:
+            severity: warning


### PR DESCRIPTION
## Context

Follow-up to the 2026-06-23 incident where `agentmemory.sklab.dev` became unreachable internally. Root cause: the `envoy-internal` proxy was serving **frozen config**, still dialing a dead agentmemory pod IP (`10.42.0.216`) after the pod was restarted to a new IP (`10.42.0.199`). The proxy couldn't get xDS updates because the `envoy-gateway` controller was crash-looping — a **liveness-kill** (exit 137, reason `Error`, **not** OOM; the controller idles ~160Mi/1Gi) triggered by stale proxies flooding the `kubejwt` auth interceptor with expired GatewayNamespaceMode SA tokens. Fixed live by restarting the controller + proxies.

This PR adds a safety net so a recurrence is caught immediately, plus a config-hygiene fix found along the way.

## Changes

**`prometheusrule.yaml` (new)** — `PrometheusRule/envoy-gateway-rules`:
- `EnvoyProxyControlPlaneDisconnected` (**critical**): `envoy_control_plane_connected_state{namespace="network"} == 0` for 10m — the direct "proxy is serving frozen config" signal (scraped from the proxies' `/stats/prometheus` via the existing PodMonitor). This is what would have paged us during the outage.
- `EnvoyGatewayControllerCrashLooping` (**warning**): controller restarts ≥2 in 15m — catches the upstream trigger early.

Both PromQL expressions were validated against live Prometheus (success, 0 series while healthy).

**`helmrelease.yaml`** — move controller resources from `config.envoyGateway.resources` (an EnvoyGateway *config* key that is **silently ignored**, so the controller ran on chart defaults) to the correct `deployment.envoyGateway.resources`. Kept at **1Gi** — memory was never the problem.

**`kustomization.yaml`** — wire in the new file.

## Not done (deliberately)

- **No version bump**: v1.8.1 is already the latest stable (1.9.0 is only `rc.0`) and already ships "fix fail-open auth in GatewayNamespaceMode".
- **No memory increase**: the controller isn't memory-constrained; the crashloop was a liveness-kill, not an OOM.
- **Durable fix deferred** (separate, plan-worthy): dropping `deploy.type: GatewayNamespace` to eliminate the cross-namespace SA-token auth entirely.

## Verification
- `kustomize build kubernetes/apps/network/envoy-gateway/app` renders clean.
- Alert metrics confirmed scraped: `envoy_control_plane_connected_state` (4 series) and `kube_pod_container_status_restarts_total` (controller).

🤖 Generated with [Claude Code](https://claude.com/claude-code)