### PR TITLE
docs(docs): close talos-1 ram rma and record 96gb per node

### DIFF
--- a/docs/hardware-incidents.md
+++ b/docs/hardware-incidents.md
@@ -2,6 +2,8 @@
 
 Tracked hardware and infrastructure incidents across cluster nodes. Each entry documents root cause, evidence, and resolution for future reference.
 
+Current node memory (as of 2026-08-21): **96 GB per node** on all 3 Talos nodes. talos-1 Stick B RMA closed; see [2026-06-19].
+
 ---
 
 ## [2026-06-30] talos-1 + talos-2 — OOMController kill storm → 4-OSD outage / 100% PG inactive
@@ -32,7 +34,7 @@ Tracked hardware and infrastructure incidents across cluster nodes. Each entry d
 Two amplifiers made the PSI spikes pathological:
 
 1. **Dead-container memory debris** — after the 06-30 kills, ~24 GiB (talos-1) and ~70 GiB (talos-2) of reclaimable slab + reparented page cache from dead OSD containers stayed pinned in `kubepods/burstable`. MemFree sat at the watermark (~0.4–2 GiB) while MemAvailable showed 26–72 GiB; every allocation burst forced slow direct reclaim through the debris → PSI `full avg10` 18–46% → trigger fired ~every second (the 07-03 storms).
-2. **talos-1's reduced-RAM window** (48 GB single stick until the RAM RMA, ~2026-08): least headroom, first to trip; its kube-apiserver (646 restarts) and cilium-agent (503 restarts) were chronic victims.
+2. **talos-1's reduced-RAM window** (48 GB single stick until the RAM RMA; **completed 2026-08-21**, all 3 nodes now 96 GB): least headroom at the time, first to trip; its kube-apiserver (646 restarts) and cilium-agent (503 restarts) were chronic victims.
 
 **RULED OUT:** MGLRU regression (`/sys/kernel/mm/lru_gen/enabled = 0x0000` verified on all 3 nodes — PR #1094 held); rook#17224 device-path drift (never materialized — every OSD re-activated on its baked `ROOK_BLOCK_PATH`, including after the full reboots); store corruption / bad hardware (zero corruption signatures across all 6 OSDs through ~6 kill cycles + reboots; SMART/dmesg clean).
 
@@ -78,9 +80,9 @@ After OOMConfig patch (15:04, trigger 50%/30s): ZERO OOMController events throug
 
 - **OOMConfig codified in `talos/machineconfig.yaml.j2`** (the live `talosctl patch mc` survives reboot but NOT a config re-render — codifying it was mandatory).
 - **cilium-agent → Guaranteed QoS** (requests == limits) — ranking weight 0.0, network plane can no longer be the OOM victim.
-- **`NotIn [talos-1]` node affinities on 7 heavy burstables** (coder, changedetection, rsshub, readarr, seerr, flaresolverr, emqx-exporter) — **TODO 2026-08: revert after the talos-1 RAM RMA restores dual-channel 96 GB**.
+- **`NotIn [talos-1]` node affinities on 7 heavy burstables** (coder, changedetection, rsshub, readarr, seerr, flaresolverr, emqx-exporter) - **RAM RMA complete 2026-08-21 (96 GB dual-channel restored on all 3 nodes).** Remaining GitOps follow-up: revert these affinities.
 - **node-exporter re-enabled + PrometheusRule alerts**: `Talos1MemoryPressure`, `NodeMemoryPSIHigh`, `CephOsdPodTerminalError`, `CephPodCrashLooping` — closes the detection gap.
-- **ceph-mon → Guaranteed QoS** (mon + logcollector requests == limits, 2Gi/500m) — mon quorum can no longer be the OOM victim. OSDs stay Burstable for now: Guaranteed would reserve 14Gi×2 on talos-1's 48 GB. **TODO 2026-08 (post-RMA): promote `resources.osd` to 14Gi==14Gi Guaranteed; evaluate MDS (blocked on `mds_cache_memory_limit` 8Gi — Guaranteed at 10Gi×4 pods is unaffordable, and a tighter limit risks cgroup OOM against the cache; standby-replay makes MDS kills tolerable meanwhile).**
+- **ceph-mon → Guaranteed QoS** (mon + logcollector requests == limits, 2Gi/500m) — mon quorum can no longer be the OOM victim. OSDs stay Burstable for now: Guaranteed would have reserved 14Gi×2 on talos-1's 48 GB single-stick window (RMA complete 2026-08-21; all 3 nodes now 96 GB). **TODO (post-RMA): promote `resources.osd` to 14Gi==14Gi Guaranteed; evaluate MDS (blocked on `mds_cache_memory_limit` 8Gi — Guaranteed at 10Gi×4 pods is unaffordable, and a tighter limit risks cgroup OOM against the cache; standby-replay makes MDS kills tolerable meanwhile).**
 
 Cross-reference: [`ceph-cluster-changelog.md` [2026-07-03]](./ceph-cluster-changelog.md) for the OOMConfig change record, the min_size=1 windows, and the noout window.
 
@@ -140,7 +142,7 @@ mon.l:          rocksdb block checksum mismatch -> "failed to write to db" (rebu
 
 **✅ ISOLATED 2026-06-20 — confirmed single bad module ("Stick B"), board/slot/IMC clear.** Controlled same-slot A/B swap: **Stick A** ran 4 full passes, 0 errors in the reference slot (proven good); **Stick B** in that *same* slot failed Test 6 (Block move) in 7 min with stuck **bit 17** (`0x00020000`) across 6 threads at ~36 GB. Only the stick changed → Stick B is defective; the IMC and socket are exonerated (Stick A passed in that exact slot). The earlier differing signature (bit 2 @ ~71 GB dual-stick) was the same Stick B surfacing via channel interleave.
 
-**Real fix = RMA Stick B** (Crucial CT48G56C46S5.M16B, lifetime warranty; advance/cross-ship if offered) and **run talos-1 on Stick A** (the 4-pass-clean module) in the meantime — 48 GB single-channel is ample for talos-1's storage/mon role (the big-RAM AI workloads are pinned to talos-3). Reinstall for dual-channel 96 GB when the replacement arrives. Node must be drained for the swap: `cordon` + `ceph osd set noout` → power off → reseat/replace → power on → uncordon → `unset noout` (one node, mind the [#17224](https://github.com/rook/rook/issues/17224) OSD device-path caveat on restart).
+**Real fix = RMA Stick B** (Crucial CT48G56C46S5.M16B, lifetime warranty; advance/cross-ship if offered) and **run talos-1 on Stick A** (the 4-pass-clean module) in the meantime - 48 GB single-channel is ample for talos-1's storage/mon role (the big-RAM AI workloads are pinned to talos-3). Reinstall for dual-channel 96 GB when the replacement arrives. **Executed 2026-08-21** (see close-out below). Node must be drained for the swap: `cordon` + `ceph osd set noout` → power off → reseat/replace → power on → uncordon → `unset noout` (one node, mind the [#17224](https://github.com/rook/rook/issues/17224) OSD device-path caveat on restart).
 
 After the swap: **re-run MemTest86 to confirm clean**, then rebuild osd.0 on clean RAM (zap + uncomment disk in the CephCluster HR + provision) and run `ceph osd deep-scrub` across talos-1 OSDs to confirm no latent inconsistency. Until then: **keep osd.0 in the contained stopgap** (or fully out) and treat talos-1 as do-not-trust for write-heavy Ceph work.
 
@@ -150,9 +152,12 @@ After the swap: **re-run MemTest86 to confirm clean**, then rebuild osd.0 on cle
 clean Stick A, osd.0 was rebuilt with a fresh BlueStore and came up `up`/out with an empty
 store. Marked `in` on 2026-07-04 (cluster HEALTH_OK, 9.7 TiB raw free after the same-day
 shared-downloads cleanup); backfill of its ~1.2 TiB share started cleanly at ~44 MiB/s with no
-slow ops. **Pending:** `ceph osd deep-scrub` across talos-1 OSDs once backfill completes, to
-confirm no latent inconsistency; dual-channel 96 GB reinstall when the Stick B RMA replacement
-arrives.
+slow ops.
+
+**✅ CLOSED 2026-08-21 - Stick B repaired/exchanged; all 3 nodes at 96 GB.** The faulty
+Crucial CT48G56C46S5.M16B ("Stick B") was replaced. talos-1 is back to dual-channel 96 GB
+(2× 48 GB DDR5 SODIMM); talos-2 and talos-3 already were. This ends the reduced-RAM window
+(48 GB single stick since 2026-06-20) and is the durable hardware fix for this incident.
 
 ---
 


### PR DESCRIPTION
## Intent

Captain report, 2026-08-21: a faulty RAM stick was repaired/exchanged; all 3 nodes now have 96GB memory. Update docs/hardware-incidents.md (and any other doc stating per-node memory capacity - check README.md, CLAUDE.md, docs/reference.md) to the corrected 96GB-per-node figure. If hardware-incidents.md has an open TODO/unresolved entry about a RAM issue, close it out with this resolution.

Constraints accepted during implementation: README.md's 16GB figure is the cluster-template minimum system requirement, not this cluster's live hardware, so leave it unchanged. CLAUDE.md and docs/reference.md do not state per-node memory capacity, so they need no edits. Do not revert NotIn [talos-1] affinities or promote OSD Guaranteed QoS in this change; those remain GitOps follow-ups after the RMA, recorded as remaining work in hardware-incidents.md.

## What Changed

- Added a summary line noting all 3 Talos nodes are now at 96 GB per node (as of 2026-08-21), with the talos-1 Stick B RMA closed.
- Updated the talos-1 reduced-RAM references (OOM incident analysis, `NotIn [talos-1]` affinity note, ceph-mon Guaranteed QoS note) to state the RMA completed 2026-08-21 and all 3 nodes are now 96 GB, while keeping the affinity revert and OSD Guaranteed QoS promotion listed as remaining GitOps follow-up work.
- Replaced the "Pending" section for the RAM incident with a "✅ CLOSED 2026-08-21" resolution stating Stick B was repaired/exchanged and talos-1 is back to dual-channel 96 GB.

## Risk Assessment

✅ Low: Docs-only change (single markdown file) that accurately records a completed hardware RMA and updates memory figures consistently across the document, with no code, manifest, or config changes and no contradiction of the stated intent constraints.

## Testing

This is a documentation-only change (docs/hardware-incidents.md) with no code paths to unit test; verification consisted of diffing the exact content change, confirming the constraint that README.md/CLAUDE.md/docs/reference.md needed no edits (checked directly - only the 16GB cluster-template minimum-requirements line exists in README.md and is unrelated to live hardware), confirming the RAM-incident TODO was properly closed while the unrelated OSD-QoS TODO was correctly left open as a follow-up, and rendering the markdown to HTML as end-user-facing evidence that the corrected 96GB-per-node figure and closure text display as intended. All checks passed with no discrepancies from the stated user intent.

<details>
<summary>Evidence: Rendered markdown fragment (marked output) of docs/hardware-incidents.md showing the corrected 96GB text and closed RMA entry</summary>

```text
<h1>Hardware Incident Log</h1>
<p>Tracked hardware and infrastructure incidents across cluster nodes. Each entry documents root cause, evidence, and resolution for future reference.</p>
<p>Current node memory (as of 2026-08-21): <strong>96 GB per node</strong> on all 3 Talos nodes. talos-1 Stick B RMA closed; see [2026-06-19].</p>
<hr>
<h2>[2026-06-30] talos-1 + talos-2 — OOMController kill storm → 4-OSD outage / 100% PG inactive</h2>
<table>
<thead>
<tr>
<th>Field</th>
<th>Value</th>
</tr>
</thead>
<tbody><tr>
<td><strong>Node</strong></td>
<td>talos-1 (10.10.10.11) + talos-2 (10.10.10.12) at onset; the 2026-07-03 recovery-day kill storms hit <strong>ALL 3 nodes</strong></td>
</tr>
<tr>
<td><strong>Component</strong></td>
<td><strong>Talos v1.12 userspace OOM controller (<code>runtime.OOMController</code>)</strong> — default PSI trigger far too aggressive for Ceph-hosting nodes. <strong>NOT hardware</strong>: RAM/disks/stores exonerated (zero corruption signatures through ~6 kill/restart cycles + reboots)</td>
</tr>
<tr>
<td><strong>Affected service</strong></td>
<td>4/6 OSDs down (osd.0 + osd.3 on talos-1; osd.5 + osd.6 on talos-2) → <strong>100% PGs inactive</strong> (393/393, 66.667% objects degraded) → ALL RBD/CephFS client IO frozen ~3 days; MDS metadata IO blocked &gt;37 h; collateral kills of cilium-agent, kube-apiserver, radarr; cluster-wide kubelet/D-state wedge</td>
</tr>
<tr>
<td><strong>Severity</strong></td>
<td><strong>critical</strong> — total storage outage for ~3 days, ran <strong>UNDETECTED</strong> (no alerts fired: node-exporter was disabled and VictoriaMetrics not deployed — monitoring was blind to node memory/PSI and to the OSD pod deaths)</td>
</tr>
</tbody></table>
<h3>Timeline (UTC)</h3>
<ul>
<li><strong>2026-06-30 ~17:07</strong> — simultaneous OOMController kill activity on talos-1 + talos-2. osd.0 and osd.3 (talos-1) exit 137 at 17:08:26–28Z; talos-2 destabilized (osd.6 fast-shutdown on 07-01; osd.5 wedged <code>Init:0/5</code> for 2d21h).</li>
<li><strong>06-30 → 07-03</strong> — <strong>100% PGs inactive</strong> (347 undersized+degraded+peered + 46 undersized+peered), MDS slow metadata IO blocked &gt;134,000 s (~37 h). Nobody noticed: no node metrics, no alerts, VictoriaMetrics scrapes died with the storage.</li>
<li><strong>07-03 ~13:30–13:38</strong> — recovery starts: <code>noout</code> set; talos-1 emergency load shed (crash-loopers scaled to 0, dead pods purged — see <code>talos1-shed-load</code> record); last pre-shed OOMController kill 13:36:13Z (cilium-agent ×4 → ~40 s VIP outage).</li>
<li><strong>07-03 afternoon</strong> — osd.3/osd.0 pod restarts hit the <strong>RBD/activate circular deadlock</strong>: ceph-volume device scan parked in kernel D-state on frozen <code>/dev/rbdX</code> devices (kernel-proven fd/stack evidence) — OSDs can&#39;t start because storage is dead, storage is dead because OSDs can&#39;t start. A <strong>brief blockpool <code>min_size=1</code></strong> window broke the loop; 4 OSDs came up briefly.</li>
<li><strong>07-03 14:46–15:03</strong> — <strong>OOMController kill storms on ALL 3 nodes</strong> (trigger fired ~every 1 s): victims = cilium-agent (talos-1/2), radarr (talos-3), kube-apiserver-talos-2; collateral = all 6 OSD pods crashed, EPERM device-cgroup errors + runc sandbox-race containerd damage.</li>
<li><strong>07-03 15:04</strong> — live <code>OOMConfig</code> patch (trigger <code>memory_full_avg10 &gt; 50.0</code>, holdoff <code>30s</code>) applied to all 3 nodes via <code>talosctl patch mc</code> → <strong>zero OOMController events from then on</strong>.</li>
<li><strong>07-03 15:04–~19:50</strong> — cluster-wide kubelet wedge remained: talos-2 kubelet D-state in <code>Stopping</code> &gt;1 h, SIGKILL-immune; even force-unmap of rbd devices blocked in-kernel waiting on the dead OSDs.</li>
<li><strong>07-03 ~19:50</strong> — <strong>user-initiated full reboot of all 3 nodes</strong> cleared all D-state/debris: <strong>all 6 OSDs up in ~60 s</strong> (on their baked device paths — no rook#17224 drift), all PGs active, <code>noout</code> unset ~20:15, <strong>HEALTH_OK</strong>; backfill of the 4.3% degraded remainder completed normally.</li>
<li><strong>Aftermath</strong> — external-secrets 2.7.0 + cert-manager v1.20.3 upgrades (frozen mid-outage) completed after the unfreeze; Flux fully reconciled: <strong>122/122 Kustomizations + 103/103 HelmReleases Ready</strong>.</li>
</ul>
<h3>Root cause</h3>
<p><strong>The Talos v1.12 OOMController default PSI trigger (<code>memory_full_avg10 &gt; 12.0 &amp;&amp; d_memory_full_avg10 &gt; 0.0 &amp;&amp; time_since_trigger &gt; 500ms</code>) is far too aggressive for Ceph nodes.</strong> Memory-PSI spikes are <em>normal</em> here (OSD peering/backfill, BlueStore cache churn, recovery IO); the controller answered them by SIGKILLing the heaviest <strong>Burstable</strong> cgroups. The victim-ranking expression never selects Guaranteed cgroups — so cilium-agent, the OSD pods, and kube-apiserver (all Burstable) were the perpetual victims, and every kill made the pressure worse.</p>
<p>Two amplifiers made the PSI spikes pathological:</p>
<ol>
<li><strong>Dead-container memory debris</strong> — after the 06-30 kills, ~24 GiB (talos-1) and ~70 GiB (talos-2) of reclaimable slab + reparented page cache from dead OSD containers stayed pinned in <code>kubepods/burstable</code>. MemFree sat at the watermark (~0.4–2 GiB) while MemAvailable showed 26–72 GiB; every allocation burst forced slow direct reclaim through the debris → PSI <code>full avg10</code> 18–46% → trigger fired ~every second (the 07-03 storms).</li>
<li><strong>talos-1&#39;s reduced-RAM window</strong> (48 GB single stick until the RAM RMA; <strong>completed 2026-08-21</strong>, all 3 nodes now 96 GB): least headroom at the time, first to trip; its kube-apiserver (646 restarts) and cilium-agent (503 restarts) were chronic victims.</li>
</ol>
<p><strong>RULED OUT:</strong> MGLRU regression (<code>/sys/kernel/mm/lru_gen/enabled = 0x0000</code> verified on all 3 nodes — PR #1094 held); rook#17224 device-path drift (never materialized — every OSD re-activated on its baked <code>ROOK_BLOCK_PATH</code>, including after the full reboots); store corruption / bad hardware (zero corruption signatures across all 6 OSDs through ~6 kill cycles + reboots; SMART/dmesg clean).</p>
<h3>Evidence</h3>
<pre><code>Default trigger:  memory_full_avg10 &gt; 12.0 &amp;&amp; d_memory_full_avg10 &gt; 0.0 &amp;&amp; time_since_trigger &gt; 500ms
Victim ranking:   memory_max.hasValue() ? 0.0
                  : {Besteffort:1.0, Burstable:0.5, Guaranteed:0.0, Podruntime:0.0, System:0.0}[class]
                    * memory_current
                  -&gt; Guaranteed cgroups are NEVER selected; big Burstable ones always are

Pre-recovery snapshot (2026-07-03 13:32 UTC):
  osd: 6 osds: 2 up (since 37h), 4 in — hosts talos-1 + talos-2 down
  pgs: 100.000% pgs not active; 393 inactive (347 undersized+degraded+peered)
  2060444/3090666 objects degraded (66.667%)
  MDS: slow metadata IOs blocked &gt;30s, oldest blocked for 134362 secs (~37h)

talos-1 memory anatomy (07-03 13:35 UTC): TOTAL 47.9Gi, FREE ~500Mi, AVAILABLE 26Gi
  Inactive(file) 24.9Gi vs Cached 1.06Gi -&gt; ~24Gi reparented dead-container cache pinned in
  kubepods/burstable (cgroup MemCurrent 30Gi vs live children ~6Gi); containerd RSS 9.5Gi
07-03 kill storms 14:46–15:03 (all 3 nodes): PSI full avg10 18–46% -&gt; kills ~every 1s
  victims: cilium-agent (talos-1/2), radarr (talos-3), kube-apiserver-talos-2;
  collateral: all 6 OSD pods crashed (EPERM device-cgroup + runc sandbox-race damage)
Chronic talos-1 victims: kube-apiserver 646 restarts, cilium-agent 503 restarts
After OOMConfig patch (15:04, trigger 50%/30s): ZERO OOMController events through
  full recovery + backfill on all 3 nodes
</code></pre>
<h3>Impact</h3>
<ul>
<li><strong>Total storage outage ~3 days</strong> — 100% PGs inactive, every RBD/CephFS consumer frozen (dozens of pods in Init/Error/CrashLoop cluster-wide); MDS blocked &gt;37 h.</li>
<li><strong>No data loss, no corruption</strong> — repli

... [23228 bytes truncated] ...

rvation</h3>
<p>Unlike the Meigao Venus incidents (recurring firmware/PM races on identical hardware), this is a <strong>discrete physical failure</strong> on a specific port/cable. Not a pattern issue — replacement fixes it permanently. But it does highlight:</p>
<ol>
<li>TrueNAS SCALE has no default swap — should add 16 GB swap on <code>/dev/sda4</code> on every install as standard practice (now done)</li>
<li>The 82599ES family has a deservedly poor reputation; the Huawei OEM rebrand is the worst variant. Prefer Mellanox for future NAS NICs</li>
<li>Heavy NFS load from the K8s cluster (Tdarr + media ingest) is the type of workload that now reliably exposes flaky NICs — consider <code>nconnect=2</code> NFS mount option to reduce per-socket pressure</li>
</ol>
<hr>
<h2>[2026-04-14] Intel iGPU GuC firmware init race — Meigao Venus PM instability (3rd subsystem)</h2>
<table>
<thead>
<tr>
<th>Field</th>
<th>Value</th>
</tr>
</thead>
<tbody><tr>
<td><strong>Node</strong></td>
<td>talos-1 (10.10.10.11) initially, fix applied to all 3 nodes</td>
</tr>
<tr>
<td><strong>Component</strong></td>
<td>Intel UHD/Iris Xe iGPU (Raptor Lake i9-13900H, device id <code>0xa7a0</code>)</td>
</tr>
<tr>
<td><strong>Affected service</strong></td>
<td>Tdarr workers (HEVC transcoding), Jellyfin (hardware transcoding if scheduled to talos-1)</td>
</tr>
<tr>
<td><strong>Severity</strong></td>
<td>medium — feature degraded, no data risk</td>
</tr>
</tbody></table>
<h3>Root cause</h3>
<p>Same Meigao Venus (AHWSA) board-level power management instability that previously caused the <strong>NVMe APST/PCIe ASPM Ceph OSD crashes</strong> (see project memory <code>project_talos_nvme_pcie_fix.md</code>, fixed 2026-03-16). This time the racy subsystem was the <strong>Intel iGPU&#39;s display power gating</strong> racing with <strong>GuC (Graphics microController) firmware handshake</strong> during boot.</p>
<p>When the i915 driver loaded, GuC firmware (<code>i915/adlp_guc_70.bin</code>, version 70.49.4) loaded but the microkernel never reached the <code>0xf0</code> (running) state — got stuck at <code>0x0</code>. Any subsequent attempt to use QSV or VAAPI hardware encoding via <code>iHD_drv_video.so</code> segfaulted deterministically at offset <code>0x1c87bc</code>.</p>
<p>The pattern matches the established Meigao board flakiness: aggressive default PM races with device init. We had already disabled PM for NVMe and external PCIe (<code>nvme_core.default_ps_max_latency_us=0</code>, <code>pcie_aspm=off</code>); this fix extends the same workaround to the iGPU&#39;s display power controller.</p>
<h3>Evidence</h3>
<p>GuC status comparison across nodes (BEFORE fix):</p>
<pre><code>talos-1: GuC status 0x800300ec   uKernel status = 0x0    ← stuck
talos-2: GuC status 0x8003f0ec   uKernel status = 0xf0   ← healthy
talos-3: GuC status 0x8005f0ec   uKernel status = 0xf0   ← healthy
</code></pre>
<p>ffmpeg QSV test on talos-1 → exit code 139 (SIGSEGV).</p>
<p>Kernel trap log full of identical-offset segfaults from every attempt to use the GPU:</p>
<pre><code>traps: HandBrakeCLI[XXXX] general protection fault ip:XXXXXXXX7bc sp:XXXXXXXX
  error:0 in iHD_drv_video.so[1c87bc,XXXXXXXX+a11000]
</code></pre>
<p>Same offset (<code>0x1c87bc</code>) every time — deterministic software fault, not hardware corruption.</p>
<p>Tdarr encoder probe before/after on talos-1:</p>
<pre><code>Before: h264_qsv-true-false,  hevc_qsv-true-false,  hevc_vaapi-true-false
After:  h264_qsv-true-true,   hevc_qsv-true-true,   hevc_vaapi-true-true
</code></pre>
<h3>Impact</h3>
<ul>
<li>Tdarr DaemonSet running on talos-1 was useless for GPU work (driver crashed on every encode)</li>
<li>Files transcoded successfully on talos-2/talos-3 but couldn&#39;t use the third GPU</li>
<li>Jellyfin would have lost hardware transcoding if rescheduled to talos-1</li>
<li>No data loss</li>
<li>The earlier Tdarr V8 <code>VerifyChecksum(blob)</code> crash on talos-1 was a separate, one-off container layer corruption (resolved by pod delete) — not connected to this issue. Initially looked like generic hardware failure but ruled out by confirming no MCE/ECC events in dmesg, healthy temps (51°C), and identical hardware/firmware across nodes</li>
</ul>
<h3>Resolution</h3>
<p>Added kernel arg <code>i915.enable_dc=0</code> to <code>talos/schematic.yaml</code> (disables iGPU display controller power gating). New factory schematic ID: <code>ac2b7006014bfd57ed2ee6bce766bfe1d3a18f02e2a5f3a6fc4f5265c77e99ee</code>.</p>
<p>Rolled out via <code>task talos:upgrade-node</code> to all 3 nodes one at a time, waiting for Ceph to rebalance between each (kept it from going degraded). After the upgrade:</p>
<ul>
<li>talos-1 GuC reached <code>0xf0</code>, all encoders show <code>true-true</code></li>
<li>The pre-existing slow-OSD warning on talos-3&#39;s <code>osd.4</code> cleared after that node&#39;s reboot — likely the same BlueStore PM stall pattern</li>
<li>All 3 nodes now have all known PM races disabled</li>
</ul>
<pre><code>NVMe:  nvme_core.default_ps_max_latency_us=0    (fixed 2026-03-16)
PCIe:  pcie_aspm=off                             (fixed 2026-03-16)
iGPU:  i915.enable_dc=0                          (fixed 2026-04-14)
</code></pre>
<h3>Pattern observation</h3>
<p>Meigao Venus boards have aggressive default BIOS power management across <strong>every</strong> PM-managed subsystem. Each subsystem&#39;s driver has to win a race against PM kicking in. Linux often loses when probing fast. <strong>Expect more surprises from this hardware over time</strong> (USB controllers, display, audio) all fixable by similar <code>disable PM for X</code> kernel args. Consider proactively auditing other subsystems&#39; PM behavior before they cause incidents.</p>
<hr>
<h2>[2026-03-21] Ceph monitor mon.j crash loop — RocksDB store corruption on talos-1</h2>
<table>
<thead>
<tr>
<th>Field</th>
<th>Value</th>
</tr>
</thead>
<tbody><tr>
<td><strong>Node</strong></td>
<td>talos-1 (10.10.10.11)</td>
</tr>
<tr>
<td><strong>Component</strong></td>
<td>Local storage (openebs-hostpath)</td>
</tr>
<tr>
<td><strong>Affected service</strong></td>
<td>mon.j (rook-ceph-mon-j)</td>
</tr>
<tr>
<td><strong>Severity</strong></td>
<td>high</td>
</tr>
</tbody></table>
<h3>Root cause</h3>
<p>RocksDB SST file <code>154904.sst</code> in mon-j&#39;s store developed a block checksum mismatch, indicating silent data corruption on the underlying openebs-hostpath volume (<code>/var/openebs/local/pvc-df451fee-f19a-4568-9e50-891988442cab</code>). The corruption was detected during a compaction of L0 into L6. Once RocksDB flagged the background error, all subsequent writes were rejected, causing mon-j to abort on every sync attempt. Suspected cause is either an unclean node shutdown or a silent bit-flip on the local disk.</p>
<h3>Evidence</h3>
<pre><code>rocksdb: Corruption: block checksum mismatch: stored = 467716038, computed = 938189546, type = 4
  in /var/lib/ceph/mon/ceph-j/store.db/154904.sst offset 13748504 size 103348

rocksdb: submit_common error: Corruption: block checksum mismatch (same as above)
  Rocksdb transaction rejected — MonitorDBStore::apply_transaction() -&gt; ceph_abort_msg(&quot;failed to write to db&quot;)

Crash backtrace: Monitor::sync_start -&gt; apply_transaction -&gt; failed to write to db -&gt; abort
55+ restarts in CrashLoopBackOff over ~4.5 hours
</code></pre>
<h3>Impact</h3>
<ul>
<li>Ceph cluster degraded to <code>HEALTH_WARN</code> — 1/3 mons down, quorum maintained by mon.h and mon.i</li>
<li>Rook operator unable to schedule replacement mon-k due to host port conflicts (3300/6789 held by crashing mon-j pod)</li>
<li>No data loss — all 6 OSDs healthy, all PGs active+clean</li>
<li>Reduced fault tolerance — loss of one more mon would break quorum</li>
</ul>
<h3>Resolution</h3>
<p>Delete mon-j deployment and PVC to free host ports and remove corrupted store. The Rook operator will automatically create a replacement monitor that syncs a fresh monstore from the quorum.</p>
<pre><code class="language-bash">kubectl -n rook-ceph delete deployment rook-ceph-mon-j
kubectl -n rook-ceph delete pvc rook-ceph-mon-j
</code></pre>
<hr>
```
</details>
- Evidence: Full styled HTML rendering of docs/hardware-incidents.md (browsable end-user view) (local file: <code>/var/folders/yr/h20mxtv56yj1c1pt9tr1_kbc0000gn/T/no-mistakes-evidence/01M0HYQ8TBHN8AGK51B9G2G7PQ/hardware-incidents-full.html</code>)
<details>
<summary>Evidence: Rendered HTML excerpt confirming the 96GB figure and RMA close-out text</summary>

```text
<p>Current node memory (as of 2026-08-21): <strong>96 GB per node</strong> on all 3 Talos nodes. talos-1 Stick B RMA closed; see [2026-06-19].</p>
...
<p><strong>✅ CLOSED 2026-08-21 - Stick B repaired/exchanged; all 3 nodes at 96 GB.</strong> The faulty
Crucial CT48G56C46S5.M16B ("Stick B") was replaced. talos-1 is back to dual-channel 96 GB
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"a0194c5c4520ec9b5cfb9e85627071b626d97c95","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `git diff d72f5b5a..a0194c5c --stat (confirms only docs/hardware-incidents.md changed)`
- `git diff d72f5b5a..a0194c5c -- docs/hardware-incidents.md (reviewed full diff content)`
- `grep -niE '48 ?gb|96 ?gb|memory' README.md CLAUDE.md docs/reference.md (confirmed README.md's 16GB line is the unrelated cluster-template minimum-requirements table, and CLAUDE.md/docs/reference.md contain no per-node memory figures needing edits)`
- `grep -n TODO docs/hardware-incidents.md (confirmed the RAM-window TODO was closed/updated to 96GB-complete status, while the unrelated OSD-Guaranteed-QoS TODO correctly remains open as a documented follow-up per the accepted constraints)`
- `npx marked -i docs/hardware-incidents.md -o <evidence>/hardware-incidents.html (rendered the corrected doc to HTML and grepped the rendered output to confirm the '96 GB per node' summary line, the closed RMA entry, and the retained affinity/QoS TODO follow-up all render correctly)`
- `git status --porcelain (confirmed clean worktree, no stray files left from testing)`

</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `docs/ceph-cluster-changelog.md:96` - Beyond the already-applied edits in docs/hardware-incidents.md (which correctly closes the RAM TODO, updates both memory-capacity mentions to 96GB, and correctly preserves the NotIn [talos-1] affinity revert and OSD Guaranteed-QoS promotion as open GitOps follow-ups per the accepted constraints), the same now-stale &#39;pending talos-1 RAM RMA (single 48GB stick)&#39; fact is still duplicated in docs/ceph-cluster-changelog.md:96 and in code comments across 8 HelmRelease manifests (kubernetes/apps/selfhosted/rsshub/app/hr.yaml, .../changedetection/app/helmrelease.yaml, .../ai/agentmemory/app/helmrelease.yaml, .../ai/kokoro/app/helmrelease.yaml, .../coder/app/helmrelease.yaml, .../downloads/radarr/app/helmrelease.yaml, .../downloads/sabnzbd/app/helmrelease.yaml, .../downloads/readarr/app/helmrelease.yaml, .../media/seerr/app/helmrelease.yaml). The user&#39;s accepted constraints explicitly scope the RMA-closure/remaining-work status to hardware-incidents.md alone and forbid touching the affinities in this change, so updating those 9 locations now would go beyond this change&#39;s scope and risk re-synchronizing a duplicate fact across many unrelated files. Recommend a small follow-up (bundled with the eventual affinity revert) that either updates or removes these stale TODO comments and points to hardware-incidents.md instead of restating the RAM figure.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
