### PR TITLE
feat(vllm): scale vllm-embed to 0 (agentmemory on OpenRouter embeddings)

### DIFF
--- a/kubernetes/apps/ai/vllm/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/vllm/app/helmrelease.yaml
@@ -112,6 +112,11 @@ spec:
               liveness: *probe
 
       vllm-embed:
+        # Scaled to 0: agentmemory (its only consumer) moved to OpenRouter
+        # embeddings (text-embedding-3-small, 1536-dim) on 2026-06-28, freeing
+        # this B70 gpu.intel.com/xe slot + ~5GB VRAM. Controller + PVC kept so
+        # restoring local embeddings is a one-line revert (replicas: 0 -> 1).
+        replicas: 0
         strategy: Recreate
         containers:
           app:


### PR DESCRIPTION
## Final step of the OpenRouter cutover

Scales the local `vllm-embed` (Qwen3-VL-Embedding-2B) to **0**. agentmemory was its only consumer and moved to OpenRouter `text-embedding-3-small` (1536-dim) in #1097, so the embedder is now unused. This frees a `gpu.intel.com/xe` slot + ~5 GB VRAM on the single B70 — the GPU-contention relief this whole effort targeted.

- Controller + PVC kept (`replicas: 0`, not removed) → one-line revert to local embeddings.
- The chat controller (`vllm`, llama.cpp 35B) is unchanged.
- Rollback safety net for the embeddings cutover: RBD VolumeSnapshot `agentmemory-pre-openrouter-cutover` (ns `ai`) is retained.

Verified before this step: OpenRouter embeddings return 1536-dim and new memories are semantically searchable end-to-end. Note: pre-cutover observation backlog is keyword-searchable only (embedding-model swap; accepted tradeoff).

Follows #1096 (Phase 1) and #1097 (Phase 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
