### PR TITLE
docs(rook-ceph): confirm v20.2.3 does not fix default csi subvolumegroup

### DIFF
--- a/docs/ceph-cluster-changelog.md
+++ b/docs/ceph-cluster-changelog.md
@@ -22,7 +22,7 @@ rather than hardware failures. The goal is that when something breaks we can ans
 | Layer | Value |
 |-------|-------|
 | **Rook** | v1.20.0 (operator + cluster chart) — latest upstream, released 2026-06-02 |
-| **Ceph** | v20.2.1 **Tentacle** — latest published point release (v20.2.2+ not yet on quay) |
+| **Ceph** | v20.2.3 **Tentacle** (GitOps `cephImage.tag` + all 17 daemons, verified 2026-08-21). Default `csi` subvolumegroup still broken; RWX stays on `ceph-filesystem-rwx` (see 2026-08-21 entry) |
 | **Talos** | v1.13.2 (kernel has `CONFIG_CEPH_FS=y`, `CONFIG_BLK_DEV_RBD=y`, `CONFIG_CEPH_LIB=y` — CephFS + krbd **built-in**) |
 | **Kubernetes** | v1.36.1 |
 | **Cluster FSID** | `6562d9b0-883a-4e55-8b5d-899eaa7e0d10` |
@@ -82,6 +82,57 @@ Notes / evidence / sources.
 ---
 
 ## Change log
+
+### [2026-08-21] Default `csi` subvolumegroup still broken on Ceph v20.2.3  (docs; no GitOps / PVC change)
+
+| Field | Value |
+|-------|-------|
+| **Change** | Docs only. Live probe: Ceph v20.2.3 did **not** repair the default `csi` group's MDS `ceph.dir.subvolume` vxattr bug. Keep subvolumegroup `csi-rwx` and StorageClass `ceph-filesystem-rwx`. Do **not** migrate `downloads/shared-downloads`, `media/tdarr-temp`, or `ai/comfyui-output`. |
+| **Why** | The 2026-06-13 entry said retire the workaround once v20.2.2+ ships and the default group is fixed. GitOps and every daemon are already on v20.2.3. v20.2.2/v20.2.3 notes mention a dashboard SMB-form subvolume-group corruption fix (PR #68103), which is a different bug from the Tentacle MDS vxattr regression (PRs #65779 / #65564). |
+| **Risk** | Throwaway `create` against group `csi` returned `EINVAL` but still left an empty dir. Live RWX PVC data was not mounted, copied, or re-bound. |
+| **Rollback** | n/a (no storage or GitOps change) |
+| **Verify** | commands and results below |
+
+**Cluster at probe time (toolbox `deploy/rook-ceph-tools`):**
+
+- `ceph version` → `ceph version 20.2.3 (06c2f9c35b67055a8a6fb99d1be236b3c4832ace) tentacle`
+- `ceph versions` → all 17 daemons on that build (3 mon / 2 mgr / 6 osd / 4 mds / 2 rgw)
+- `ceph health` → `HEALTH_ERR Module 'crash' has failed: dictionary changed size during iteration` (mgr crash module; unrelated to MDS)
+- `ceph mds stat` → `ceph-filesystem:2 {0=ceph-filesystem-a=up:active,1=ceph-filesystem-b=up:active} 2 up:standby-replay`
+- Groups: `csi` (created 2025-10-05) and `csi-rwx` (created 2026-06-13)
+
+**Default group `csi` (still broken):**
+
+```text
+ceph fs subvolume getpath ceph-filesystem csi-vol-901cd38e-4a3e-479f-8b39-cc634c692cc8 --group-name csi
+# Error EINVAL: invalid value specified for ceph.dir.subvolume  (exit 22)
+
+# same EINVAL on leftover probe names already in the group:
+#   diag-test-1781359451, diag-retest, t-existing-p1
+# and on info / rm / rm --force for those names
+
+ceph fs subvolume create ceph-filesystem fm-verify-csi-1787308879 --group-name csi --size 1048576
+# Error EINVAL: invalid value specified for ceph.dir.subvolume  (exit 22)
+# BUT the name still appears in `ceph fs subvolume ls` (partial create)
+```
+
+libcephfs (toolbox, admin key): dir `/volumes/csi/fm-verify-csi-1787308879` exists, empty uuid child `b06dd9b4-f715-49fd-b8cd-290cc81844c6`, vxattr `ceph.dir.subvolume=0` (a real subvolume is `1`). `rmdir` → `PermissionDenied`. Toolbox `ceph-fuse` cannot mount (`fuse: device not found`). Leftover dir remains; same class as the pre-existing `diag-*` names. Do not `rm -rf` anything under `/volumes/csi/csi-vol-*`.
+
+**Control group `csi-rwx` (healthy):**
+
+```text
+ceph fs subvolume getpath ceph-filesystem csi-vol-65d64298-ceeb-42c3-af19-628317eb2af6 --group-name csi-rwx
+# /volumes/csi-rwx/csi-vol-65d64298-ceeb-42c3-af19-628317eb2af6/77f03695-b368-4a59-be2c-fa1d6e154f93
+
+ceph fs subvolume create ceph-filesystem fm-verify-csi-1787308879 --group-name csi-rwx --size 1048576   # exit 0
+ceph fs subvolume getpath ceph-filesystem fm-verify-csi-1787308879 --group-name csi-rwx                 # exit 0
+ceph fs subvolume rm ceph-filesystem fm-verify-csi-1787308879 --group-name csi-rwx                      # exit 0
+# csi-rwx still has exactly the original 3 CSI volumes (the 3 RWX PVCs)
+```
+
+**Still using `ceph-filesystem-rwx`:** `downloads/pvc` (`shared-downloads` 2Ti), `media/tdarr` (`tdarr-temp` 200Gi), `ai/comfyui` (`comfyui-output` 25Gi).
+
+**Retirement rule:** image tag is not sufficient. Re-test with a throwaway `create`/`getpath`/`rm` against group `csi` on a future Ceph release; only migrate the 3 RWX PVCs after that probe is clean. Prefer a name you can leave behind if `create` EINVAL-leaks another empty dir.
 
 ### [2026-07-03] OOM-outage recovery: Talos OOMConfig retuned (live + codified), transient `min_size=1` windows, noout window  (operational + `talos/machineconfig.yaml.j2`)
 
@@ -195,7 +246,7 @@ Evidence captured 2026-06-14 (read-only): all CephFS mounts kernel-client; ceph-
 | **Rollback** | old PVs kept as `Retain` safety-net (delete when confident) |
 | **Verify** | apps healthy on `ceph-filesystem-rwx`, Ceph back to baseline |
 
-Cross-ref: [CephFS Tentacle subvolumegroup bug](../) (memory). Retire `csi-rwx` when Ceph v20.2.2+ ships and the default group is fixed.
+Cross-ref: [CephFS Tentacle subvolumegroup bug](../) (memory). Do **not** retire `csi-rwx` on image tag alone: live probe on v20.2.3 (2026-08-21) still fails `create`/`getpath` against the default `csi` group with `EINVAL: invalid value specified for ceph.dir.subvolume`. Keep `ceph-filesystem-rwx` until a future release passes that probe.
 
 ### [2026-06-12] CephFS CSI forced to autodetect → `ceph-fuse`  (PR — commit 17c7a9df, ae44b3ac)
 

--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/cephfs-rwx-storageclass.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/cephfs-rwx-storageclass.yaml
@@ -2,7 +2,8 @@
 # CephFS RWX StorageClass backed by the healthy `csi-rwx` subvolumegroup
 # (see cephfs-rwx-subvolumegroup.yaml). Use this INSTEAD of `ceph-filesystem`
 # for any ReadWriteMany workload while the default `csi` subvolumegroup is broken
-# by the Ceph Tentacle v20.2.1 `ceph.dir.subvolume` regression.
+# by the Ceph Tentacle MDS `ceph.dir.subvolume` vxattr regression (v20.2.1;
+# still broken on live v20.2.3, see docs/ceph-cluster-changelog.md 2026-08-21).
 #
 # `clusterID` MUST match the `csi-rwx` group's generated CSI clusterID
 # (`.status.info.clusterID` of CephFilesystemSubVolumeGroup/ceph-filesystem-csi-rwx).

--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/cephfs-rwx-subvolumegroup.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/cephfs-rwx-subvolumegroup.yaml
@@ -11,9 +11,12 @@
 # repair is blocked on Tentacle (mgr-only write). Verified empirically that a
 # FRESH subvolumegroup is unaffected — create + getpath + info all succeed.
 #
-# This `csi-rwx` group backs the `ceph-filesystem-rwx` StorageClass. Migrate RWX
-# workloads off `ceph-filesystem` (broken `csi` group) onto `ceph-filesystem-rwx`.
-# Remove this once a fixed Ceph release (v20.2.2+) lets the default `csi` group work.
+# This `csi-rwx` group backs the `ceph-filesystem-rwx` StorageClass. Keep RWX
+# workloads on `ceph-filesystem-rwx` while the default `csi` group is broken.
+# v20.2.3 did not fix it (live create/getpath still EINVAL; see
+# docs/ceph-cluster-changelog.md 2026-08-21). Do not delete this CR because
+# the image tag is past v20.2.2. Re-test create/getpath against group `csi`
+# before anyone migrates the 3 RWX PVCs back to `ceph-filesystem`.
 apiVersion: ceph.rook.io/v1
 kind: CephFilesystemSubVolumeGroup
 metadata:


### PR DESCRIPTION
## Intent

Verify live whether this cluster's Ceph v20.2.3 can do a subvolume create/getpath against the default csi group, then update docs accordingly. Do not migrate live PVC storage.

Captain decision 2026-08-21: verify before deciding. Read the csi-rwx section of the storage docs audit (C1 / P1-3 in data/homeops-docs-audit-storage/report.md) for exact evidence and file locations.

docs/ceph-cluster-changelog.md said retire the csi-rwx workaround once Ceph v20.2.2+ ships and the default csi group's MDS vxattr bug is fixed. GitOps is on v20.2.3 now, but the workaround (ceph-filesystem-rwx) is still used by 3 RWX PVCs (downloads/pvc, media/tdarr, ai/comfyui).

Verify live, read-only first: can this cluster's Ceph successfully do a subvolume create/getpath against the default csi group on v20.2.3? Use the rook-ceph toolbox (docs/ceph/toolbox.md) to test this without touching any live workload's storage.

If the default group works cleanly: propose migrating the 3 RWX PVCs off the workaround onto the default group, and update docs/ceph-cluster-changelog.md to record retirement - but do not actually migrate live PVC storage in this task without a separate explicit go-ahead, since that risks live data for downloads/tdarr/comfyui. Stop at "verified safe, here's the migration plan".

If the default group still fails: update the changelog to record that v20.2.3 did not fix it, keep the workaround, and note exactly what you tested.

Live probe outcome: default csi group still fails create/getpath/info/rm with EINVAL invalid value specified for ceph.dir.subvolume on v20.2.3; csi-rwx control create/getpath/rm succeeded. Changelog 2026-08-21 entry plus ceph-filesystem-rwx YAML comments were updated so v20.2.2+ is not treated as retirement. The 3 RWX PVCs were not migrated. A throwaway create against csi EINVAL-leaked empty dir fm-verify-csi-1787308879 (rm and libcephfs rmdir fail, same class as pre-existing diag-* leftovers); that leftover is documented and was not force-deleted because doing so would risk live /volumes/csi/csi-vol-* paths.

## What Changed

- Recorded a live, read-only probe (via rook-ceph toolbox) showing Ceph v20.2.3 still returns `EINVAL: invalid value specified for ceph.dir.subvolume` on `create`/`getpath`/`info`/`rm` against the default `csi` subvolumegroup, while the `csi-rwx` control group succeeds cleanly - so `docs/ceph-cluster-changelog.md` is updated with the 2026-08-21 findings (cluster version/health snapshot, exact commands/output for both groups, and a documented leftover empty dir from the throwaway probe) instead of the previously planned "retire on v20.2.2+" note.
- Updated the cluster version table and the prior 2026-06-13 changelog entry's cross-reference to state that image-tag alone is not sufficient evidence and that `ceph-filesystem-rwx`/`csi-rwx` must stay in place until a future release passes the same probe.
- Updated in-repo comments on `cephfs-rwx-storageclass.yaml` and `cephfs-rwx-subvolumegroup.yaml` to reflect that the bug persists on v20.2.3 and to warn against deleting the `csi-rwx` CR or migrating the 3 RWX PVCs (`downloads/pvc`, `media/tdarr`, `ai/comfyui`) based on image tag alone; no StorageClass/CephFilesystemSubVolumeGroup spec fields were changed and no live PVC storage was migrated.

## Risk Assessment

✅ Low: The change is docs-only plus non-functional YAML comment updates (no StorageClass/SubvolumeGroup spec fields changed, no PVC migration), and it faithfully records the live verification outcome (default csi group still EINVAL on v20.2.3, csi-rwx workaround kept) exactly as required by the authorized intent, with no forbidden live-migration behavior introduced.

## Testing

This is a documentation-only change (Ceph changelog entry plus YAML comment updates); there is no application code or automated test suite applicable. Static verification confirms the two touched YAML manifests have no functional diff (comment-only) and that the 3 live RWX PVCs (downloads/pvc, media/tdarr, ai/comfyui) and their storage-class bindings are untouched, satisfying the "do not migrate live PVC storage" constraint. The core claim under test - that Ceph v20.2.3's default `csi` subvolumegroup still fails create/getpath with EINVAL while `csi-rwx` succeeds - is an operational, live-cluster observation that cannot be independently re-executed from this sandboxed worktree (no kubectl/toolbox connectivity available). That said, the changelog entry itself embeds the actual CLI transcript (exact `ceph fs subvolume` commands, exit codes, and error text) as the product-level evidence of the live probe, which I extracted verbatim into the evidence directory; no fabricated or independently-reproduced evidence was needed since the transcript is already part of the change under review.

<details>
<summary>Evidence: Live Ceph v20.2.3 csi-group probe transcript (extracted from changelog entry under review)</summary>

```text
### [2026-08-21] Default `csi` subvolumegroup still broken on Ceph v20.2.3  (docs; no GitOps / PVC change)

| Field | Value |
|-------|-------|
| **Change** | Docs only. Live probe: Ceph v20.2.3 did **not** repair the default `csi` group's MDS `ceph.dir.subvolume` vxattr bug. Keep subvolumegroup `csi-rwx` and StorageClass `ceph-filesystem-rwx`. Do **not** migrate `downloads/shared-downloads`, `media/tdarr-temp`, or `ai/comfyui-output`. |
| **Why** | The 2026-06-13 entry said retire the workaround once v20.2.2+ ships and the default group is fixed. GitOps and every daemon are already on v20.2.3. v20.2.2/v20.2.3 notes mention a dashboard SMB-form subvolume-group corruption fix (PR #68103), which is a different bug from the Tentacle MDS vxattr regression (PRs #65779 / #65564). |
| **Risk** | Throwaway `create` against group `csi` returned `EINVAL` but still left an empty dir. Live RWX PVC data was not mounted, copied, or re-bound. |
| **Rollback** | n/a (no storage or GitOps change) |
| **Verify** | commands and results below |

**Cluster at probe time (toolbox `deploy/rook-ceph-tools`):**

- `ceph version` → `ceph version 20.2.3 (06c2f9c35b67055a8a6fb99d1be236b3c4832ace) tentacle`
- `ceph versions` → all 17 daemons on that build (3 mon / 2 mgr / 6 osd / 4 mds / 2 rgw)
- `ceph health` → `HEALTH_ERR Module 'crash' has failed: dictionary changed size during iteration` (mgr crash module; unrelated to MDS)
- `ceph mds stat` → `ceph-filesystem:2 {0=ceph-filesystem-a=up:active,1=ceph-filesystem-b=up:active} 2 up:standby-replay`
- Groups: `csi` (created 2025-10-05) and `csi-rwx` (created 2026-06-13)

**Default group `csi` (still broken):**

`` `text
ceph fs subvolume getpath ceph-filesystem csi-vol-901cd38e-4a3e-479f-8b39-cc634c692cc8 --group-name csi
# Error EINVAL: invalid value specified for ceph.dir.subvolume  (exit 22)

# same EINVAL on leftover probe names already in the group:
#   diag-test-1781359451, diag-retest, t-existing-p1
# and on info / rm / rm --force for those names

ceph fs subvolume create ceph-filesystem fm-verify-csi-1787308879 --group-name csi --size 1048576
# Error EINVAL: invalid value specified for ceph.dir.subvolume  (exit 22)
# BUT the name still appears in `ceph fs subvolume ls` (partial create)
`` `

libcephfs (toolbox, admin key): dir `/volumes/csi/fm-verify-csi-1787308879` exists, empty uuid child `b06dd9b4-f715-49fd-b8cd-290cc81844c6`, vxattr `ceph.dir.subvolume=0` (a real subvolume is `1`). `rmdir` → `PermissionDenied`. Toolbox `ceph-fuse` cannot mount (`fuse: device not found`). Leftover dir remains; same class as the pre-existing `diag-*` names. Do not `rm -rf` anything under `/volumes/csi/csi-vol-*`.

**Control group `csi-rwx` (healthy):**

`` `text
ceph fs subvolume getpath ceph-filesystem csi-vol-65d64298-ceeb-42c3-af19-628317eb2af6 --group-name csi-rwx
# /volumes/csi-rwx/csi-vol-65d64298-ceeb-42c3-af19-628317eb2af6/77f03695-b368-4a59-be2c-fa1d6e154f93

ceph fs subvolume create ceph-filesystem fm-verify-csi-1787308879 --group-name csi-rwx --size 1048576   # exit 0
ceph fs subvolume getpath ceph-filesystem fm-verify-csi-1787308879 --group-name csi-rwx                 # exit 0
ceph fs subvolume rm ceph-filesystem fm-verify-csi-1787308879 --group-name csi-rwx                      # exit 0
# csi-rwx still has exactly the original 3 CSI volumes (the 3 RWX PVCs)
`` `

**Still using `ceph-filesystem-rwx`:** `downloads/pvc` (`shared-downloads` 2Ti), `media/tdarr` (`tdarr-temp` 200Gi), `ai/comfyui` (`comfyui-output` 25Gi).

**Retirement rule:** image tag is not sufficient. Re-test with a throwaway `create`/`getpath`/`rm` against group `csi` on a future Ceph release; only migrate the 3 RWX PVCs after that probe is clean. Prefer a name you can leave behind if `create` EINVAL-leaks another empty dir.

### [2026-07-03] OOM-outage recovery: Talos OOMConfig retuned (live + codified), transient `min_size=1` windows, noout window  (operational + `talos/machineconfig.yaml.j2`)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"f0f43bdd391b94e773023af0e2271825cffcd5b7","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`git diff d72f5b5a..f0f43bd --stat` to confirm change scope is limited to docs/ceph-cluster-changelog.md and two YAML comment blocks</code>
- <code>`diff &lt;(grep -v &#39;^\s*#&#39; &lt;old&gt;) &lt;(grep -v &#39;^\s*#&#39; &lt;new&gt;)` on both changed YAML files to confirm zero functional/spec diff, comment-only</code>
- <code>`git diff --stat` filtered for downloads/tdarr/comfyui app paths to confirm the 3 RWX PVCs and their ceph-filesystem-rwx StorageClass references are unmodified</code>
- <code>`python3 -c &#39;yaml.safe_load_all(...)&#39;` on both changed YAML files to confirm they still parse as valid YAML</code>
- `checked for live cluster/kubectl/toolbox connectivity in this sandbox (none available) to see if the documented Ceph probe could be independently re-executed`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
