### PR TITLE
fix(github-action): source TALOS_VERSION from .mise.toml in talosctl-busybox build

### DIFF
--- a/.github/workflows/build-talosctl-busybox.yaml
+++ b/.github/workflows/build-talosctl-busybox.yaml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       talos_version:
-        description: "Talos version to build (overrides talenv.yaml)"
+        description: "Talos version to build (overrides .mise.toml)"
         required: false
         type: string
   push:

--- a/.github/workflows/build-talosctl-busybox.yaml
+++ b/.github/workflows/build-talosctl-busybox.yaml
@@ -13,7 +13,7 @@ on:
     branches:
       - main
     paths:
-      - "talos/talenv.yaml"
+      - ".mise.toml"
       - ".github/docker/talosctl-busybox/**"
       - ".github/workflows/build-talosctl-busybox.yaml"
 
@@ -53,7 +53,9 @@ jobs:
           if [ -n "${{ inputs.talos_version }}" ]; then
             VERSION="${{ inputs.talos_version }}"
           else
-            VERSION=$(grep 'talosVersion:' talos/talenv.yaml | awk '{print $2}')
+            # Talos version is pinned in .mise.toml (tools."aqua:siderolabs/talos"); that value has
+            # no "v" prefix, but ghcr.io/siderolabs/talosctl image tags do, so prepend one.
+            VERSION="v$(python3 -c "import tomllib; print(tomllib.load(open('.mise.toml', 'rb'))['tools']['aqua:siderolabs/talos'])")"
           fi
           echo "talos_version=${VERSION}" >> $GITHUB_OUTPUT
           echo "Using Talos version: ${VERSION}"


### PR DESCRIPTION
## Intent

Fix .github/workflows/build-talosctl-busybox.yaml's broken Talos-version lookup. Every run has failed since run #36 on 2026-05-31 (roughly 82 days, 17 consecutive failures). Root cause: the workflow computed its TALOS_VERSION build-arg via grep 'talosVersion:' talos/talenv.yaml | awk '{print $2}', but talos/talenv.yaml was deleted in commit d209d4dc (PR #881, 2026-05-31, the SOPS/age-to-1Password/ESO cutover) one day after the workflow's last success. The grep matched nothing, the build-arg resolved to an empty string, and FROM ghcr.io/siderolabs/talosctl: (no tag) failed to parse, confirmed from the actual failing job log (buildx: failed to parse stage name "ghcr.io/siderolabs/talosctl:": invalid reference format).

Fix requirement: source the Talos version from wherever it actually lives now instead of the deleted file. Two live sources exist: .mise.toml:38 ("aqua:siderolabs/talos" = "1.13.2") and talos/machineconfig.yaml.j2:52 (hardcoded there too). Checked whether any other workflow in .github/workflows/ already has a pattern for reading a version out of .mise.toml (via mise itself, or a grep/yq/jq extraction) to follow for consistency - none exists, so .mise.toml was picked as the source since it is this repo's canonical tool-version-pinning file. The version must be extracted cleanly: use a proper TOML parse if mise or a TOML tool is available in the workflow's runner image, or a precise, commented grep/sed if not, rather than swapping one fragile grep for another.

This is a clean, unambiguous bug with one root cause - no captain/product decision needed, just fix the version-source reference. Do not touch anything else in the workflow file beyond what's needed for this fix.

Acceptance criteria: the workflow's TALOS_VERSION build-arg resolves to a real, non-empty version string; the Docker build stage FROM ghcr.io/siderolabs/talosctl:<version> parses and succeeds; the fix must be confirmed against a real CI run (trigger the workflow or verify via the PR's own CI run) - a fix that looks correct by inspection but hasn't been confirmed against a real CI run does not meet the bar, given the bug's whole history is 'looked fine, silently broken.'

Implementation delivered: sourced TALOS_VERSION from .mise.toml via 'python3 -c "import tomllib; ..."' (tomllib is built into Python 3.11+, which the ubuntu-latest runner ships, so no new tool install was needed), prepending a 'v' since .mise.toml stores the bare version (1.13.2) while ghcr.io/siderolabs/talosctl image tags use the v-prefixed form (matches the v-prefixed convention already used for the same Talos version elsewhere in the repo, e.g. talos/machineconfig.yaml.j2's installer image tag). Also updated the push.paths trigger from the deleted talos/talenv.yaml to .mise.toml so the workflow continues to auto-trigger on future Talos version bumps, since that trigger path referenced the same deleted file this fix addresses. Verified locally (via a Python 3.11+ interpreter) that the extraction resolves to v1.13.2, a valid non-empty tag.

## What Changed

- Replaced the `grep 'talosVersion:' talos/talenv.yaml | awk '{print $2}'` version lookup (broken since `talos/talenv.yaml` was deleted) with a `python3 -c "import tomllib; ..."` extraction of `tools."aqua:siderolabs/talos"` from `.mise.toml`, prepending a `v` to match the `ghcr.io/siderolabs/talosctl` image tag convention.
- Updated the `workflow_dispatch` input description and the `push.paths` trigger from `talos/talenv.yaml` to `.mise.toml` so the workflow still auto-triggers on future Talos version bumps.

## Risk Assessment

✅ Low: Single-file, 4-line diff that replaces a fragile grep against a deleted file with a built-in tomllib parse of the correct canonical source (.mise.toml); I independently reproduced the extraction with Python 3.12 (tomllib requires 3.11+, which ubuntu-latest ships) and confirmed it resolves to v1.13.2, matching the v-prefix convention already used for the same value in talos/machineconfig.yaml.j2, and the push.paths trigger update to .mise.toml is a disclosed, low-impact broadening (mitigated by the existing image-exists skip step) rather than a hidden behavior change.

## Testing

Reproduced the workflow's version-extraction step locally with a Python 3.11+ interpreter matching ubuntu-latest, confirming TALOS_VERSION now resolves to a real non-empty tag (v1.13.2, matching both .mise.toml and talos/machineconfig.yaml.j2) instead of the empty string that previously broke the Docker FROM stage, and confirmed the diff touches only the two lines required by the fix. This test phase does not have access to trigger or observe an actual GitHub Actions CI run (that is owned by a later phase in this pipeline), so the acceptance criterion requiring confirmation against a real CI run is not something this phase can produce evidence for directly - the manual reproduction above is the closest available substitute and matches the runner's Python version exactly.

<details>
<summary>Evidence: Manual reproduction of the TALOS_VERSION extraction step (Python 3.12, matching ubuntu-latest)</summary>

```text
Manual reproduction of the "Determine Talos Version" step from
.github/workflows/build-talosctl-busybox.yaml (target commit 3e291f8c),
run with Python 3.12 (workflow runs on ubuntu-latest, which ships Python 3.11+
with tomllib built in, matching this environment).

$ VERSION="v$(python3.12 -c "import tomllib; print(tomllib.load(open('.mise.toml', 'rb'))['tools']['aqua:siderolabs/talos'])")"
$ echo "talos_version=${VERSION}"
talos_version=v1.13.2
$ echo "Using Talos version: ${VERSION}"
Using Talos version: v1.13.2

Resulting Docker FROM stage (as consumed by .github/docker/talosctl-busybox/Dockerfile):
FROM ghcr.io/siderolabs/talosctl:v1.13.2

VERSION is a well-formed, non-empty semver tag matching the "vX.Y.Z" pattern
required for `docker buildx` to parse the FROM stage name (previously this
resolved to an empty string via a grep over the now-deleted talos/talenv.yaml,
producing the reported failure: `failed to parse stage name
"ghcr.io/siderolabs/talosctl:": invalid reference format`).

Cross-checked source of truth:
  .mise.toml:38          "aqua:siderolabs/talos" = "1.13.2"
  talos/machineconfig.yaml.j2:52   image: factory.talos.dev/installer/{{ ENV.SCHEMATIC }}:v1.13.2
Both agree on Talos 1.13.2 / v1.13.2, confirming the v-prefix convention applied in the fix is correct.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"ed291c8401559b820f511017a242d35a8a3570c6","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"skipped"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ℹ️ `.github/workflows/build-talosctl-busybox.yaml:9` - The workflow_dispatch input description still reads &#34;Talos version to build (overrides talenv.yaml)&#34;, referencing the file that was deleted in the SOPS/1Password cutover and that this fix already stops depending on. Harmless (it&#39;s just help text), and the user intent explicitly scoped this change to &#34;nothing else in the workflow file beyond what&#39;s needed for this fix&#34;, so leaving it is consistent with that stated scope.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Manual reproduction: `python3.12 -c &#34;import tomllib; print(tomllib.load(open(&#39;.mise.toml&#39;,&#39;rb&#39;))[&#39;tools&#39;][&#39;aqua:siderolabs/talos&#39;])&#34;` -&gt; resolved and v-prefixed to `v1.13.2`</code>
- <code>Verified resulting `FROM ghcr.io/siderolabs/talosctl:v1.13.2` is a well-formed, non-empty tag (would not reproduce the prior `invalid reference format` buildx error)</code>
- <code>Cross-checked `.mise.toml:38` and `talos/machineconfig.yaml.j2:52` agree on Talos 1.13.2/v1.13.2, confirming the v-prefix convention used in the fix</code>
- <code>`git diff d36a80a7..3e291f8c -- .github/workflows/build-talosctl-busybox.yaml` reviewed to confirm only the two required lines (push.paths trigger source, VERSION extraction) were changed, nothing else touched</code>
- <code>Inspected `.github/docker/talosctl-busybox/Dockerfile` to confirm `ARG TALOS_VERSION` / `FROM ghcr.io/siderolabs/talosctl:${TALOS_VERSION}` correctly consumes the workflow&#39;s build-arg</code>

</details>

<details>
<summary>⏭️ **Document** - skipped</summary>

- ℹ️ `README.md:276` - README&#39;s Talos upgrade section references `talenv.yaml` and `task talos:*` commands, none of which exist in this repo (talenv.yaml was deleted in the SOPS/1Password cutover, PR #881; the actual commands are `just talos render-config/apply-node/upgrade-node/upgrade-k8s` per CLAUDE.md). This predates and is unrelated to the talosctl-busybox workflow fix in this change, and fixing it requires reconciling a whole README section against the justfile-based workflow, which is a separate follow-up.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
