### PR TITLE
feat(downloads): janitor cronjob + shared-downloads capacity alert

### DIFF
--- a/docs/downloads/sabnzbd-disk-space-runbook.md
+++ b/docs/downloads/sabnzbd-disk-space-runbook.md
@@ -1,0 +1,157 @@
+# Runbook: shared-downloads disk-full / SABnzbd auto-pause
+
+When SABnzbd reports "Too little diskspace forcing PAUSE" (or sits globally
+paused with a full queue) and the movie pipeline (download → import → transcode)
+stalls. The disk that fills is the **2 Ti `shared-downloads` CephFS RWX PVC**
+(ns `downloads`, StorageClass `ceph-filesystem-rwx`) that holds
+`usenet/complete/` — *not* the RBD `sabnzbd-incomplete` scratch volume.
+
+- **Guardrails in Git** → `kubernetes/apps/downloads/maintenance/` (janitor CronJob + capacity alert, this incident's output)
+- **Prior art** → the 2026-06-24 `_UNPACK_` cleanup (memory/`reference_sabnzbd_complete_unpack_diskfull`)
+- **Ceph-side context** → [`../ceph-cluster-changelog.md`](../ceph-cluster-changelog.md)
+
+---
+
+## Incident 2026-07-03 — 96% full, ~1.7 TiB of dead data
+
+`shared-downloads` hit **96% used (84 GiB free)**, tripping SABnzbd's
+`complete_free=100G` auto-pause with 126 queued jobs. Ceph itself went
+HEALTH_WARN (osd.3 nearfull, 10 PGs `backfill_toofull`) — a downloads-volume
+problem became a storage-cluster problem. Nothing alerted before the pause.
+
+Where the space went (all sizes from `du` in the **radarr** pod — see the
+gotcha below for why not the sab pod):
+
+| Tier | What | Size | Root cause |
+|------|------|------|------------|
+| a | **Ghost pre-migration `usenet/incomplete` tree on CephFS** | **498 GiB** | PR #983 moved SAB's `download_dir` onto an RBD PVC but never deleted the old CephFS data. The sab pod's RBD mount *shadows* the path, so the ghost tree was invisible in the sab pod while still consuming quota. |
+| b | **Orphaned `_UNPACK_*` / `_FAILED_*` / numbered-duplicate dirs** under `complete/movies` | **1030 GiB** | Death spiral: disk fills → unpack fails partway → SAB retries → new numbered `_UNPACK_` turd → even less space. 18 Shutter Island attempts, 25 For.a.Few.Dollars.More, 12 Jaws. Nothing ever GC'd failed unpack dirs. |
+| c | **Unpacked-but-never-cleaned dirs** whose movie was already in the NAS library at equal/better quality | **183 GiB** | "Not an upgrade" `importPending` items — Radarr won't import them, won't delete them, they sit forever. |
+| — | **Root-level uncategorized side-channel dumps** (manual/uncategorized adds, no *arr tracking) | **237 GiB** | Downloads that never went through Radarr/Sonarr get no completed-download cleanup — a permanent leak. |
+
+### Decisions made (2026-07-03, recorded here so they stick)
+
+1. **The MegaPACK / root-level side-channel dumps were DELETED, not archived.**
+2. **Side-channel downloads are STOPPED as policy.** Every download must flow
+   through Radarr/Sonarr/Lidarr so completed-download handling cleans up after
+   import. Corollary: the janitor deliberately does **not** delete non-empty
+   regular dirs — under this policy any such dir is either an active job or a
+   policy violation a human should look at, never something to auto-delete.
+
+---
+
+## ⚠️ The ghost-under-mount gotcha (read before deleting anything)
+
+The sabnzbd pod mounts the RBD `sabnzbd-incomplete` PVC **on top of**
+`/data/downloads/usenet/incomplete`, over the CephFS `shared-downloads` mount.
+Two consequences:
+
+- The old CephFS `usenet/incomplete` data is **invisible inside the sab pod**
+  (hidden under the mountpoint) but still counts against the PVC. `df` in the
+  sab pod shows the usage; `du` in the sab pod can't find it.
+- **NEVER delete `usenet/incomplete` contents from inside the sab pod** — you
+  would be deleting from the **live RBD scratch volume** (active article
+  assembly), not the ghost data.
+
+The correct vantage point is the **radarr pod** (or sonarr, or a one-off debug
+pod): it mounts `shared-downloads` as plain CephFS with no RBD overlay, so it
+sees — and can safely delete — the ghost tree. This asymmetry is the whole
+reason the ghost data survived PR #983 unnoticed.
+
+---
+
+## Triage one-liners
+
+```bash
+# 1. How full is it really? (sab pod — df is accurate, du is not; see gotcha)
+kubectl -n downloads exec deploy/sabnzbd -c app -- df -h /data/downloads
+
+# 2. Where did it go? (radarr pod — sees the true CephFS tree incl. ghosts)
+kubectl -n downloads exec deploy/radarr -c app -- \
+  sh -c "du -sm /data/downloads/usenet/incomplete /data/downloads/usenet/complete/* /data/downloads/* 2>/dev/null | sort -rn | head -30"
+
+# 3. Is SABnzbd paused, and what's queued? (API key: secret sabnzbd-secret, field SABNZBD_API_KEY)
+kubectl -n downloads exec deploy/sabnzbd -c app -- \
+  sh -c 'curl -s "http://localhost:8080/api?mode=queue&output=json&apikey=$SABNZBD_API_KEY" | head -c 2000'
+
+# 4. What is Radarr stuck on? (API key: secret radarr-secret, field RADARR__AUTH__APIKEY)
+kubectl -n downloads exec deploy/radarr -c app -- \
+  sh -c 'curl -s -H "X-Api-Key: $RADARR__AUTH__APIKEY" "http://localhost:7878/api/v3/queue?pageSize=200"' | head -c 4000
+
+# 5. Orphaned unpack turds right now?
+kubectl -n downloads exec deploy/radarr -c app -- \
+  sh -c "find /data/downloads/usenet/complete -mindepth 2 -maxdepth 2 -type d \( -name '_UNPACK_*' -o -name '_FAILED_*' \) | wc -l"
+```
+
+Cross-check before deleting any `_UNPACK_*` dir: a fresh mtime may belong to a
+queued/paused SAB job that will resume and reuse it — compare against the SAB
+queue (one-liner 3) and only remove dirs with no matching active job.
+
+## ⚠️ Ceph caution: batch the deletes
+
+Bulk `rm -rf` on CephFS is metadata work on the MDS, and sustained full-throttle
+IO **wedges the small OSDs** (osd.0/osd.6 — the same reason data migrations use
+`rsync --bwlimit=80M`). Delete in batches (a few hundred GiB at a time), watch
+`ceph status` from the rook toolbox between batches, and pause if slow-ops
+warnings appear. This matters double when Ceph is already nearfull, as it was
+during this incident.
+
+---
+
+## Durable guardrails (deployed from this incident)
+
+Both live in `kubernetes/apps/downloads/maintenance/` (Flux ks
+`downloads-maintenance`):
+
+### 1. `downloads-janitor` CronJob — daily 05:30
+
+Mounts `shared-downloads` at `/data/downloads` and, at depth 2 under
+`usenet/complete` only (`complete/<category>/<dir>`):
+
+- deletes `_UNPACK_*` / `_FAILED_*` dirs untouched for **>24 h** (a live unpack
+  keeps its mtime fresh; day-old attempts are dead — SAB starts a *new*
+  numbered dir on retry)
+- prunes **empty** dirs older than 7 days
+
+It prints every path before removing it, so the Job log is an audit trail
+(`kubectl -n downloads logs job/<downloads-janitor-...>`). It never touches
+non-empty regular dirs (see decision 2), the `complete/` root level, or
+`usenet/incomplete`.
+
+Manual dry-run of the same selection, any time:
+
+```bash
+kubectl -n downloads exec deploy/radarr -c app -- \
+  sh -c "find /data/downloads/usenet/complete -mindepth 2 -maxdepth 2 -type d \( -name '_UNPACK_*' -o -name '_FAILED_*' \) -mmin +1440 -print"
+```
+
+### 2. `SharedDownloadsAlmostFull` PrometheusRule
+
+Fires on kubelet volume stats for the `shared-downloads` PVC:
+
+- **warning**: <15% free for 30m
+- **critical**: <7% free for 15m
+
+Rationale: SAB pauses at 100 G free ≈ **5%** of 2 Ti, so both thresholds fire
+*before* the pipeline freezes — the whole point is that a human acts first.
+(Consumed by the VictoriaMetrics operator's PrometheusRule→VMRule converter,
+same as every other rule in this repo.)
+
+---
+
+## Notes
+
+- **SAB's disk thresholds are runtime state, not GitOps.** `complete_free=100G`,
+  `download_free=100G` and `direct_unpack=1` were set via the SAB API
+  (2026-06-24) and live in the sabnzbd **config PVC** — they survive restarts
+  but are invisible in Git. If the config PVC is ever rebuilt, re-apply them
+  via `api?mode=set_config`.
+- The Radarr-grabbed happy path is correctly configured and was NOT the leak
+  (`enableCompletedDownloadHandling=true`, `autoRedownloadFailed=true`,
+  `downloadClientWorkingFolders=_UNPACK_|_FAILED_`, SAB `fail_hopeless_jobs=1`).
+  The leaks were the ghost tree, failed-unpack orphans, and side-channel
+  downloads — the first is one-time, the other two are covered by the janitor
+  and by decision 2.
+- Tier-c "Not an upgrade" items must also be cleared from the **Radarr queue**
+  (`DELETE /api/v3/queue/{id}?removeFromClient=true&blocklist=true`), not just
+  from disk, or Radarr re-grabs them.

--- a/kubernetes/apps/downloads/kustomization.yaml
+++ b/kubernetes/apps/downloads/kustomization.yaml
@@ -15,6 +15,7 @@ resources:
   # - ./cross-seed/ks.yaml
   - ./flaresolverr/ks.yaml
   - ./lidarr/ks.yaml
+  - ./maintenance/ks.yaml
   - ./prowlarr/ks.yaml
   - ./pvc/ks.yaml
   # - ./qbittorrent/ks.yaml

--- a/kubernetes/apps/downloads/maintenance/app/cronjob.yaml
+++ b/kubernetes/apps/downloads/maintenance/app/cronjob.yaml
@@ -1,0 +1,83 @@
+---
+# Daily janitor for the shared-downloads CephFS volume (2026-07-03 incident:
+# the 2 Ti PVC hit 96% and tripped SABnzbd's complete_free=100G auto-pause;
+# ~1 TiB of it was orphaned _UNPACK_*/_FAILED_* dirs — SAB retry-loops unpacks
+# as the disk fills and never garbage-collects the failed attempts).
+# Full writeup: docs/downloads/sabnzbd-disk-space-runbook.md
+#
+# Scope is DELIBERATELY narrow — depth-2 under usenet/complete only
+# (i.e. complete/<category>/<dir>):
+#   1. _UNPACK_*/_FAILED_* dirs untouched for >24h (a live unpack keeps its
+#      mtime fresh; anything a day old is a dead attempt SAB will never reuse)
+#   2. empty leftover dirs older than 7 days
+# It NEVER touches non-empty regular dirs (all downloads flow through the
+# *arrs whose completed-download handling cleans them — side-channel
+# downloads are stopped as policy, see runbook), NEVER the complete/ root
+# level, and NEVER usenet/incomplete (live SABnzbd assembly area).
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: downloads-janitor
+  labels:
+    app.kubernetes.io/component: maintenance
+spec:
+  schedule: "30 5 * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  startingDeadlineSeconds: 600
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      ttlSecondsAfterFinished: 86400
+      activeDeadlineSeconds: 3600
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/component: maintenance
+        spec:
+          restartPolicy: OnFailure
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 2000
+            runAsGroup: 2000
+            fsGroup: 2000
+          containers:
+            - name: janitor
+              # renovate: datasource=docker depName=mirror.gcr.io/alpine
+              image: mirror.gcr.io/alpine:3.22
+              imagePullPolicy: IfNotPresent
+              command:
+                - /bin/sh
+                - -ec
+                - |
+                  root=/data/downloads/usenet/complete
+                  echo "[$(date -u +%FT%TZ)] downloads-janitor starting (root=${root})"
+                  echo "--- deleting stale _UNPACK_/_FAILED_ dirs (depth 2, untouched >24h) ---"
+                  find "${root}" -mindepth 2 -maxdepth 2 -type d \
+                    \( -name '_UNPACK_*' -o -name '_FAILED_*' \) -mmin +1440 \
+                    -print -exec rm -rf {} +
+                  echo "--- pruning empty leftover dirs (depth 2, older than 7d) ---"
+                  find "${root}" -mindepth 2 -maxdepth 2 -type d -empty -mtime +7 \
+                    -print -exec rmdir {} +
+                  echo "[$(date -u +%FT%TZ)] downloads-janitor done"
+                  df -h /data/downloads
+              volumeMounts:
+                - name: downloads
+                  mountPath: /data/downloads
+              resources:
+                requests:
+                  cpu: 10m
+                  memory: 32Mi
+                limits:
+                  cpu: 100m
+                  memory: 128Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                capabilities:
+                  drop: ["ALL"]
+          volumes:
+            - name: downloads
+              persistentVolumeClaim:
+                claimName: shared-downloads

--- a/kubernetes/apps/downloads/maintenance/app/kustomization.yaml
+++ b/kubernetes/apps/downloads/maintenance/app/kustomization.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./cronjob.yaml
+  - ./prometheusrule.yaml

--- a/kubernetes/apps/downloads/maintenance/app/prometheusrule.yaml
+++ b/kubernetes/apps/downloads/maintenance/app/prometheusrule.yaml
@@ -1,0 +1,43 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/monitoring.coreos.com/prometheusrule_v1.json
+# Capacity tripwire from the 2026-07-03 incident: shared-downloads (2 Ti CephFS
+# RWX) silently filled to 96% with dead data, SABnzbd hit its complete_free=100G
+# auto-pause and the whole usenet pipeline froze — nothing alerted first.
+# 100G ≈ 5% of 2 Ti, so these thresholds (15% warn / 7% crit) fire BEFORE the
+# pause trips. Runbook: docs/downloads/sabnzbd-disk-space-runbook.md
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: downloads-maintenance-rules
+spec:
+  groups:
+    - name: shared-downloads-capacity.rules
+      rules:
+        - alert: SharedDownloadsAlmostFull
+          expr: |-
+            kubelet_volume_stats_available_bytes{namespace="downloads", persistentvolumeclaim="shared-downloads"}
+              / kubelet_volume_stats_capacity_bytes{namespace="downloads", persistentvolumeclaim="shared-downloads"} < 0.15
+          for: 30m
+          annotations:
+            summary: >-
+              shared-downloads has been below 15% free for 30m
+              ({{ $value | humanizePercentage }} available). SABnzbd auto-pauses
+              at 100G free (~5% of 2Ti) — clean up NOW, before the pipeline
+              freezes: check for _UNPACK_/_FAILED_ orphans and side-channel
+              dumps (docs/downloads/sabnzbd-disk-space-runbook.md).
+          labels:
+            severity: warning
+        - alert: SharedDownloadsAlmostFull
+          expr: |-
+            kubelet_volume_stats_available_bytes{namespace="downloads", persistentvolumeclaim="shared-downloads"}
+              / kubelet_volume_stats_capacity_bytes{namespace="downloads", persistentvolumeclaim="shared-downloads"} < 0.07
+          for: 15m
+          annotations:
+            summary: >-
+              shared-downloads is below 7% free
+              ({{ $value | humanizePercentage }} available) — SABnzbd's 100G
+              complete_free pause is imminent or already tripped, and Ceph
+              nearfull follows (2026-07-03 pattern). Reclaim space immediately
+              per docs/downloads/sabnzbd-disk-space-runbook.md.
+          labels:
+            severity: critical

--- a/kubernetes/apps/downloads/maintenance/ks.yaml
+++ b/kubernetes/apps/downloads/maintenance/ks.yaml
@@ -1,0 +1,25 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app downloads-maintenance
+  namespace: &namespace downloads
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: downloads-pvc
+      namespace: downloads
+  interval: 1h
+  path: ./kubernetes/apps/downloads/maintenance/app
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  timeout: 5m
+  wait: false


### PR DESCRIPTION
## Summary

Durable GitOps guardrails from the **2026-07-03 shared-downloads disk-full incident**: the 2 Ti CephFS RWX PVC hit 96% (84 GiB free), tripped SABnzbd's `complete_free=100G` auto-pause with 126 queued jobs, and pushed Ceph into HEALTH_WARN (osd.3 nearfull, 10 PGs backfill_toofull). Triage found ~1.7 TiB of dead data: a 498 GiB ghost pre-PR-#983 `usenet/incomplete` tree hidden under the sab pod's RBD mount, 1030 GiB of orphaned `_UNPACK_*`/`_FAILED_*` retry turds, 183 GiB of never-cleaned "Not an upgrade" leftovers, and 237 GiB of untracked side-channel dumps.

New Flux app `kubernetes/apps/downloads/maintenance/`:

- **`downloads-janitor` CronJob** (daily 05:30, alpine, uid/gid 2000, read-only rootfs, no caps): deletes `_UNPACK_*`/`_FAILED_*` dirs untouched >24h and empty dirs >7d, **depth-2 under `usenet/complete` only**. Prints every path before removal (auditable Job logs). Deliberately never touches non-empty regular dirs, the `complete/` root level, or `usenet/incomplete`.
- **`SharedDownloadsAlmostFull` PrometheusRule**: warning <15% free for 30m, critical <7% free for 15m — fires *before* SAB's 100G pause (~5% of 2Ti). Consumed by the VM-operator PrometheusRule converter like all other rules.
- **`docs/downloads/sabnzbd-disk-space-runbook.md`**: incident writeup, the ghost-under-mount gotcha (delete from the **radarr** pod, never sab — its RBD mount shadows the path), triage one-liners, Ceph batch-delete caution, the API-set SAB thresholds note, and the two recorded decisions (MegaPACK dumps deleted, not archived; side-channel downloads stopped as policy).

## Validation

- `task flux:test:ns NAMESPACE=downloads` — fails for environment reasons (flux-local temp-file `PermissionError`, known-broken on Windows)
- Fallback: `kustomize build kubernetes/apps/downloads/maintenance/app | kubeconform -strict` with the datree CRD catalog — **2/2 valid** (CronJob + PrometheusRule, no skips)
- `kubeconform -strict` on `maintenance/ks.yaml` (Flux Kustomization schema) — valid
- `kustomize build kubernetes/apps/downloads` — namespace kustomization builds with the new `./maintenance/ks.yaml` entry

## Deployment note

⚠️ **Do not merge yet** — deployment is gated on the in-flight cluster cleanup task (ghost-tree + orphan deletion). After merge + reconcile, trigger one manual run (`kubectl -n downloads create job --from=cronjob/downloads-janitor downloads-janitor-manual`) and verify the log deletes nothing unexpected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)