### PR TITLE
fix(talos): disable MGLRU + pin sabnzbd off OOM-prone nodes

### DIFF
--- a/kubernetes/apps/downloads/sabnzbd/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/sabnzbd/app/helmrelease.yaml
@@ -125,11 +125,16 @@ spec:
                   - ALL
 
     defaultPodOptions:
-      # TEMPORARY: talos-1 is running on ~47Gi (single stick) pending the bad-RAM
-      # (Stick B) RMA. Under memory-PSI pressure Talos's runtime.OOMController
-      # repeatedly SIGKILLs sabnzbd's cgroup (par2/post-processing is the largest
-      # growing consumer there). Pin away from talos-1 until full RAM is restored,
-      # then REMOVE this affinity block. See docs/hardware-incidents.md (2026-06-19/20).
+      # TEMPORARY: pinned away from the two memory-pressured nodes (→ runs on talos-2).
+      # - talos-1: on ~47Gi (single stick) pending the bad-RAM (Stick B) RMA — under
+      #   memory-PSI pressure Talos's runtime.OOMController SIGKILLs sabnzbd's cgroup
+      #   (par2/post-processing is the largest growing consumer).
+      # - talos-3: B70 LLM stack + Ceph + tdarr transcodes, no swap + a kernel-6.18
+      #   MGLRU reclaim regression → node-wide OOM bursts. One killed sabnzbd (exit137)
+      #   as collateral on 2026-06-27. MGLRU is now disabled via machine.sysfs
+      #   (talos/machineconfig.yaml.j2); keep sabnzbd off talos-3 until that soaks.
+      # Re-evaluate: drop talos-1 after the RAM RMA, talos-3 after the MGLRU fix is
+      # proven. See docs/hardware-incidents.md (2026-06-19/20, 2026-06-27).
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -139,6 +144,7 @@ spec:
                     operator: NotIn
                     values:
                       - talos-1
+                      - talos-3
       topologySpreadConstraints:
         - maxSkew: 2
           topologyKey: kubernetes.io/hostname

--- a/talos/machineconfig.yaml.j2
+++ b/talos/machineconfig.yaml.j2
@@ -117,6 +117,16 @@ machine:
     vm.nr_hugepages: "1024"
     vm.swappiness: "1"
     vm.vfs_cache_pressure: "50"
+  sysfs:
+    # Disable MGLRU (multi-gen LRU). On kernel 6.18 the MGLRU reclaim path fails to
+    # reclaim page cache fast enough under heavy file I/O on these no-swap nodes, so
+    # the OOM-killer / Talos runtime.OOMController fires during transcode/backup/model
+    # bursts and SIGKILLs burstable pods even with reclaimable memory (talos-3 node-wide
+    # OOM on 2026-06-27 took out sabnzbd + vllm + tdarr). Writing 0 reverts to the
+    # classic active/inactive LRU. There is NO kernel cmdline arg for MGLRU — sysfs is
+    # the control; Talos applies machine.sysfs immediately (no reboot). See
+    # docs/hardware-incidents.md and reference_ceph_cascade_rootcause.
+    kernel/mm/lru_gen/enabled: "0"
   udev:
     rules:
       # NVMe scheduler optimization (none scheduler for NVMe)


### PR DESCRIPTION
## Why

talos-3 hit a **node-wide OOM on 2026-06-27 (16:10–16:13)** that SIGKILLed **sabnzbd, vllm, and tdarr** together. Kernel log confirms whole-node memory pressure (`Error/137` Talos `runtime.OOMController` kills on sabnzbd + vllm; tdarr blew its own cgroup limit). sabnzbd was using only **579Mi of its 10Gi limit** — innocent collateral, not the cause.

Root cause = the known talos-3 weakness: **kernel-6.18 MGLRU reclaim regression + no swap + heavy file I/O** (B70 model loads + Ceph + tdarr transcodes). MGLRU fails to reclaim page cache fast enough during I/O bursts, so the OOM-killer fires even with reclaimable memory.

## Changes

1. **`talos/machineconfig.yaml.j2`** — disable MGLRU cluster-wide via `machine.sysfs: kernel/mm/lru_gen/enabled: "0"` (reverts to classic active/inactive LRU). There is **no kernel cmdline arg** for MGLRU — sysfs is the only control. Talos applies `machine.sysfs` **immediately (no reboot)**, so the Ceph storage node is never rebooted. Cluster-wide because all nodes run the affected kernel and pods migrate.
2. **`kubernetes/apps/downloads/sabnzbd/app/helmrelease.yaml`** — extend anti-affinity to `NotIn [talos-1, talos-3]` so sabnzbd runs on talos-2, away from both pressured nodes (talos-1 = bad-RAM RMA pending; talos-3 = this OOM node). Revisit once MGLRU soaks + the talos-1 RAM RMA lands.

## Rollout

- **sabnzbd**: auto-deploys via Flux on merge → reschedules to talos-2.
- **MGLRU (talos/ is not Flux-managed)**: apply manually, **no reboot**:
  ```
  just talos apply-node talos-3   # add --dry-run first to preview; then talos-2, talos-1
  talosctl -n 10.10.10.13 read /sys/kernel/mm/lru_gen/enabled   # expect 0x0000
  ```

## Validation

- `kustomize build … sabnzbd/app | kubeconform -strict` → 3/3 valid.
- Talos `machine.sysfs` structure verified against Talos docs (applied-immediately list; `/`-separator = path under `/sys`, no remapping). Render/apply validation runs in the maintainer's talosctl+1Password env via `just talos apply-node --dry-run`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)