### PR TITLE
fix(talos): tighten kubelet imageGC thresholds to 60/45

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,18 +90,8 @@ task bootstrap:apps         # Bootstrap applications into cluster
 
 ## NOTES
 
-- **`talos/machineconfig.yaml.j2` changes are NOT applied by Flux.** No Flux Kustomization or CI
-  workflow watches `talos/`; a merged change only takes effect after an operator runs
-  `just talos apply-node <node>` (or `upgrade-node`) against each real node with a live
-  `talosconfig`. Validate with `just talos render-config <node> | talosctl validate -m metal -c
-  /dev/stdin` before applying.
-- A disposable/isolated worktree with no `talosconfig`/1Password creds can still validate a
-  `talos/*.j2` template edit: render raw with `minijinja-cli` (skip the `vals`-piped `just
-  template`/`render-config` recipes, which need `OP_SERVICE_ACCOUNT_TOKEN`), substitute dummy
-  base64 values for unresolved `ref+op://...` refs, then `talosctl machineconfig patch` + `talosctl
-  validate -m metal`. Note `just talos ...` itself needs *some* (even fake) `TALOSCONFIG` context
-  to parse — `bootstrap/mod.just`'s module-level `controller`/`nodes` vars run
-  `talosctl config info` eagerly for any `just talos` invocation via the root `mod bootstrap` import.
+- `talos/AGENTS.md` NOTES: how `talos/*.j2` changes take effect (not via Flux) and how
+  to validate them offline in a credential-less worktree.
 - `age.key` and `kubeconfig` are gitignored — required locally but never committed
 - SOPS age key: `age13qrheg54vtg3azk0qa7ua7fnszvcc839ln8zazpdvszsfxekrf3s8jytnl`
 - SOPS encrypts only `data`/`stringData` fields in bootstrap/kubernetes, full encryption for talos

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,6 +90,18 @@ task bootstrap:apps         # Bootstrap applications into cluster
 
 ## NOTES
 
+- **`talos/machineconfig.yaml.j2` changes are NOT applied by Flux.** No Flux Kustomization or CI
+  workflow watches `talos/`; a merged change only takes effect after an operator runs
+  `just talos apply-node <node>` (or `upgrade-node`) against each real node with a live
+  `talosconfig`. Validate with `just talos render-config <node> | talosctl validate -m metal -c
+  /dev/stdin` before applying.
+- A disposable/isolated worktree with no `talosconfig`/1Password creds can still validate a
+  `talos/*.j2` template edit: render raw with `minijinja-cli` (skip the `vals`-piped `just
+  template`/`render-config` recipes, which need `OP_SERVICE_ACCOUNT_TOKEN`), substitute dummy
+  base64 values for unresolved `ref+op://...` refs, then `talosctl machineconfig patch` + `talosctl
+  validate -m metal`. Note `just talos ...` itself needs *some* (even fake) `TALOSCONFIG` context
+  to parse — `bootstrap/mod.just`'s module-level `controller`/`nodes` vars run
+  `talosctl config info` eagerly for any `just talos` invocation via the root `mod bootstrap` import.
 - `age.key` and `kubeconfig` are gitignored — required locally but never committed
 - SOPS age key: `age13qrheg54vtg3azk0qa7ua7fnszvcc839ln8zazpdvszsfxekrf3s8jytnl`
 - SOPS encrypts only `data`/`stringData` fields in bootstrap/kubernetes, full encryption for talos

--- a/talos/AGENTS.md
+++ b/talos/AGENTS.md
@@ -49,6 +49,20 @@ just talos upgrade-node talos-1
 just talos upgrade-k8s v1.36.1
 ```
 
+Merging a `machineconfig.yaml.j2`/node-overlay/`schematic.yaml.j2` change only lands
+the code — no Flux Kustomization or CI workflow watches `talos/`. An operator with a
+live `talosconfig` must separately run `just talos apply-node <node>` (or
+`upgrade-node`) against each of the three nodes for the change to take effect.
+
+A worktree with no `talosconfig`/1Password creds can still validate a `*.j2` edit
+offline: render raw with `minijinja-cli` (skip the `vals`-piped `just
+template`/`render-config` recipes, which need `OP_SERVICE_ACCOUNT_TOKEN`), substitute
+dummy base64 values for unresolved `ref+op://...` refs, then `talosctl machineconfig
+patch` + `talosctl validate -m metal -c <rendered-file>`. Note `just talos ...` itself
+still needs *some* (even fake) `TALOSCONFIG` context to parse —
+`bootstrap/mod.just`'s module-level `controller`/`nodes` vars run `talosctl config
+info` eagerly for any `just talos` invocation via the root `mod bootstrap` import.
+
 ## ANTI-PATTERNS
 
 - **NEVER** put plaintext secrets in `*.yaml.j2` — use `ref+op://Home-Lab/talos/*` references

--- a/talos/machineconfig.yaml.j2
+++ b/talos/machineconfig.yaml.j2
@@ -70,11 +70,29 @@ machine:
       serializeImagePulls: false
       maxPods: 250
       # Reclaim accumulated container-image layers. The kubelet prunes unused
-      # images when the imagefs (/var) hits 70% full, down to 55%. Default is
+      # images when the imagefs (/var) hits 60% full, down to 45%. Default is
       # 85/80, which let ~600G of old image versions pile up on this
-      # image-churn-heavy cluster (Renovate bumps + redeploys).
-      imageGCHighThresholdPercent: 70
-      imageGCLowThresholdPercent: 55
+      # image-churn-heavy cluster (Renovate bumps + redeploys); a first
+      # tightening pass to 70/55 (2026-06) wasn't enough headroom on its own -
+      # as of 2026-08-20 talos-1 (the busiest node) already sits at 42%
+      # imagefs / 51% total disk, well above the other two nodes (~29-30%
+      # imagefs), with the same Renovate-churn trend that forced both prior
+      # interventions still ongoing. 60/45 keeps the prior pair's 15-point
+      # high/low gap but moves the ceiling down another 10 points (~100G on
+      # a 997G disk): meaningful headroom above today's 42% high-water mark
+      # without sitting so close to it that GC thrashes against Spegel's
+      # kept-layer cache, and a lower low-water mark so each GC pass reclaims
+      # down to a deeper floor, keeping normal reclaim events smaller and
+      # more frequent instead of one large, IO-heavy purge - a factor in the
+      # 2026-06-14 mon-corruption incident on this same disk (PR #979's
+      # ~370G GC delete under a firmware bug that has since been fixed by an
+      # SN770M firmware update, but heavy, bursty /var IO is still worth
+      # avoiding on general principle). This also lets standing kubelet GC
+      # reclaim the ~173G of verified cluster-wide-orphaned image digests
+      # identified in the 2026-08-20 image audit, without a one-off manual
+      # `talosctl image remove` pass.
+      imageGCHighThresholdPercent: 60
+      imageGCLowThresholdPercent: 45
       featureGates:
         ImageVolume: true
     nodeIP:


### PR DESCRIPTION
## Intent

Tighten Talos imageGC thresholds further to build more disk headroom against the cluster's ongoing container-image churn.

Captain decision (2026-08-20) resolving two related backlog decisions at once (folded together deliberately): tighten imageGCHighThresholdPercent/imageGCLowThresholdPercent further than the current 70/55 in talos/machineconfig.yaml.j2, with specific reasoned new numbers, not just arbitrarily lower ones.

Context used to size the numbers: the existing comment at talos/machineconfig.yaml.j2:73-77 documents prior history (tuned down once already from an 85/80 default after ~600GB of old image versions piled up on this image-churn-heavy cluster, PR #979, 2026-06-13); docs/hardware-incidents.md documents a 2026-06-14 incident where that same imageGC change deleting ~370GB off /var was a contributing factor in mon-store corruption on the same disk (root cause: a WD SN770M firmware HMB bug, since fixed via firmware update on all 3 nodes, but heavy bursty /var IO is still worth avoiding on general principle). Current measured state (2026-08-20): talos-1 (closest to the ceiling) at 42% imagefs / 51% total disk, talos-2 at 30%/38%, talos-3 at 29%/38%. The new high-water mark must give meaningfully more headroom before the next dependency-bump churn cycle pushes talos-1 back toward the ceiling - the same pattern that already forced two prior interventions. Use the existing 70/55 pair's 15-point high/low gap as a reference ratio unless there's a concrete reason to change the gap itself.

Chosen values: imageGCHighThresholdPercent: 60, imageGCLowThresholdPercent: 45 (keeps the 15-point gap; lowers the ceiling another 10 points, ~100GB on a 997GB disk, giving meaningful absolute headroom above today's 42% high-water mark on talos-1 without sitting so close to current usage that GC would thrash against Spegel's kept-layer cache; the lower low-water mark means each GC pass reclaims to a deeper floor, producing smaller/more frequent reclaim events instead of one large IO-heavy purge like the one implicated in the mon-corruption incident). The machine config comment was rewritten to document this full reasoning and history for future readers.

This also folds in a separate, already-identified one-time cleanup opportunity from a sibling investigation (data/homeops-ci-rework-scout/report.md section 5): ~173GB of verified cluster-wide-orphaned container images (cross-referenced against every pod's actual image references across the whole cluster, correctly accounting for Spegel's P2P image-mirroring so nothing still-needed was miscounted). Rather than a one-off manual `talosctl image remove` pass, the captain chose to let the tightened standing imageGC threshold reclaim from that same orphaned set automatically going forward - no separate cleanup script or one-time job was added.

Safety gate already satisfied before this run: this change touches live Talos machine config on production nodes. I ran this repo's own dry-run review path already. `just talos render-config <node>` normally pipes through `vals` to resolve `ref+op://Home-Lab/talos/*` 1Password secret references, and this task's isolated worktree deliberately has no `talosconfig` or 1Password/OP_SERVICE_ACCOUNT_TOKEN credentials (same credential-less-by-design pattern documented by two prior sibling scout tasks in this same worktree lineage), so I could not run a literal live `just talos apply-node <node> --dry-run` against a real node. Instead I rendered the raw Jinja template directly with minijinja-cli (bypassing the vals secret-resolution step), substituted dummy base64 values for the unresolved ref+op:// secret placeholders (structural validation only - never used against a real node), patched in the talos-1 node overlay via `talosctl machineconfig patch`, and ran `talosctl validate -m metal -c <rendered-file>`, which returned "valid for metal mode" with the new imageGCHighThresholdPercent: 60 / imageGCLowThresholdPercent: 45 values present and correctly positioned in the rendered kubelet extraConfig. This is the closest available equivalent to the documented dry-run path given this worktree's deliberate lack of live cluster/1Password credentials, and it is a materially weaker check than a real `apply-node --dry-run` against a live node (it validates schema/structure, not an actual diff against a running node's current config or connectivity) - this gap should be called out to the captain, not hidden.

How this takes effect after merge: talos/machineconfig.yaml.j2 changes are NOT applied by Flux GitOps reconciliation - no Flux Kustomization or CI workflow in this repo watches the talos/ directory. Merging this PR only lands the code; an operator with real talosconfig credentials must separately run `just talos apply-node <node>` (or `upgrade-node`) against each of the three live nodes for the new thresholds to actually take effect on the running cluster. This must be stated plainly to the captain - merging is not the same as applying here.

I also added a short note to this project's AGENTS.md recording both of these facts (Flux does not apply talos/ changes; how to validate a talos/*.j2 edit offline in a credential-less worktree) since they are durable, reusable project knowledge, not task-specific detail.

Acceptance criteria for this task: talos/machineconfig.yaml.j2 has new, reasoned threshold values (done: 60/45); the dry-run review output is captured and reported (done, with the credential gap noted above); the report states clearly how/when this takes effect on real nodes after merge (done: manual just talos apply-node per node, not Flux-automated).

## What Changed

- `talos/machineconfig.yaml.j2`: lowered `imageGCHighThresholdPercent`/`imageGCLowThresholdPercent` from 70/55 to 60/45 (keeping the prior 15-point gap) and rewrote the surrounding comment to document the full history and reasoning (85/80 default → 70/55 in PR #979 → 60/45 now), current per-node disk usage as of 2026-08-20, the 2026-06-14 mon-corruption incident context, and that the lower thresholds also let standing GC reclaim ~173G of previously-identified orphaned image digests.
- `talos/AGENTS.md`: added a note that `machineconfig.yaml.j2`/node-overlay/`schematic.yaml.j2` changes are not applied by Flux or CI and require a manual `just talos apply-node <node>` (or `upgrade-node`) per node, plus a documented offline validation procedure for `*.j2` edits in a worktree without `talosconfig`/1Password credentials (raw `minijinja-cli` render with dummy secret values, then `talosctl machineconfig patch` + `talosctl validate`).
- `AGENTS.md`: added a pointer in the NOTES section to the new `talos/AGENTS.md` guidance.

## Risk Assessment

✅ Low: Well-bounded config-value + comment change to talos/machineconfig.yaml.j2 (imageGC 70/55 -> 60/45) plus a documentation-only AGENTS.md addition; all cited figures, incident history, and justfile/module-eval mechanics were verified against docs/hardware-incidents.md and bootstrap/mod.just and are accurate, and Flux does not watch talos/ so the change cannot auto-apply to live nodes.

## Testing

Reproduced the credential-less offline validation path exactly as described in the intent (minijinja-cli render, dummy-secret substitution, talosctl machineconfig patch, talosctl validate -m metal) and it passes cleanly with the new 60/45 thresholds correctly embedded; a rendered-output diff against the base commit shows the change is scoped to precisely those two values. All historical/factual claims in the rewritten comment and AGENTS.md note (PR #979, the 2026-06-14 mon-corruption incident, SN770M firmware fix, and Flux/CI not touching talos/) were independently verified against git history and docs/hardware-incidents.md and are accurate. No issues found; worktree left clean with all render/validation artifacts confined to the evidence directory.

<details>
<summary>Evidence: talosctl validate output (patched talos-1 config, imageGC 60/45)</summary>

`/var/folders/.../patched-talos1.yaml is valid for metal mode`

```text
/var/folders/yr/h20mxtv56yj1c1pt9tr1_kbc0000gn/T/no-mistakes-evidence/01M0H71YDR3ZSZFXQQN671KQ5Z/patched-talos1.yaml is valid for metal mode
```
</details>
<details>
<summary>Evidence: Rendered+patched machine config for talos-1 (dummy secrets, real thresholds)</summary>

```text
version: v1alpha1
debug: false
persist: true
machine:
    type: controlplane
    token: ZHVtbXktc2VjcmV0LXZhbHVlLWZvci12YWxpZGF0aW9uLW9ubHk=
    ca:
        crt: ZHVtbXktc2VjcmV0LXZhbHVlLWZvci12YWxpZGF0aW9uLW9ubHk=
        key: ZHVtbXktc2VjcmV0LXZhbHVlLWZvci12YWxpZGF0aW9uLW9ubHk=
    certSANs:
        - 127.0.0.1
        - 10.10.10.10
        - talos.sklab.dev
    kubelet:
        image: ghcr.io/siderolabs/kubelet:v1.36.1
        extraMounts:
            - destination: /var/openebs/local
              type: bind
              source: /var/openebs/local
              options:
                - rbind
                - rshared
                - rw
        extraConfig:
            featureGates:
                ImageVolume: true
            imageGCHighThresholdPercent: 60
            imageGCLowThresholdPercent: 45
            maxPods: 250
            serializeImagePulls: false
        defaultRuntimeSeccompProfileEnabled: true
        nodeIP:
            validSubnets:
                - 10.10.10.0/24
        disableManifestsDirectory: true
    network:
        nameservers:
            - 10.10.10.1
            - 1.1.1.1
            - 1.0.0.1
        disableSearchDomain: true
    install:
        disk: /dev/disk/by-id/nvme-WD_BLACK_SN770M_1TB_251211800127
        image: factory.talos.dev/installer/0000000000000000000000000000000000000000000000000000000000000000:v1.13.2
        wipe: false
        grubUseUKICmdline: true
    files:
        - content: |-
            [plugins."io.containerd.cri.v1.images"]
              discard_unpacked_layers = false
          permissions: 0o644
          path: /etc/cri/conf.d/20-customization.part
          op: create
        - content: |
            [ NFSMount_Global_Options ]
            nfsvers=4.2
            hard=True
            nconnect=16
            noatime=True
          permissions: 0o644
          path: /etc/nfsmount.conf
          op: overwrite
    time:
        disabled: false
        servers:
            - 162.159.200.1
            - 162.159.200.123
    sysctls:
        fs.aio-max-nr: "1048576"
        fs.file-max: "1048576"
        fs.inotify.max_user_instances: "8192"
        fs.inotify.max_user_watches: "1048576"
        net.core.default_qdisc: fq
        net.core.netdev_max_backlog: "5000"
        net.core.rmem_default: "262144"
        net.core.rmem_max: "134217728"
        net.core.wmem_default: "262144"
        net.core.wmem_max: "134217728"
        net.ipv4.neigh.default.gc_thresh1: "4096"
        net.ipv4.neigh.default.gc_thresh2: "8192"
        net.ipv4.neigh.default.gc_thresh3: "16384"
        net.ipv4.tcp_congestion_control: bbr
        net.ipv4.tcp_rmem: 4096 87380 134217728
        net.ipv4.tcp_timestamps: "1"
        net.ipv4.tcp_window_scaling: "1"
        net.ipv4.tcp_wmem: 4096 65536 134217728
        vm.dirty_background_ratio: "5"
        vm.dirty_expire_centisecs: "12000"
        vm.dirty_ratio: "15"
        vm.dirty_writeback_centisecs: "1500"
        vm.nr_hugepages: "1024"
        vm.swappiness: "1"
        vm.vfs_cache_pressure: "50"
    sysfs:
        kernel/mm/lru_gen/enabled: "0"
    features:
        kubernetesTalosAPIAccess:
            enabled: true
            allowedRoles:
                - os:admin
            allowedKubernetesNamespaces:
                - actions-runner-system
                - system-upgrade
        diskQuotaSupport: true
        kubePrism:
            enabled: true
            port: 7445
        hostDNS:
            enabled: true
            forwardKubeDNSToHost: true
            resolveMemberNames: true
    udev:
        rules:
            - SUBSYSTEM=="block", KERNEL=="nvme*", ACTION=="add|change", ATTR{queue/scheduler}="none"
            - SUBSYSTEM=="block", KERNEL=="nvme*", ACTION=="add|change", ATTR{queue/nr_requests}="1024"
            - SUBSYSTEM=="block", KERNEL=="nvme*", ACTION=="add|change", ATTR{queue/read_ahead_kb}="256"
            - SUBSYSTEM=="block", KERNEL=="nvme*", ACTION=="add|change", ATTR{queue/rq_affinity}="2"
    nodeLabels:
        intel.feature.node.kubernetes.io/gpu: "true"
        topology.kubernetes.io/region: kubernetes
        topology.kubernetes.io/zone: m
cluster:
    id: ZHVtbXktc2VjcmV0LXZhbHVlLWZvci12YWxpZGF0aW9uLW9ubHk=
    secret: ZHVtbXktc2VjcmV0LXZhbHVlLWZvci12YWxpZGF0aW9uLW9ubHk=
    controlPlane:
        endpoint: https://10.10.10.10:6443
    clusterName: kubernetes
    network:
        cni:
            name: none
        dnsDomain: cluster.local
        podSubnets:
            - 10.42.0.0/16
        serviceSubnets:
            - 10.43.0.0/16
    token: ZHVtbXktc2VjcmV0LXZhbHVlLWZvci12YWxpZGF0aW9uLW9ubHk=
    secretboxEncryptionSecret: ZHVtbXktc2VjcmV0LXZhbHVlLWZvci12YWxpZGF0aW9uLW9ubHk=
    ca:
        crt: ZHVtbXktc2VjcmV0LXZhbHVlLWZvci12YWxpZGF0aW9uLW9ubHk=
        key: ZHVtbXktc2VjcmV0LXZhbHVlLWZvci12YWxpZGF0aW9uLW9ubHk=
    aggregatorCA:
        crt: ZHVtbXktc2VjcmV0LXZhbHVlLWZvci12YWxpZGF0aW9uLW9ubHk=
        key: ZHVtbXktc2VjcmV0LXZhbHVlLWZvci12YWxpZGF0aW9uLW9ubHk=
    serviceAccount:
        key: ZHVtbXktc2VjcmV0LXZhbHVlLWZvci12YWxpZGF0aW9uLW9ubHk=
    apiServer:
        image: registry.k8s.io/kube-apiserver:v1.36.1
        extraArgs:
            default-watch-cache-size: "1500"
            enable-aggregator-routing: "true"
            etcd-compaction-interval: 5m
            etcd-count-metric-poll-period: 1m
            etcd-servers-overrides: /events#https://127.0.0.1:2379
            feature-gates: ImageVolume=true,MutatingAdmissionPolicy=true
            runtime-config: admissionregistration.k8s.io/v1beta1=true
            watch-cache-sizes: persistentvolumeclaims#1000,persistentvolumes#1000
        certSANs:
            - 127.0.0.1
            - 10.10.10.10
            - talos.sklab.dev
        admissionControl:
            - name: PodSecurity
              configuration:
                apiVersion: pod-security.admission.config.k8s.io/v1alpha1
                defaults:
                    audit: privileged
                    audit-version: latest
                    enforce: privileged
                    enforce-version: latest
                    warn: privileged
                    warn-version: latest
                exemptions:
                    namespaces:
                        - kube-system
                    runtimeClasses: []
                    usernames: []
                kind: PodSecurityConfiguration
        auditPolicy:
            apiVersion: audit.k8s.io/v1
            kind: Policy
            rules:
                - level: Metadata
    controllerManager:
        image: registry.k8s.io/kube-controller-manager:v1.36.1
        extraArgs:
            bind-address: 0.0.0.0
    proxy:
        disabled: true
        image: registry.k8s.io/kube-proxy:v1.36.1
    scheduler:
        image: registry.k8s.io/kube-scheduler:v1.36.1
        extraArgs:
            bind-address: 0.0.0.0
    discovery:
        enabled: true
        registries:
            kubernetes:
                disabled: true
            service: {}
    etcd:
        ca:
            crt: ZHVtbXktc2VjcmV0LXZhbHVlLWZvci12YWxpZGF0aW9uLW9ubHk=
            key: ZHVtbXktc2VjcmV0LXZhbHVlLWZvci12YWxpZGF0aW9uLW9ubHk=
        extraArgs:
            auto-compaction-mode: periodic
            auto-compaction-retention: 1h
            election-timeout: "1500"
            heartbeat-interval: "150"
            listen-metrics-urls: http://0.0.0.0:2381
            snapshot-count: "10000"
        advertisedSubnets:
            - 10.10.10.0/24
    coreDNS:
        disabled: true
    allowSchedulingOnControlPlanes: true
---
apiVersion: v1alpha1
kind: OOMConfig
triggerExpression: memory_full_avg10 > 50.0 && d_memory_full_avg10 > 0.0 && time_since_trigger > duration("30s")
---
apiVersion: v1alpha1
kind: HostnameConfig
auto: "off"
hostname: talos-1
---
apiVersion: v1alpha1
kind: LinkAliasConfig
name: net%d
selector:
    match: link.driver == "i40e"
---
apiVersion: v1alpha1
kind: BondConfig
name: bond0
links:
    - net0
    - net1
bondMode: 802.3ad
miimon: 100
updelay: 200
downdelay: 200
xmitHashPolicy: layer3+4
lacpRate: fast
mtu: 9000
---
apiVersion: v1alpha1
kind: DHCPv4Config
name: bond0
---
apiVersion: v1alpha1
kind: Layer2VIPConfig
name: 10.10.10.10
link: bond0
---
apiVersion: v1alpha1
kind: VLANConfig
name: bond0.3
vlanID: 3
parent: bond0
mtu: 9000
---
apiVersion: v1alpha1
kind: VLANConfig
name: bond0.90
vlanID: 90
parent: bond0
mtu: 9000
```
</details>
<details>
<summary>Evidence: Rendered-config diff: base (70/55) vs target (60/45) - isolated to the two threshold values only</summary>

<code>27,28c27,28&#10;&lt; imageGCHighThresholdPercent: 70&#10;&lt; imageGCLowThresholdPercent: 55&#10;---&#10;&gt; imageGCHighThresholdPercent: 60&#10;&gt; imageGCLowThresholdPercent: 45</code>

```text
27,28c27,28
<             imageGCHighThresholdPercent: 70
<             imageGCLowThresholdPercent: 55
---
>             imageGCHighThresholdPercent: 60
>             imageGCLowThresholdPercent: 45
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"305f1590490205627fb3b81fb1576e2567449ef1","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`minijinja-cli --config-file .minijinja.toml talos/machineconfig.yaml.j2` and `talos/nodes/talos-1.yaml.j2` render successfully with dummy CONTROLPLANE/SCHEMATIC env vars</code>
- <code>Substituted dummy base64 values for all `ref+op://` placeholders in the rendered output (no leftover refs)</code>
- <code>`talosctl machineconfig patch &lt;rendered-mc&gt; -p @&lt;rendered-node-overlay&gt;` succeeds and produces imageGCHighThresholdPercent: 60 / imageGCLowThresholdPercent: 45 under kubelet.extraConfig</code>
- <code>`talosctl validate -m metal -c &lt;patched-config&gt;` returns exit 0 / &#34;valid for metal mode&#34;</code>
- `Diffed rendered+patched output for base commit (e5aab02f, 70/55) vs target commit (beb7e261, 60/45) - diff is exactly the two threshold lines, nothing else changed`
- <code>`git log --oneline --grep=979` and inline history confirm PR #979 set 70/55 on 2026-06-13; `docs/hardware-incidents.md` confirms the 2026-06-14 SN770M firmware HMB bug, ~370GB imageGC reclaim as a contributing factor in mon corruption, and the firmware fix across all 3 nodes</code>
- <code>Searched `kubernetes/flux/` and `.github/workflows/` for any Kustomization or CI job watching `talos/` - none found, confirming the AGENTS.md/intent claim that merging does not auto-apply</code>
- <code>Confirmed `bootstrap/mod.just`&#39;s module-level `controller`/`nodes` backtick vars eagerly call `talosctl config info`, matching the AGENTS.md note about `just talos` needing TALOSCONFIG context</code>

</details>

<details>
<summary>🔧 **Document** - 1 issue found → auto-fixed ✅</summary>

- ℹ️ `AGENTS.md:93` - The new AGENTS.md NOTES entries (root AGENTS.md lines 93-104) document Talos-specific operational facts - that Flux/CI never applies talos/machineconfig.yaml.j2 changes, and how to validate a *.j2 edit offline without talosconfig/1Password creds. talos/AGENTS.md already exists as the scoped owner doc for this exact directory, with its own WORKFLOW and NOTES sections covering render-config/apply-node. Placing this new operational knowledge there instead of (or in addition to a one-line pointer from) the root grab-bag NOTES section would better match the repo&#39;s single-owner documentation pattern. Not fixed here since it&#39;s a placement judgment call on content the author deliberately added, not a stale or incorrect fact - flagging for the captain to decide whether to relocate in a follow-up.

🔧 Fix: docs(talos): relocate operational notes into talos/AGENTS.md
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
