### PR TITLE
feat(hermes): route Grok via OpenRouter, retire xai-oauth subscription

### DIFF
--- a/kubernetes/apps/ai/agentgateway/app/rules/cost.yaml
+++ b/kubernetes/apps/ai/agentgateway/app/rules/cost.yaml
@@ -92,6 +92,24 @@ spec:
         - record: *price
           labels: { gen_ai_request_model: grok-4.3, gen_ai_token_type: output }
           expr: vector(2.50)
+        # --- OpenRouter (/openrouter) - slug-form ids (with provider prefix),
+        # billed PAYG from OpenRouter credit at provider list price (no markup).
+        # Hermes vision + fallback use x-ai/grok-4.3; agentmemory consolidation
+        # uses deepseek/deepseek-v4-flash. Distinct from the bare grok-4.3 /
+        # deepseek-v4-flash ids above (direct xAI / free OpenCode-Go routes).
+        # deepseek rate is an estimate — confirm on the live OpenRouter model page. ---
+        - record: *price
+          labels: { gen_ai_request_model: x-ai/grok-4.3, gen_ai_token_type: input }
+          expr: vector(1.25)
+        - record: *price
+          labels: { gen_ai_request_model: x-ai/grok-4.3, gen_ai_token_type: output }
+          expr: vector(2.50)
+        - record: *price
+          labels: { gen_ai_request_model: deepseek/deepseek-v4-flash, gen_ai_token_type: input }
+          expr: vector(0.09)
+        - record: *price
+          labels: { gen_ai_request_model: deepseek/deepseek-v4-flash, gen_ai_token_type: output }
+          expr: vector(0.18)
         # --- OpenCode Go (/opencodego) - flat $10/mo subscription, so the
         # marginal per-token cost is $0 (the fixed monthly fee is not captured
         # by token metrics). Priced at 0 so Go traffic leaves the "unpriced

--- a/kubernetes/apps/ai/hermes/app/resources/config.yaml
+++ b/kubernetes/apps/ai/hermes/app/resources/config.yaml
@@ -30,28 +30,38 @@ custom_providers:
     base_url: http://internal-noauth.ai.svc.cluster.local/vllm/v1
     api_key: no-auth
     api_mode: chat_completions
+  # Cloud models via OpenRouter (one key, no per-token markup). The gateway's
+  # /openrouter route injects the real OPENROUTER_API_KEY upstream and overrides
+  # Authorization, so the api_key here is a dummy — `no-auth` survives the v11->12
+  # migration (the `no-key-required` sentinel would be dropped). Referenced as
+  # `custom:openrouter`; call models by their OpenRouter slug (e.g. x-ai/grok-4.3).
+  # Replaced the xai-oauth Grok subscription for vision + fallback (PR: openrouter move).
+  - name: openrouter
+    base_url: http://internal-noauth.ai.svc.cluster.local/openrouter/v1
+    api_key: no-auth
+    api_mode: chat_completions
 
 # Default serving model: the local Qwen3.6-35B-A3B on the B70 (custom:local ->
 # /vllm route). Free and rate-limit-proof, so long-running tasks never hit the
 # xAI subscription throttle or the OpenCode-Go GoUsageLimitError. To serve a
-# cloud model instead, set e.g. model: { default: grok-4.3, provider: xai-oauth }.
+# cloud model instead, set e.g. model: { default: x-ai/grok-4.3, provider: custom:openrouter }.
 model:
   default: qwen3.6-35b-a3b
   provider: custom:local
 
 # Fail-over chain for the MAIN agentic loop: if the local B70 model errors or is
 # unavailable (e.g. ComfyUI scaled vllm to 0 under the Dedicated-VRAM runbook),
-# fall back to glm-5.1 via the gateway, then to Grok (xai-oauth subscription;
-# creds added once with `hermes auth add xai-oauth --manual-paste`, kept in
-# /opt/data/auth.json). glm-5.1 is the strongest tool-caller on the OpenCode-Go
+# fall back to glm-5.1 via the gateway, then to Grok (x-ai/grok-4.3 via the
+# /openrouter route, billed PAYG from OpenRouter credit — replaced the old
+# xai-oauth subscription). glm-5.1 is the strongest tool-caller on the OpenCode-Go
 # sub (tops τ²-bench / BFCL agentic vs kimi/deepseek/qwen), which matters because
 # this fallback runs the full tool-calling loop. The aux chores below stay on
 # kimi-k2.6 — they only summarise content, they don't tool-call.
 fallback_providers:
   - provider: custom:gateway
     model: glm-5.1
-  - provider: xai-oauth
-    model: grok-4.3
+  - provider: custom:openrouter
+    model: x-ai/grok-4.3
 
 # Auxiliary context chores run on kimi via the gateway, NOT the local model:
 # web_extract fires N parallel LLM calls (one per fetched page) on large content,
@@ -67,14 +77,14 @@ auxiliary:
     provider: custom:gateway
     model: kimi-k2.6
     fallback_chain:
-      - provider: xai-oauth
-        model: grok-4.3
+      - provider: custom:openrouter
+        model: x-ai/grok-4.3
   compression:
     provider: custom:gateway
     model: kimi-k2.6
     fallback_chain:
-      - provider: xai-oauth
-        model: grok-4.3
+      - provider: custom:openrouter
+        model: x-ai/grok-4.3
   session_search:
     provider: custom:gateway
     model: kimi-k2.6
@@ -82,8 +92,8 @@ auxiliary:
     provider: custom:gateway
     model: kimi-k2.6
   vision:
-    provider: xai-oauth
-    model: grok-4.3
+    provider: custom:openrouter
+    model: x-ai/grok-4.3
 
 # Web search via the SearXNG instance already running in ns ai.
 web:


### PR DESCRIPTION
## Phase 1 of consolidating cloud LLM onto OpenRouter

Routes Grok through **OpenRouter** instead of the standalone **$30/mo xAI SuperGrok subscription**, so that sub can be cancelled. Grok is now only a fallback + vision model in Hermes (demoted when the default flipped to the local B70), so PAYG OpenRouter credit at grok-4.3's $1.25/$2.50 is cheaper than a flat sub.

### Changes
- **`kubernetes/apps/ai/hermes/app/resources/config.yaml`**
  - Adds a `custom:openrouter` provider (internal-noauth `/openrouter` route; the gateway injects the real `OPENROUTER_API_KEY` upstream, so the in-config key is the usual `no-auth` dummy).
  - Repoints **vision**, the **main-loop fallback** (`fallback_providers[1]`), and the **aux** `web_extract` / `compression` fallback chains from `xai-oauth grok-4.3` → `custom:openrouter x-ai/grok-4.3`.
  - **Unchanged:** `model.default` stays `custom:local` (local 35B remains main + OpenRouter-outage insurance); OpenCode-Go (`custom:gateway` glm/kimi) untouched.
- **`kubernetes/apps/ai/agentgateway/app/rules/cost.yaml`**
  - Adds price rows for the OpenRouter slug-form ids `x-ai/grok-4.3` ($1.25/$2.50) and `deepseek/deepseek-v4-flash` ($0.09/$0.18, estimate) so the spend dashboard keeps counting them.

### Verification
- `kustomize build` of both apps: OK. `yq` parse of both files: OK.
- **Live smoke test:** a real `x-ai/grok-4.3` completion through `internal-noauth/openrouter/v1/chat/completions` returned **HTTP 200**, billed PAYG (`is_byok=false`). The `openrouter-secret` ExternalSecret is `SecretSynced`.

### Notes
- The `xai-oauth` creds in `/opt/data/auth.json` are left in place for now — **keep the $30 sub live for ~1 month** while watching real OpenRouter spend, then cancel and (optionally) `hermes auth remove xai-oauth`.
- The agentgateway `xai.yaml` backend (direct `XAI_API_KEY`, pay-as-you-go) is a separate path and is intentionally untouched.
- **Not in this PR:** Phase 2 (agentmemory embeddings + consolidation → OpenRouter, frees the B70) ships as its own PR with a snapshot-gated re-index. Image generation (Phase 3) is a later spike.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
