### PR TITLE
fix(radarr): pin off talos-1 (OOMController CrashLoop on reduced-RAM node)

### DIFF
--- a/kubernetes/apps/downloads/radarr/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/radarr/app/helmrelease.yaml
@@ -75,6 +75,22 @@ spec:
               readOnlyRootFilesystem: true
               capabilities: { drop: ["ALL"] }
 
+    defaultPodOptions:
+      # TEMPORARY: keep off talos-1 (reduced RAM ~47Gi, single stick, bad-stick RMA
+      # pending). Radarr's startup library disk-scan grows memory; on the RAM-starved
+      # node Talos runtime.OOMController SIGKILLs its cgroup (exit137/Error, NO K8s OOM
+      # event) → CrashLoop (101 restarts/21h, 2026-06-28). Remove after the RAM RMA.
+      # Same pattern as sabnzbd. See docs/hardware-incidents.md.
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/hostname
+                    operator: NotIn
+                    values:
+                      - talos-1
+
     service:
       app:
         controller: *app


### PR DESCRIPTION
## Why radarr is down

radarr is **CrashLoopBackOff — 101 restarts in 21h** on **talos-1**, killed with **exit137 / reason `Error`**. talos-1 `dmesg` confirms **Talos `runtime.OOMController` repeatedly `Sending SIGKILL to cgroup .../pod25ab080a-...`** (= radarr''s pod UID) under node memory pressure. talos-1 is on **~47Gi (single stick, bad-stick RMA pending)**. radarr''s startup **library disk-scan** grows its memory and tips the RAM-starved node over; the previous-container logs show it dying mid-scan with no app error = external SIGKILL, not a crash. It was never pinned off talos-1 like sabnzbd.

## Fix

Add `defaultPodOptions.affinity.nodeAffinity` → `NotIn [talos-1]` so radarr schedules on talos-2/talos-3 (both healthy; talos-3''s MGLRU OOM was fixed in #1094). Same pattern as sabnzbd. Temporary — remove after the talos-1 RAM RMA.

## Validation
`kustomize build … radarr/app | kubeconform -strict` → 2/2 valid.

After merge, Flux reschedules radarr off talos-1 and the CrashLoop ends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)