### PR TITLE
feat(ai): validate B70 LLM serving + pin slots + isolate ComfyUI

### DIFF
--- a/docs/ai/b70-llm-serving-tuning.md
+++ b/docs/ai/b70-llm-serving-tuning.md
@@ -1,0 +1,228 @@
+# B70 LLM Serving — Benchmark & Tuning Runbook
+
+> **Hardware:** single Intel Arc Pro B70 (Xe2 / Battlemage G31, 32 GB) on `talos-3`.
+> **App:** `kubernetes/apps/ai/vllm/app/helmrelease.yaml` (chat = llama.cpp SYCL named
+> `vllm`; embeddings = vLLM named `vllm-embed`). **Date:** 2026-06-26.
+>
+> This runbook records the measured baseline, the SYCL-vs-Vulkan backend decision, the
+> tuning A/B matrix, and the single-card workload-isolation design. It is the evidence
+> trail for any change to `helmrelease.yaml`. Reproduction commands are inline.
+
+## TL;DR
+
+- **Backend stays SYCL.** Measured on our `b9592` build: SYCL decode **~61 t/s** vs Vulkan
+  **~36 t/s** on the exact MoE chat model — SYCL wins **1.68×**. The Reddit "Vulkan 2.5–3×
+  faster on MoE" finding was from broken build `8739`; the SYCL MoE expert-dispatch penalty
+  is **fixed** in `b9592` (PRs #21527/#21638 merged). **No image/backend change.**
+- **Current llama.cpp args are already near-optimal.** `q8_0` KV is required for the 131072
+  context to fit in VRAM; `kv_unified=true` with 4 auto slots already gives single requests
+  the full window *and* fleet concurrency. No arg changes improve single-stream throughput.
+- **The real bottleneck is single-card compute contention, not config.** Chat decode
+  collapses **38×** (61 → 1.6 t/s) when embeddings runs flat-out; the Intel GPU plugin
+  time-slices compute with no hardware partition. The durable win is workload isolation
+  (below) and, structurally, a second card (see
+  [`b70-second-card-decision.md`](./b70-second-card-decision.md)).
+
+## 1. Baseline (measured 2026-06-26, build `server-intel-b9592`)
+
+`llama-bench` is **not** shipped in the `ggml-org/llama.cpp:server-intel` image (only
+`/app/llama-server`). Baseline was taken with the plan's documented fallback: timed
+`/completion` requests (the server returns per-request `timings`) plus the `--metrics`
+Prometheus gauges. Decode/prefill are sensitive to live production traffic on the shared
+card, so figures are **best-of-N within idle windows** unless noted.
+
+| Metric | Value | Notes |
+| --- | --- | --- |
+| **Decode `tg128` (clean, idle)** | **~61 t/s** | 58.2 / 61.3 / 62.2 / 63.1 across runs |
+| Decode under embeddings flood | **~1.6 t/s** | 17 req/s embeddings → **38× collapse** |
+| Decode under normal prod load | ~5.7 t/s | 4 slots interleaving real requests |
+| Decode rolling-average (`predicted_tokens_seconds`) | ~14.6 t/s | production-experienced; incl. prefill + queue |
+| **Prefill `pp512` (best, contended)** | ~185 t/s | 20–185 t/s range under live load |
+| Prefill `pp2102` | ~79 t/s | contended sample |
+| GPU | Arc Pro B70, 32656 MiB total | ~27 GiB free idle; ~22.7 GiB free with embeddings resident |
+| Slots / KV | `n_parallel=4` (auto), `kv_unified=true` | **all 4 slots report `n_ctx=131072`** → single req gets full window |
+| KV cache | `q8_0/q8_0`, `--flash-attn on` | |
+| Backend | SYCL, `-DGGML_SYCL_F16=ON` | confirmed in `intel.Dockerfile` (research) |
+| Model | `Qwen3.6-35B-A3B UD-Q4_K_M` (multimodal, mmproj-BF16) | weights ~20.6 GiB |
+
+**Vs published references (same model, same card):**
+
+| Source | Build | Decode tg128 | Prefill pp512 |
+| --- | --- | --- | --- |
+| Reddit post | `8739` | ~14 t/s SYCL (erratic) / 39.4 Vulkan | — |
+| PMZFX | `b8840` | 54.7 t/s SYCL | 615 t/s |
+| **Ours** | **`b9592`** | **~61 t/s SYCL / ~36 Vulkan** | best ~185 (contended) |
+
+- **Decode gap is resolved in our favour:** our SYCL `b9592` (~61) **exceeds** PMZFX's `b8840`
+  (54.7). The MoE penalty is fixed; the `predicted_tokens_seconds` gauge (14.6) is a
+  long-window average corrupted by prefill + queue, **not** the decode rate — the per-request
+  `timings.predicted_per_second` (~61) is authoritative.
+- **Prefill gap is real but expected:** our best ~185 t/s vs PMZFX's 615 (idle, isolated).
+  Two causes: (1) our samples were under live contention; (2) **structural** — llama.cpp SYCL
+  has no XMX flash-attention kernel, so prefill stays well behind vLLM-XPU. This is the
+  strongest argument in the [second-card memo](./b70-second-card-decision.md), not something
+  single-card tuning can fix.
+
+### Reproduce
+
+```bash
+# decode tg128 (per-request timings; run several, take best idle reading)
+kubectl -n ai exec deploy/vllm -c app -- sh -lc \
+  'curl -s localhost:8000/completion -d "{\"prompt\":\"Once upon a time\",\"n_predict\":128,\"ignore_eos\":true,\"temperature\":0,\"cache_prompt\":false}" | tr "," "\n" | grep predicted_per_second'
+
+# prefill pp512 (large prompt, n_predict=1)
+kubectl -n ai exec deploy/vllm -c app -- sh -lc \
+  'P=$(yes "lorem ipsum dolor" | head -180 | tr "\n" " "); curl -s localhost:8000/completion -d "{\"prompt\":\"$P\",\"n_predict\":1,\"cache_prompt\":false}" | tr "," "\n" | grep -E "prompt_n|prompt_per_second"'
+
+# live throughput gauges + slot config
+kubectl -n ai exec deploy/vllm -c app -- sh -lc 'curl -s localhost:8000/metrics | grep -E "tokens_seconds|requests_"; curl -s localhost:8000/props | tr "," "\n" | grep -E "n_ctx|total_slots"'
+```
+
+## 2. Upstream applicability verdicts (research, build `b9592`)
+
+| Knob / question | Verdict | Evidence |
+| --- | --- | --- |
+| `b9592` newer than `b8840` | **Yes** | monotonic build numbers; 9592 > 8840 |
+| SYCL Q8_0 reorder PRs #21527 / #21638 | **In our build** | merged far below b8840; #21527 lifted Q8_0 tg 3.1× |
+| `-DGGML_SYCL_F16=ON` | **On** | default ARG in `ggml-org` `intel.Dockerfile` |
+| SYCL MoE expert-dispatch fix (8739→b8840) | **In our build** | proven by PMZFX 54.7 t/s + our 61 t/s |
+| Vulkan beats SYCL on MoE | **Does NOT apply** | true only on broken `8739`; SYCL fixed since |
+| `q8_0` KV cost (~6% tg) | **Accepted** | required for VRAM fit; see §3 |
+| vLLM hosts 35B MoE on 1 card (`intel/llm-scaler#382`) | **Still blocked** | #382 OPEN; OOMs even on 2 cards. Keep llama.cpp |
+| `GGML_SYCL_DISABLE_OPT=1` for MoE stability | **Not needed for us** | single-source claim; our pod ran 7d, 4 slots, no SEGV |
+
+## 3. Tuning A/B matrix
+
+Each row is an isolated test on the live card; backend A/B led because it gates the rest.
+
+### Backend: SYCL vs Vulkan — **SYCL wins, KEEP SYCL**
+
+Method: `flux suspend hr vllm` → patch deployment image to `ghcr.io/ggml-org/llama.cpp:server-vulkan`
++ `GGML_VK_VISIBLE_DEVICES=0` → Recreate → benchmark → revert image/env, `resume`.
+
+| Backend (b9592, MoE, q8_0 KV, 131072 ctx) | Decode tg128 | Notes |
+| --- | --- | --- |
+| **SYCL (current)** | **~61 t/s** | 58.96 / 63.05 / 61.34 |
+| Vulkan | ~36 t/s | very stable 33.3–36.4 |
+
+- **Vulkan is feasible on our Intel-plugin Talos node** — ANV (Mesa 26 / Battlemage) found the
+  GPU off the device-plugin's render node alone; **no `card0` hostPath needed**. So the
+  feasibility blocker did *not* materialise — but Vulkan is simply slower on this MoE.
+- Vulkan's ~36 t/s ≈ the Reddit post's 39.4 — Vulkan stayed flat across builds while SYCL
+  improved 14 → 61. Coherent story: **the SYCL fixes, not a backend switch, are the win.**
+- ⚠️ Operational note: the Vulkan build runs a strict `common_fit_params` memory-fit step that
+  **aborts** with `-ngl 99` when free VRAM is tight (it refused to load with only 22.7 GiB free
+  while embeddings was resident). SYCL has no such abort. Another reason to stay on SYCL.
+
+### KV-cache precision: `q8_0` vs `f16` — **KEEP q8_0 (VRAM-bound, not speed-bound)**
+
+- `q8_0` K/V is **required** to fit the 131072 context. The Vulkan abort above and the idle
+  free-VRAM figure (~27 GiB, dropping to ~22.7 with embeddings) show headroom is genuinely
+  tight against ~20.6 GiB weights. `f16` KV roughly doubles KV size and would not fit at
+  131072 alongside weights + embeddings + ComfyUI.
+- The documented ~6% SYCL decode cost of `q8_0` is moot: our `q8_0` decode (~61) **already
+  exceeds** the `f16`-capable reference (54.7). We are not leaving meaningful decode on the
+  table. **No change.**
+
+### Parallel slots — **KEEP auto (4 + kv_unified); pin for determinism**
+
+- Live server auto-selects `n_parallel=4, kv_unified=true`. With a unified KV cache, a single
+  request addresses the full 131072 pool (verified: all 4 slots log `n_ctx=131072`) **and** up
+  to 4 fleet requests can run concurrently. This is already the best of both worlds — no 1-vs-2-vs-4
+  trade-off to make. Recommend pinning `--parallel 4` + `--kv-unified` explicitly so the
+  behaviour can't silently change on an image bump (see §4).
+
+### `--cache-reuse` 256, `UD-Q4_K_XL`, `--threads`
+
+- `--cache-reuse 256`: no evidence to change; multi-turn agents already benefit. **Keep.**
+- `UD-Q4_K_XL`: VRAM is tight; a larger quant erodes the q8_0-KV headroom and risks the fit.
+  **Skip** — current `UD-Q4_K_M` validated against the reference.
+- `--threads`: **excluded** per plan (confirmed no-op at `-ngl 99`).
+
+**Matrix conclusion:** keep the current image and all llama.cpp args. The only config change
+worth shipping is pinning the slot/KV behaviour for determinism (§4); the real win is
+workload isolation (§4) and, structurally, the second card.
+
+## 4. Single-card workload isolation (B70 time-slice contention)
+
+`talos-3` runs three GPU workloads against **one** B70 via the Intel GPU device plugin:
+**chat** (`vllm` = llama.cpp SYCL, service `vllm-app`), **embeddings** (`vllm-embed`), and
+**ComfyUI** (`comfyui`, default-off). The B70 has **no hardware compute partition** (no MIG,
+no SR-IOV compute slicing), so co-resident workloads **time-slice** the GPU and starve each
+other's compute when both are active.
+
+> ⚠️ `--gpu-memory-utilization` and the device plugin's `sharedDevNum: 99`
+> (`kubernetes/apps/system/intel-device-plugin-operator/gpu/`) only divide **VRAM /
+> device-count** — neither isolates **compute**. The plugin advertises the one card as 99
+> schedulable slots, so all three pods hold a `gpu.intel.com/xe: 1` claim on the *same*
+> physical card. The only effective control is to keep two heavy compute consumers from
+> being active at the same time.
+
+### Symptom & measured penalty
+
+- Isolated chat decode ≈ **61 t/s**. Under a synthetic embeddings flood (1183 req in 70 s ≈
+  17 req/s) chat collapsed to ≈ **1.6 t/s — a 38× degradation**. Normal sporadic production
+  sits ≈ 5.7 t/s (rolling average ≈ 14.6 t/s).
+- ComfyUI image generation while chat is resident is the **heaviest** contention source
+  (sustained full-GPU diffusion + wants the whole 32 GB in Dedicated-VRAM mode).
+
+### Mechanism (why no knob fixes it)
+
+- `sharedDevNum`: multiplexes device *count* only — leave it (cluster-wide; transcoders depend on it).
+- vLLM `--gpu-memory-utilization`: VRAM cap only, zero effect on compute scheduling.
+- PriorityClass / in-cluster hooks: govern scheduling/preemption, not GPU time-slice
+  arbitration, and would fight Flux — **not used.**
+- The only real lever is **admission control**: mutual exclusion of the heavy pair (ComfyUI ↔ chat).
+
+### Mutual-exclusion procedure (chat ↔ ComfyUI)
+
+ComfyUI is pinned `replicas: 0` in git (`kubernetes/apps/ai/comfyui/app/helmrelease.yaml`).
+Run a ComfyUI session **only** after freeing the card from chat, and restore chat afterward.
+Flux (`interval: 1h`) reconciles ComfyUI back to 0 on its own, so the git default is the net.
+
+**Start a ComfyUI session (free the card from chat first):**
+```bash
+flux -n ai suspend hr vllm                              # so Flux won't fight the scale
+kubectl -n ai scale deploy vllm vllm-embed --replicas=0
+kubectl -n ai rollout status deploy/vllm --timeout=120s
+kubectl -n ai scale deploy comfyui --replicas=1
+kubectl -n ai rollout status deploy/comfyui --timeout=300s
+```
+
+**End the session (return the card to chat):**
+```bash
+kubectl -n ai scale deploy comfyui --replicas=0
+kubectl -n ai rollout status deploy/comfyui --timeout=120s
+flux -n ai resume hr vllm                               # resume alone does NOT restore replicas
+kubectl -n ai scale deploy vllm vllm-embed --replicas=1
+kubectl -n ai rollout status deploy/vllm --timeout=600s
+```
+
+> Both controllers use `strategy: Recreate` + `terminationGracePeriodSeconds: 60`, so each
+> releases its GPU cleanly before the other claims it. Do **not** skip the `rollout status`
+> waits — starting the second workload before the first's pod is gone re-creates the
+> contention you are avoiding.
+
+### Embeddings caveat (don't flood it)
+
+`vllm-embed` is capped at `--gpu-memory-utilization=0.20` (~6.5 GiB) and is low-rate in
+normal use — it coexists with chat fine at steady state. The 38× collapse only reproduced
+under a *synthetic* flood. The risk is a **consumer** flooding it (e.g. agentmemory
+auto-compress / per-observation embedding storms — already disabled, commit `daa291d8`), not
+VRAM. If chat decode tanks while ComfyUI is at 0, check whether something is hammering
+`vllm-embed` before suspecting the chat server. **Do not** lower the embeddings VRAM cap to
+"fix" this — it is a request-rate problem, not a memory problem.
+
+### The structural fix
+
+This procedure **manages** contention; it does not eliminate it. The only way to remove it
+is a **second B70** (one model per card, no time-slicing) — currently **deferred**; see
+[`b70-second-card-decision.md`](./b70-second-card-decision.md).
+
+
+
+## 5. Change log
+
+| Date | Change | Result |
+| --- | --- | --- |
+| 2026-06-26 | Baseline + SYCL-vs-Vulkan A/B + tuning matrix | SYCL kept (61 vs 36 t/s); config validated; isolation identified as the win |

--- a/docs/ai/b70-second-card-decision.md
+++ b/docs/ai/b70-second-card-decision.md
@@ -1,0 +1,181 @@
+# Decision Memo: Second Intel Arc Pro B70 for LLM Serving
+
+> **Status:** Recommendation only — **NO purchase authorized**. This memo weighs the
+> cost (~$949) of a second Intel Arc Pro B70 (Xe2 / Battlemage G31, 32 GB) against the
+> three concrete benefits it would unlock on `talos-3`, and records the open hardware
+> question that gates any of them. Written 2026-06-26.
+
+## TL;DR
+
+A second B70 is **not worth buying today**, but there is one specific condition under
+which it becomes a clear yes (see [Recommendation](#recommendation)). Today's single-card
+chat performance is already good (≈54.7 t/s single-stream on the exact chat model on SYCL —
+see [`PMZFX/llm-benchmarks.md`][pmzfx-llm]), the most compelling dual-card win
+(vLLM tensor-parallel) is **blocked by an unresolved upstream OOM bug** that a second card
+does **not** automatically fix ([`intel/llm-scaler#382`][382], still OPEN), and the
+physical ability to seat a second GPU in `talos-3` is **unverified** (likely needs an
+OCuLink/M.2 adapter).
+
+## Current State (the problem a 2nd card would solve)
+
+`talos-3` runs **three GPU workloads contending for one 32 GB B70** via the Intel GPU
+device plugin (`gpu.intel.com/xe`):
+
+| Workload | Engine | VRAM appetite | Notes |
+| --- | --- | --- | --- |
+| Chat (Qwen3.6-35B-A3B MoE, UD-Q4_K_M) | `llama.cpp:server-intel` (SYCL) | ~22–24 GB (weights + 128k KV q8_0) | Single-stream, ≈54.7 t/s |
+| Embeddings | `intel/llm-scaler-vllm:0.14.0-b8.3.1` | a few GB (pooling) | |
+| ComfyUI | `intel/llm-scaler-omni` | bursty, multi-GB images | Forced to ceph-block RWO, pinned talos-3 |
+
+These coexist via VRAM partitioning runbooks (e.g. scale vllm→0 for big ComfyUI jobs),
+i.e. **contention is managed manually, not eliminated**. A second card is fundamentally a
+way to remove that contention and/or unlock capabilities one 32 GB card cannot deliver.
+
+## Cost
+
+- **~$949** for a second Arc Pro B70 32 GB (street price, single unit).
+- Plus **non-trivial hidden cost**: an OCuLink or M.2-to-PCIe adapter + external GPU
+  enclosure/riser **if** `talos-3` cannot seat a second card internally (see
+  [hardware constraints](#hardware-constraint-talos-3-expansion-open-question)).
+- Plus power: each B70 draws ~114 W under llama.cpp load and up to its board limit under
+  vLLM ([`PMZFX/llm-benchmarks.md`][pmzfx-llm]).
+
+## Benefit Options
+
+### Option (a) — Independent models per card
+
+Run **chat on GPU0** and **embeddings + ComfyUI on GPU1**. This cleanly removes today's
+three-workloads-on-one-card contention and gives **full single-card performance to each
+workload simultaneously** (no more "scale vllm→0 to run ComfyUI" dance).
+
+- **Pro:** Simplest, lowest-risk, no new software stack. Each workload keeps the perf it
+  has today but stops fighting for VRAM/compute. Device selection is trivial — the device
+  plugin hands each pod its own `renderD12X` and SYCL/Level-Zero device index.
+- **Con:** Buys *isolation*, not *more capability*. Does not make chat faster, does not
+  enable >32 GB models, does not fix prefill throughput. Pure quality-of-life.
+- **Verdict:** The safest reason to buy, but the weakest ROI — it solves a problem we are
+  already managing acceptably by hand.
+
+### Option (b) — vLLM tensor-parallel across 2 cards (`-tp=2`)
+
+Serve the 35B MoE on **vLLM-XPU with tensor parallelism**, gaining two things llama.cpp
+SYCL cannot give us:
+
+1. **XMX / DPAS flash-attention prefill.** `PMZFX/engine-comparison.md` measures vLLM-XPU
+   prompt processing at **2.4× (pp128), 4.5× (pp512), 15.3× (pp2048)** faster than
+   llama.cpp SYCL, because **"llama.cpp SYCL's attention path is scalar FP16, no XMX"** —
+   the repo calls the XMX FA kernel *"one of the biggest open performance projects for the
+   SYCL backend"* ([`PMZFX/engine-comparison.md`][pmzfx-engine]). For long-context / RAG /
+   agent prompts this is the single biggest prefill win available.
+2. **VRAM headroom** that *might* clear the MoE warmup OOM.
+
+> ⚠️ **Critical caveat — the OOM is NOT auto-solved by a 2nd card.**
+> [`intel/llm-scaler#382`][382] is literally *"Unable to run Qwen3.6-35B-A3B FP8 on **2× B70s**
+> using `llm-scaler-vllm:0.14.0-b8.2`"* — it fails with `UR_RESULT_ERROR_OUT_OF_RESOURCES`
+> **even on two cards** with `-tp=2`. The issue is **still OPEN** (as of this memo); the only
+> contributor guidance is to *lower* `gpu-memory-util` (e.g. 0.8) and try an older build.
+> So Option (b)'s headroom thesis is **unproven** — buying a 2nd card to "fix the OOM" is a
+> bet on an unmerged fix, not a guaranteed outcome. Decode itself is roughly a tie with
+> llama.cpp (both memory-bandwidth-bound, ~tie at ~36 t/s on the 14B dual-GPU test in
+> [`PMZFX/engine-comparison.md`][pmzfx-engine]) — so the win is **prefill, not tg**.
+
+- **Pro:** Real, large prefill speedup; proper continuous batching; the "right" engine for
+  multi-user / agent traffic.
+- **Con:** OOM risk unresolved upstream; decode is not faster than what we have; more
+  operational complexity than llama.cpp.
+- **Verdict:** The most *capable* option, but currently the most *risky* because of #382.
+
+### Option (c) — Layer-split for >32 GB models
+
+Two cards = 64 GB usable, enabling models that do not fit one B70:
+
+| Model | Size | dual-B70 tg | Power | Source |
+| --- | --- | --- | --- | --- |
+| Qwen3-Coder-Next 80B-A3B Q4_K_M (MoE) | 45.1 GiB | **43.4 t/s** | 79 W | [`PMZFX/multi-gpu.md`][pmzfx-multi] |
+| Qwen 3.5-35B-A3B Q8_0 (MoE) | 34.4 GiB | 36.5 t/s | 91 W | [`PMZFX/multi-gpu.md`][pmzfx-multi] |
+| DeepSeek-R1-Distill-Llama-70B Q4_K_M (dense) | 39.6 GiB | **11.5 t/s** | — | [`PMZFX/multi-gpu.md`][pmzfx-multi] |
+| Llama 3.3-70B Instruct Q4_K_M (dense) | 39.6 GiB | 11.5 t/s | — | [`PMZFX/multi-gpu.md`][pmzfx-multi] |
+
+The pattern is decisive: **MoE layer-splits beautifully (80B-A3B at 43 t/s), dense 70B does
+not (11.5 t/s)** because llama.cpp layer-split is sequential — *"both GPUs sit idle half the
+time"* ([`PMZFX/multi-gpu.md`][pmzfx-multi]). And the repo's own guidance: *"models that fit
+one card should stay on one card"* (a dual-GPU 27B is ~4% **slower**). So Option (c) only
+pays off if we actually want a **>32 GB MoE** (e.g. an 80B-A3B coder) — for which it is
+excellent — and is a poor reason to buy if we only ever run ≤35B.
+
+## Hardware Constraint: talos-3 expansion (OPEN QUESTION)
+
+`talos-3` is a **mini-PC-class node**. The existing B70 was only enumerated after adding
+`pci=realloc assign-busses` kernel args (it sits at `03:00.0`, 32 GB ReBAR) — consistent
+with an **OCuLink / external-GPU** attachment rather than a clean internal x16 slot. The
+`PMZFX/multi-gpu.md` reference rig runs **both cards at CPU-direct PCIe 5.0 x8** (it has the
+lanes); whether `talos-3` can do the same is **unknown and must be physically verified**:
+
+- Does the chassis have a **second OCuLink port** or a free **M.2 slot** usable via an
+  M.2→PCIe/OCuLink adapter?
+- Does the platform support **x8/x8 bifurcation** (or will a 2nd card force x4/x4, throttling
+  TP all-reduce)?
+- Is there physical space + power + cooling for a second external enclosure?
+
+> 🚩 **This is the gating open question.** Until someone inspects the physical `talos-3`
+> chassis and BIOS bifurcation options, the cost of a 2nd card is *unknown* (card alone vs.
+> card + adapter + enclosure) and the benefit ceiling is *unknown* (x8 vs x4 link width
+> materially affects TP scaling). Resolve this **before** any purchase decision.
+
+## Single-card alternative: batched request-density (no 2nd card)
+
+A different optimization target entirely. The r/LocalLLaMA B70 author reported **235 t/s
+aggregate across 100 concurrent requests** using a **dense Gemma-3-27B Intel AutoRound**
+quant on **vLLM-XPU** on a *single* card. That is **aggregate batched throughput**, a
+fundamentally different metric from our **single-stream MoE decode** on llama.cpp.
+
+- **Trade-off:** vLLM-XPU gives real continuous batching + XMX prefill on **one** card, but
+  at **lower single-stream tg** and only for a **dense** model — our **MoE-on-vLLM path is
+  still blocked by [#382][382]**. So this is a single-card software change (engine + model +
+  quant swap), not a hardware purchase, and it optimizes *concurrency*, not *latency*.
+- **Decision input only:** if the real need is "serve many simultaneous users," the cheapest
+  first experiment is vLLM-XPU batching on the *current* card with a dense AutoRound model —
+  **before** spending $949. If the need is "one fast single-stream MoE chat," we already have
+  it (54.7 t/s) and neither this nor a 2nd card improves single-stream decode much.
+
+## Recommendation
+
+**DEFER. Do not buy a second B70 now.** Conditions, in priority order:
+
+1. **Buy-if (the clear yes):** we commit to running a **>32 GB MoE model** in production
+   (e.g. an 80B-A3B coder at ~43 t/s, Option c) **AND** `talos-3` is confirmed able to seat
+   a second card at **≥ PCIe x8**. That combination is the one place a 2nd card delivers a
+   capability we cannot get any other way, at good performance. Resolve the
+   [hardware open question](#hardware-constraint-talos-3-expansion-open-question) first.
+2. **Buy-if (secondary):** vLLM-XPU prefill throughput (Option b) becomes a hard requirement
+   for agent/RAG traffic **AND** [#382][382] is fixed upstream (a newer `llm-scaler-vllm`
+   tag closes it or `gpu-memory-util`/`enforce_eager`/`--max-num-seqs` tuning is proven to
+   host the 35B MoE). Until #382 closes, this is a bet, not a buy.
+3. **Probably-not-worth-it:** Option (a) (pure isolation) alone. Today's manual VRAM
+   partitioning is acceptable; $949 to remove a manageable inconvenience is poor ROL.
+4. **Try first / instead:** the [single-card vLLM-XPU batching experiment](#single-card-alternative-batched-request-density-no-2nd-card)
+   if the underlying need turns out to be *concurrency*. It is free of hardware spend.
+
+**What would change this recommendation:**
+- [#382][382] closes (then Option b moves from "bet" to "buy-if-needed").
+- A concrete need for a >32 GB MoE appears (then Option c is the justification).
+- `talos-3` is confirmed to have a usable second high-bandwidth GPU attachment (removes the
+  cost/benefit uncertainty).
+- vLLM gains an XMX FA kernel *in llama.cpp* (would erase Option b's prefill advantage and
+  further weaken the case for a 2nd card).
+
+## Sources
+
+- [PMZFX — LLM benchmarks (single-card B70)][pmzfx-llm]
+- [PMZFX — engine comparison (SYCL vs vLLM-XPU; XMX FA)][pmzfx-engine]
+- [PMZFX — multi-GPU (layer-split / dual-card)][pmzfx-multi]
+- [PMZFX — methodology][pmzfx-method]
+- [PMZFX — upstream contributions][pmzfx-upstream]
+- [intel/llm-scaler#382 — vLLM MoE OOM on B70 (OPEN)][382]
+
+[pmzfx-llm]: https://github.com/PMZFX/intel-arc-pro-b70-benchmarks/blob/master/llm-benchmarks.md
+[pmzfx-engine]: https://github.com/PMZFX/intel-arc-pro-b70-benchmarks/blob/master/engine-comparison.md
+[pmzfx-multi]: https://github.com/PMZFX/intel-arc-pro-b70-benchmarks/blob/master/multi-gpu.md
+[pmzfx-method]: https://github.com/PMZFX/intel-arc-pro-b70-benchmarks/blob/master/methodology.md
+[pmzfx-upstream]: https://github.com/PMZFX/intel-arc-pro-b70-benchmarks/blob/master/upstream-contributions.md
+[382]: https://github.com/intel/llm-scaler/issues/382

--- a/kubernetes/apps/ai/comfyui/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/comfyui/app/helmrelease.yaml
@@ -27,6 +27,12 @@ spec:
     controllers:
       comfyui:
         # Single GPU + RWO model/input PVCs -> never run two pods at once.
+        # Default OFF: ComfyUI time-slices the one B70 against chat (vllm) and
+        # collapses chat decode ~38x (no hardware compute partition on Battlemage).
+        # Scale to 1 only for a deliberate image session AFTER scaling vllm +
+        # vllm-embed to 0; Flux returns this to 0 on the next reconcile. See
+        # docs/ai/b70-llm-serving-tuning.md (Single-card workload isolation).
+        replicas: 0
         strategy: Recreate
         pod:
           terminationGracePeriodSeconds: 60

--- a/kubernetes/apps/ai/vllm/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/vllm/app/helmrelease.yaml
@@ -46,10 +46,18 @@ spec:
               - "8000"
               - --ctx-size
               # Native window is 262144 (no yarn). Hybrid arch (10/40 full-attn
-              # layers, 2 KV heads) → ~20 KiB/token → ~2.6 GiB KV @128k. Single
-              # request gets the whole pool (kv_unified=true). Shares 32G B70 with
-              # vllm-embed + comfyui — step down to 98304/65536 on VRAM OOM.
+              # layers, 2 KV heads) → ~20 KiB/token → ~2.6 GiB KV @128k. The server
+              # auto-selects n_parallel=4 + kv_unified=true: the 128k pool is shared
+              # across up to 4 slots and a single request can address all of it.
+              # Pinned below for determinism (don't rely on auto-detect across image
+              # bumps — VRAM headroom is tight, ~22.7 GiB free with embeddings).
+              # Shares 32G B70 with vllm-embed + comfyui — step down to 98304/65536
+              # on VRAM OOM. Measured: ~61 t/s decode (SYCL), see
+              # docs/ai/b70-llm-serving-tuning.md.
               - "131072"
+              - --parallel
+              - "4"
+              - --kv-unified
               - -ngl
               - "99"
               - --jinja


### PR DESCRIPTION
## Summary

Benchmark-driven review of the single-Intel-Arc-Pro-B70 LLM stack on `talos-3`, executed measure-first (no knob changed on assumption). Every number below was measured live on build `server-intel-b9592`; full method + reproduction in `docs/ai/b70-llm-serving-tuning.md`.

## Headline result: keep SYCL (Vulkan A/B settled by measurement)

| Backend (b9592, MoE, q8_0 KV, 131072 ctx) | decode tg128 |
| --- | --- |
| **SYCL (current)** | **~61 t/s** (58.96 / 63.05 / 61.34) |
| Vulkan | ~36 t/s (stable 33–36) |

SYCL wins **1.68×**. The Reddit "Vulkan 2.5–3× faster on MoE" finding was from broken build `8739`; the SYCL MoE expert-dispatch penalty is **fixed** in `b9592` (PRs #21527/#21638 merged, `-DGGML_SYCL_F16=ON`). Our decode (~61) even **exceeds** the PMZFX `b8840` reference (54.7). Vulkan is feasible on our Intel-plugin node (ANV found the GPU off the render node, no `card0` needed) — it's just slower. **No image/backend change.**

## What changed

1. **`vllm/helmrelease.yaml`** — pin `--parallel 4` + `--kv-unified` (the server was relying on auto-detect; these are the explicit form of what it already selects, so VRAM footprint is unchanged — purely deterministic across image bumps, which matters given the tight ~22.7 GiB headroom). Comment corrected + measured numbers added.
2. **`comfyui/helmrelease.yaml`** — ⚠️ **behavior change, please confirm:** set `replicas: 0` (default OFF). ComfyUI currently has **no replicas pin in git** so it defaults to 1; the live "scaled to 0" state is a drift hazard Flux would revert. ComfyUI time-slices the one B70 against chat and collapses chat decode ~38×.
3. **`docs/ai/b70-llm-serving-tuning.md`** (new) — baseline table, backend A/B, tuning matrix, isolation runbook (chat↔ComfyUI mutual-exclusion toggle).
4. **`docs/ai/b70-second-card-decision.md`** (new) — dual-B70 cost/benefit; verdict **DEFER**.

## Knobs evaluated (measured, not assumed)

- **KV `q8_0` vs `f16`**: keep `q8_0` — required for 131072 to fit VRAM; the ~6% cost is moot (our q8_0 decode already beats the f16-capable reference).
- **Parallel slots**: auto `n_parallel=4` + `kv_unified=true` already optimal (single req gets full 131072; 4 slots give fleet concurrency). Pinned for determinism.
- **`--cache-reuse` 256 / `UD-Q4_K_XL` / `--threads`**: keep / skip (VRAM-tight) / excluded (no-op at `-ngl 99`).

## Real bottleneck

Not the backend or config — **single-card compute contention**. Chat decode collapses **38×** (61 → 1.6 t/s) under an embeddings flood; the B70 has no hardware compute partition and `sharedDevNum: 99` only multiplexes device count. Mitigation = the documented mutual-exclusion runbook; structural fix = a 2nd card (deferred).

## Validation

- `kustomize build … | kubeconform -strict`: vllm 3/3 valid, comfyui 2/2 valid.
- Pre-commit hooks passed.
- Live A/B performed by temporarily patching the deployment (HR suspended), then fully restored; post-restore SYCL decode reconfirmed at ~61 t/s (no regression), alias `qwen3.6-35b-a3b` still served, both pods Running on talos-3.
- Service names `vllm-app`/`vllm-embed`, alias, port 8000, and `/vllm` + `/vllm-embed` + `/v1` routes preserved (no service/route edits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)