### PR TITLE
docs: reconcile README Talos upgrade section with justfile tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,31 +260,37 @@ task talos:reset
 ### ⚙️ Updating Talos node configuration
 
 > [!TIP]
-> Ensure you have updated `talconfig.yaml` and any patches with your updated configuration. In some cases you **not only need to apply the configuration but also upgrade talos** to apply new configuration.
+> Ensure you have updated `talos/machineconfig.yaml.j2`, the per-node overlay in `talos/nodes/`, or `talos/schematic.yaml.j2` with your updated configuration. In some cases you **not only need to apply the configuration but also upgrade Talos** to apply new configuration.
 
 ```sh
-# (Re)generate the Talos config
-task talos:generate-config
+# Render a node's machine config to stdout for review (node = talos-1|talos-2|talos-3)
+just talos render-config talos-1
+
+# Validate the rendered config
+just talos render-config talos-1 | talosctl validate -m metal -c /dev/stdin
+
+# Preview the diff before applying
+just talos apply-node talos-1 --dry-run
+
 # Apply the config to the node
-task talos:apply-node IP=? MODE=?
-# e.g. task talos:apply-node IP=10.10.10.10 MODE=auto
+just talos apply-node talos-1
 ```
 
 ### ⬆️ Updating Talos and Kubernetes versions
 
 > [!TIP]
-> Ensure the `talosVersion` and `kubernetesVersion` in `talenv.yaml` are up-to-date with the version you wish to upgrade to.
+> Ensure the installer image version in `talos/machineconfig.yaml.j2` (Renovate-managed) is up-to-date with the Talos version you wish to upgrade to before running the upgrade below.
 
 ```sh
-# Upgrade node to a newer Talos version
-task talos:upgrade-node IP=?
-# e.g. task talos:upgrade-node IP=10.10.10.10
+# Upgrade Talos on a node (install image derived from the rendered config)
+just talos upgrade-node talos-1
+# e.g. just talos upgrade-node talos-1
 ```
 
 ```sh
-# Upgrade cluster to a newer Kubernetes version
-task talos:upgrade-k8s
-# e.g. task talos:upgrade-k8s
+# Upgrade the Kubernetes version on the cluster
+just talos upgrade-k8s v1.36.1
+# e.g. just talos upgrade-k8s v1.36.1
 ```
 
 ## 🤖 Renovate


### PR DESCRIPTION
## Intent

Reconcile README.md's Talos upgrade section, which still referenced the deleted talos/talenv.yaml file and task talos:* commands, neither of which exist after PR #881 (2026-05-31, the SOPS/age-to-1Password/ESO cutover that removed talenv.yaml and the task-based tooling). Rewrite the section to describe the real current upgrade workflow using the actual justfile-based commands (just talos render-config, apply-node, upgrade-node, upgrade-k8s), verified directly against talos/mod.just rather than trusting CLAUDE.md's prose alone. Acceptance criteria: the README's Talos upgrade section names no file or command that no longer exists; a reader following the README could actually perform a Talos upgrade with the commands shown. Scope is intentionally limited to the named Talos upgrade section (the '🛠️ Talos and Kubernetes Maintenance' heading and its two subsections); a separate stale 'task talos:reset' reference in the unrelated 'Reset' section above was left untouched as out of scope.

## What Changed

- Updated the "⚙️ Updating Talos node configuration" subsection to reference the actual config sources (`talos/machineconfig.yaml.j2`, per-node overlays in `talos/nodes/`, `talos/schematic.yaml.j2`) and replaced the removed `task talos:generate-config` / `task talos:apply-node` commands with `just talos render-config`, `talosctl validate`, `just talos apply-node --dry-run`, and `just talos apply-node`.
- Updated the "⬆️ Updating Talos and Kubernetes versions" subsection to point at the Renovate-managed installer image version in `talos/machineconfig.yaml.j2` (removing the stale `talenv.yaml` reference) and replaced `task talos:upgrade-node` / `task talos:upgrade-k8s` with `just talos upgrade-node` / `just talos upgrade-k8s`.
- Left the unrelated stale `task talos:reset` reference in the "Reset" section untouched, matching the intended scope of this change.

## Risk Assessment

✅ Low: Documentation-only change confined to README.md that replaces stale talenv.yaml/task talos:* references with justfile commands verified to exist in talos/mod.just, exactly matching the stated scope and acceptance criteria.

## Testing

Docs-only change verified by direct comparison of the rewritten README Talos upgrade commands/paths against talos/mod.just and the repo's actual file layout; every command, flag, and file path shown in the README's two Talos upgrade subsections exists and matches, talenv.yaml is confirmed gone repo-wide, and the intentionally-out-of-scope 'task talos:reset' line elsewhere was left untouched. No automated test suite applies to a markdown-only change, so no unit tests were run.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"7bf6c3283d485c4f5437311cd9ec93f725a41f4a","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"skipped"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `git diff e5aab02f 7bf6c328 -- README.md (reviewed the change)`
- `grep -n "^apply-node\|^render-config\|^upgrade-node\|^upgrade-k8s" talos/mod.just (confirmed recipe signatures match README usage, including apply-node's *args supporting --dry-run)`
- `ls talos/machineconfig.yaml.j2 talos/schematic.yaml.j2 talos/nodes/ (confirmed referenced files exist)`
- `grep -rn talenv . (confirmed talenv.yaml is not referenced anywhere in the repo)`
- `grep -rn 'task talos:' README.md (confirmed only the out-of-scope Reset-section reference remains, as intended)`

</details>

<details>
<summary>⏭️ **Document** - skipped</summary>

- ℹ️ `AGENTS.md:84` - Top-level AGENTS.md (dated &#34;Generated: 2026-04-09&#34;, predates the 2026-05-31 SOPS/age-to-1Password/ESO cutover in PR #881) still lists task-based tooling that no longer exists: `task talos:generate-config`, `task talos:apply-node IP=X`, `talconfig.yaml`, `.taskfiles/talos`, plus SOPS/age-key references for the talos directory. This duplicates and contradicts the now-accurate talos/AGENTS.md and the just-fixed README section. It reads as an auto-generated project snapshot rather than hand-authored prose, and the staleness spans far beyond the Talos section (SOPS references throughout), so a full regeneration is the right fix rather than a manual patch confined to this change&#39;s scope. Left untouched per scope discipline (out-of-scope consolidation) and per the standing instruction not to hand-edit files that look auto-generated.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
