### PR TITLE
fix(ai): revert vllm --parallel/--kv-unified pin (VRAM thrash, 0.5 t/s)

### DIFF
--- a/docs/ai/b70-llm-serving-tuning.md
+++ b/docs/ai/b70-llm-serving-tuning.md
@@ -124,13 +124,18 @@ Method: `flux suspend hr vllm` → patch deployment image to `ghcr.io/ggml-org/l
   exceeds** the `f16`-capable reference (54.7). We are not leaving meaningful decode on the
   table. **No change.**
 
-### Parallel slots — **KEEP auto (4 + kv_unified); pin for determinism**
+### Parallel slots — **KEEP auto (do NOT pin)**
 
 - Live server auto-selects `n_parallel=4, kv_unified=true`. With a unified KV cache, a single
   request addresses the full 131072 pool (verified: all 4 slots log `n_ctx=131072`) **and** up
   to 4 fleet requests can run concurrently. This is already the best of both worlds — no 1-vs-2-vs-4
-  trade-off to make. Recommend pinning `--parallel 4` + `--kv-unified` explicitly so the
-  behaviour can't silently change on an image bump (see §4).
+  trade-off to make.
+- ⚠️ **Pinning `--parallel 4 --kv-unified` explicitly was tried and reverted.** On `b9592` the
+  explicit flags overcommit the KV allocation and thrash the tight 32 GB VRAM — decode collapsed
+  to **~0.5 t/s** (slower than CPU; a thrashing signature) even on an idle card, while the *auto*
+  path with the identical reported values (`n_parallel=4, kv_unified=true`) runs at ~61 t/s.
+  **Leave it auto** — the auto path sizes the shared cache correctly. (Verified in production
+  2026-06-27; reverted same day.)
 
 ### `--cache-reuse` 256, `UD-Q4_K_XL`, `--threads`
 
@@ -139,9 +144,10 @@ Method: `flux suspend hr vllm` → patch deployment image to `ghcr.io/ggml-org/l
   **Skip** — current `UD-Q4_K_M` validated against the reference.
 - `--threads`: **excluded** per plan (confirmed no-op at `-ngl 99`).
 
-**Matrix conclusion:** keep the current image and all llama.cpp args. The only config change
-worth shipping is pinning the slot/KV behaviour for determinism (§4); the real win is
-workload isolation (§4) and, structurally, the second card.
+**Matrix conclusion:** keep the current image and all llama.cpp args **as auto** — no arg
+changes ship for the chat server (the one tried, pinning `--parallel/--kv-unified`, was
+reverted for VRAM thrash). The real win is workload isolation (§4) and, structurally, the
+second card.
 
 ## 4. Single-card workload isolation (B70 time-slice contention)
 

--- a/kubernetes/apps/ai/vllm/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/vllm/app/helmrelease.yaml
@@ -48,16 +48,15 @@ spec:
               # Native window is 262144 (no yarn). Hybrid arch (10/40 full-attn
               # layers, 2 KV heads) → ~20 KiB/token → ~2.6 GiB KV @128k. The server
               # auto-selects n_parallel=4 + kv_unified=true: the 128k pool is shared
-              # across up to 4 slots and a single request can address all of it.
-              # Pinned below for determinism (don't rely on auto-detect across image
-              # bumps — VRAM headroom is tight, ~22.7 GiB free with embeddings).
+              # across up to 4 slots and a single request can address all of it
+              # (~61 t/s decode, SYCL — see docs/ai/b70-llm-serving-tuning.md).
+              # DO NOT pin --parallel/--kv-unified explicitly: on b9592 that
+              # overcommits the KV allocation and thrashes the tight 32G VRAM,
+              # collapsing decode to ~0.5 t/s (verified 2026-06-27). The auto path
+              # sizes the shared cache correctly — leave it auto.
               # Shares 32G B70 with vllm-embed + comfyui — step down to 98304/65536
-              # on VRAM OOM. Measured: ~61 t/s decode (SYCL), see
-              # docs/ai/b70-llm-serving-tuning.md.
+              # on VRAM OOM.
               - "131072"
-              - --parallel
-              - "4"
-              - --kv-unified
               - -ngl
               - "99"
               - --jinja


### PR DESCRIPTION
## Urgent fix — production regression from #1092

PR #1092 pinned `--parallel 4 --kv-unified` on the chat server for determinism. **On build `b9592` this overcommits the KV allocation and thrashes the tight 32G B70 VRAM:** chat decode collapsed to **~0.5 t/s on an idle card** (no contention — verified chat + embeddings both idle), slower than CPU — a memory-thrashing signature.

The server's **auto** path reports the *identical* `n_parallel=4, kv_unified=true` yet runs at **~61 t/s** — so the auto path sizes the shared KV cache correctly and the explicit pin does not. 

### Change
- Remove `--parallel 4` + `--kv-unified` from `vllm/helmrelease.yaml` (back to auto).
- Document the trap in the arg comment + tuning runbook so it is not re-attempted.

ComfyUI `replicas: 0`, the docs, and the second-card memo from #1092 are unaffected and stay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)