### PR TITLE
docs: fix stale root and Talos documentation from docs audit

### DIFF
--- a/.secrets.env.example
+++ b/.secrets.env.example
@@ -1,8 +1,12 @@
 # Copy to .secrets.env (gitignored) and fill in.
 # Loaded automatically by mise (_.file in .mise.toml) so that `vals`/`op`
-# can resolve ref+op://kubernetes/talos/* references during the talos render path.
+# can resolve ref+op://Home-Lab/talos/* references during the talos render path.
 #
-# Use a 1Password service-account token scoped to the `kubernetes` vault for an
+# Vals (bootstrap and Talos render) uses vault `Home-Lab`. In-cluster ESO
+# Connect uses vaults `Homelab`, `Automation`, and `Services` - different
+# channel, different spelling.
+#
+# Use a 1Password service-account token scoped to the `Home-Lab` vault for an
 # unattended render path (CI, non-interactive `just talos render-config`):
 #
 #   OP_SERVICE_ACCOUNT_TOKEN=ops_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,50 +1,46 @@
 # PROJECT KNOWLEDGE BASE
 
-**Generated:** 2026-04-09 | **Commit:** bffbe886 | **Branch:** main
-
-## OVERVIEW
-
-Home-ops GitOps infrastructure repo: Talos Linux k8s cluster managed by Flux v2. 21 namespaces, 100+ apps, triple-redundant Volsync backups, Cilium CNI, Rook-Ceph storage, OnePassword secrets via External Secrets Operator.
+Home-ops GitOps repo for a 3-node Talos Linux Kubernetes cluster managed by Flux v2. For operator command detail use [`CLAUDE.md`](CLAUDE.md), [`talos/AGENTS.md`](talos/AGENTS.md), and [`bootstrap/AGENTS.md`](bootstrap/AGENTS.md).
 
 ## STRUCTURE
 
 ```
 .
 ├── kubernetes/
-│   ├── apps/           # 21 namespaces, each with app subdirs (see kubernetes/AGENTS.md)
-│   ├── components/     # 5 reusable Kustomize Components (volsync, common, alerts, dragonfly, gatus)
-│   └── flux/           # cluster ks.yaml (entry point) + meta/repos (OCI/Helm sources)
-├── talos/              # Talos Linux config (see talos/AGENTS.md)
-├── bootstrap/          # Helmfile-based initial cluster bootstrap (cilium, coredns, flux)
-├── .taskfiles/         # 9 task domains: bootstrap, talos, flux, rook, k8s, network, postgres, 1password, actions-runner
-├── scripts/            # bootstrap-apps.sh, create-dynamic-bucket.sh
-├── docs/               # Reference docs (ai-system, ceph, networking, 1password)
-├── specs/              # Ceph reliability plans and verification best practices
-└── .renovate/          # Renovate config presets (autoMerge, customManagers, groups, labels, overrides)
+│   ├── apps/           # 19 namespaces, each with app subdirs
+│   ├── components/     # alerts, common, dragonfly, volsync
+│   └── flux/           # cluster ks.yaml entry + meta/repos (Helm/OCI sources)
+├── talos/              # minijinja templates (see talos/AGENTS.md)
+├── bootstrap/          # just bootstrap stages (see bootstrap/AGENTS.md)
+├── .taskfiles/         # included: 1password, k8s, flux, rook, network, actions-runner
+├── docs/               # runbooks, incident history, ceph/network notes
+└── .renovate/          # Renovate presets
 ```
+
+Gatus is an app under `kubernetes/apps/monitoring/gatus`, not a component. Endpoint wiring is the `gatus.home-operations.com/endpoint` annotation on HTTPRoutes.
 
 ## WHERE TO LOOK
 
 | Task | Location | Notes |
 |------|----------|-------|
-| Add new app | `kubernetes/apps/{namespace}/{app}/` | Follow pattern: `ks.yaml` + `app/` dir |
+| Add new app | `kubernetes/apps/{namespace}/{app}/` | Pattern: `ks.yaml` + `app/` dir |
 | Add app to namespace | `kubernetes/apps/{namespace}/kustomization.yaml` | Add `- ./{app}/ks.yaml` to resources |
-| Enable backups | `kubernetes/apps/{ns}/{app}/app/kustomization.yaml` | Add `components: [../../../components/volsync]` |
+| Enable backups | `kubernetes/apps/{ns}/{app}/ks.yaml` | Flux `spec.components` + `dependsOn: volsync` (namespace `system`) + `VOLSYNC_*` substitute keys. Example: `media/immich/ks.yaml` |
 | App secrets | `kubernetes/apps/{ns}/{app}/app/externalsecret.yaml` | OnePassword via ClusterSecretStore `onepassword` |
-| Bootstrap secrets | `kubernetes/components/common/sops/` | SOPS+age encrypted, cluster-wide only |
-| Flux entry point | `kubernetes/flux/cluster/ks.yaml` | `cluster-meta` → `cluster-apps` dependency chain |
-| Helm/OCI repos | `kubernetes/flux/meta/repos/` | 13 repo definitions |
-| Talos node config | `talos/talconfig.yaml` | Source of truth for all nodes |
-| Task commands | `Taskfile.yaml` + `.taskfiles/{domain}/` | `task --list` for all available |
-| CI workflows | `.github/workflows/` | flux-local, renovate, codeql, image-pull, label-sync |
+| Bootstrap secrets | `bootstrap/kustomize/apps/security/` | `vals` injects `ref+op://Home-Lab/1password/*` |
+| Flux entry point | `kubernetes/flux/cluster/ks.yaml` | `cluster-meta` -> `cluster-apps` dependency chain |
+| Helm/OCI repos | `kubernetes/flux/meta/repos/` | 12 repo yaml files plus `kustomization.yaml` |
+| Talos node config | `talos/machineconfig.yaml.j2` + `talos/nodes/*.yaml.j2` + `talos/schematic.yaml.j2` | Rendered by `just talos`, not Flux |
+| Task commands | `Taskfile.yaml` + `.taskfiles/{domain}/` | `task --list`. Talos/bootstrap are `just`, not `task` |
+| CI workflows | `.github/workflows/` | flux-local, renovate, codeql, image-pull, label-sync, plus build-talosctl-busybox, labeler, tag, test-runner |
 | Renovate config | `.renovaterc.json5` + `.renovate/` | Extends from Aviator-Coding/mortyops + local presets |
-| Tool versions | `.mise.toml` | 25+ tools: kubectl, flux, talos, helm, sops, age, etc. |
+| Tool versions | `.mise.toml` | kubectl, flux, talos, helm, vals, 1password-cli, just, minijinja, etc. |
 
 ## CONVENTIONS
 
 - **YAML schemas**: Every manifest starts with `# yaml-language-server: $schema=...` comment
-- **ks.yaml anchors**: `name: &app myapp`, `namespace: &namespace myns` — referenced via `*app`, `*namespace`
-- **Schema URL**: Use `kubernetes-schemas.pages.dev` — never `crd.movishell.pl` or `fluxcd-community`
+- **ks.yaml anchors**: `name: &app myapp`, `namespace: &namespace myns` - referenced via `*app`, `*namespace`
+- **Schema URL**: Use `kubernetes-schemas.pages.dev` - never `crd.movishell.pl` or `fluxcd-community`
 - **Naming**: All lowercase, kebab-case dirs/files. `helmrelease.yaml`, `kustomization.yaml`, `ks.yaml`, `externalsecret.yaml`
 - **Commit format**: `type(scope): description` - types: feat, fix, chore, ci, docs, refactor, test. Authoritative rules: `.commitlintrc.yaml` (commit-msg hook in `.pre-commit-config.yaml`)
 - **Commit scopes**: container, helm, github-action, mise, talos, flux, deps, github-release, or app/namespace names
@@ -52,52 +48,48 @@ Home-ops GitOps infrastructure repo: Talos Linux k8s cluster managed by Flux v2.
 - **DNS annotation**: `external-dns.alpha.kubernetes.io/target: "internal.${SECRET_DOMAIN}"` or `"external.${SECRET_DOMAIN}"`
 - **Homepage annotations**: `gethomepage.dev/*` annotations on HTTPRoutes for dashboard integration
 - **Gatus monitoring**: `gatus.home-operations.com/endpoint` annotation with conditions on HTTPRoutes
-- **HelmRelease defaults**: Auto-patched by cluster-apps Kustomization — CRD CreateReplace, rollback recreate, upgrade remediation
+- **HelmRelease defaults**: Auto-patched by cluster-apps Kustomization - CRD CreateReplace, rollback recreate, upgrade remediation
 
 ## ANTI-PATTERNS (THIS PROJECT)
 
-- **NEVER** edit `talos/clusterconfig/` — generated from `talconfig.yaml`
-- **NEVER** use SOPS for application secrets — use ExternalSecret + OnePassword only
-- **NEVER** commit unencrypted secrets — pre-commit hooks catch but be vigilant
-- **NEVER** commit without pre-commit validation — `task setup-dev-env` to install hooks
-- **DO NOT** store secrets in `**/resources/**` — Renovate ignores this path
-- **DO NOT** use `*.sops.yaml` for app secrets — reserved for cluster bootstrap only
-- Secrets pattern: `**/*.sops.yaml` = SOPS encrypted; `externalsecret.yaml` = OnePassword reference
+- **NEVER** put plaintext secrets in Git. App secrets are ExternalSecret + 1Password only. Bootstrap/Talos secrets are `ref+op://Home-Lab/...` resolved by `vals`.
+- **NEVER** add a helm `postRenderer: bash` (breaks on Helm 4)
+- **NEVER** run `just bootstrap cluster` / `apps` against a healthy cluster. See `bootstrap/AGENTS.md`
+- **NEVER** commit without pre-commit file/security hooks - `task setup-dev-env` to install them
+- **DO NOT** store secrets in `**/resources/**` - Renovate ignores this path
+- There is no SOPS/age path and no `talos/clusterconfig/` or `talos/talconfig.yaml`. Do not reintroduce them.
 
 ## UNIQUE STYLES
 
 - **Flux variable substitution**: `postBuild.substituteFrom` references `cluster-secrets` Secret + inline `substitute` map
 - **Component composition**: Namespace `kustomization.yaml` includes `../../components/common` + `../../components/alerts` as components
-- **Volsync triple-backup**: Apps get 3 ReplicationSources (ceph/minio/r2) + 1 ReplicationDestination via single component include
-- **Staggered backup schedules**: 27 apps have unique cron offsets to avoid IOPS contention (see `kubernetes/components/volsync/Readme.md`)
-- **VOLSYNC_CACHE_CAPACITY**: Must be sized 20-50% of PVC size — small PVCs need 50-100%
-- **dependsOn chains**: 68 apps use `dependsOn` in ks.yaml — typically `onepassword-store` in `security` namespace
+- **Volsync triple-backup**: Apps get 3 ReplicationSources (ceph/minio/r2) + 1 ReplicationDestination via a single component include on the Flux `ks.yaml` (`../../../../components/volsync`). Defaults: Ceph every 4h, MinIO every 6h, R2 daily at 02:00. Override with `VOLSYNC_SCHEDULE_*` on `ks.yaml`. See `kubernetes/components/volsync/Readme.md`
+- **VOLSYNC_CACHE_CAPACITY**: Must be sized 20-50% of PVC size - small PVCs need 50-100%
+- **dependsOn chains**: Many apps use `dependsOn` in ks.yaml - typically `onepassword-store` in `security` namespace
 
 ## COMMANDS
 
 ```bash
-task setup-dev-env          # Install tools + pre-commit hooks
-task reconcile              # Force Flux sync from Git
-task cleanup-all            # Remove failed/completed pods + old replicasets
-task flux:test:ns NS=X      # Validate Flux manifests for namespace
-task talos:generate-config  # Regenerate Talos configs from talconfig.yaml
-task talos:apply-node IP=X  # Apply config to node
-task rook:check-disks       # Check Ceph disk status
-task bootstrap:talos        # First-time cluster bootstrap
-task bootstrap:apps         # Bootstrap applications into cluster
+task setup-dev-env                 # Install tools + pre-commit hooks
+task reconcile                     # Force Flux sync from Git
+task cleanup-all                   # Remove failed/completed pods + old replicasets
+task flux:test:ns NAMESPACE=X      # Validate Flux manifests for namespace
+task rook:check-disks              # Check Ceph disk status
+just talos render-config talos-1   # Render a node's machine config
+just talos apply-node talos-1      # Apply config (node names, not IPs)
+just bootstrap cluster             # DR / first-time only
 ```
+
+Talos nodes are `talos-1|talos-2|talos-3` mapping to `10.10.10.11/12/13`. Do not target the VIP `10.10.10.10`. Full recipes: `talos/AGENTS.md`, `bootstrap/AGENTS.md`.
 
 ## NOTES
 
-- `talos/AGENTS.md` NOTES: how `talos/*.j2` changes take effect (not via Flux) and how
-  to validate them offline in a credential-less worktree.
-- `age.key` and `kubeconfig` are gitignored — required locally but never committed
-- SOPS age key: `age13qrheg54vtg3azk0qa7ua7fnszvcc839ln8zazpdvszsfxekrf3s8jytnl`
-- SOPS encrypts only `data`/`stringData` fields in bootstrap/kubernetes, full encryption for talos
+- `talos/*.j2` changes are not applied by Flux. Render, `--dry-run`, then `just talos apply-node` per node. Offline validation without creds is documented in `talos/AGENTS.md`.
+- `kubeconfig` and `talos/talosconfig` are gitignored
+- Vals (bootstrap/Talos render) uses 1Password vault `Home-Lab`. In-cluster ESO Connect uses vaults `Homelab`, `Automation`, and `Services`
 - Cluster control plane VIP: `10.10.10.10`
 - Nodes use bonded interfaces (802.3ad LACP), MTU 9000, VLANs 3 and 90
 - Storage classes: `ceph-block` (RWO), `ceph-filesystem` (RWX), `openebs-hostpath` (local)
-- `docs/` and `specs/` are gitignored from Claude artifacts — reference only
 - `.private/` directory for local-only files (gitignored)
 - Renovate ignores `**/*.sops.*` and `**/resources/**` paths
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ This is a **home-ops** infrastructure repository managing a self-hosted Kubernet
 - **Secrets**: OnePassword + External Secrets Operator (all secrets); bootstrap minimum via `vals` + `kustomize`
 - **External Access**: Cloudflare Tunnel (cloudflared)
 - **DNS**: External-DNS with Cloudflare integration
-- **Backup**: Volsync with multiple destinations (NAS MinIO, NFS, Cloudflare R2)
+- **Backup**: Volsync with three destinations (local Ceph S3, NAS MinIO, Cloudflare R2)
 
 ## Common Commands
 
@@ -107,8 +107,8 @@ task rook:cleanup
 ### Bootstrap Operations
 
 > ⚠️ **Bootstrap is a disaster-recovery / first-time-setup operation only.** The
-> `apps`/`crds`/`resources` stages `helmfile sync` and `kubectl apply` against the
-> cluster — never run a full bootstrap against a healthy running cluster. See
+> `base` and `apps` stages `kubectl apply` / `helmfile sync` against the
+> cluster - never run a full bootstrap against a healthy running cluster. See
 > `bootstrap/AGENTS.md`.
 
 ```bash
@@ -135,20 +135,20 @@ via `bootstrap/kustomize/apps/` (kustomize + vals pipeline).
 │   ├── apps/           # Applications organized by namespace
 │   │   ├── flux-system/      # Flux controllers
 │   │   ├── kube-system/      # Core K8s components (Cilium, CoreDNS)
-│   │   ├── monitoring/       # Observability (Grafana, Prometheus, VictoriaMetrics, Loki)
+│   │   ├── monitoring/       # Observability (Grafana, Prometheus, VictoriaMetrics, Loki, Gatus)
 │   │   ├── database/         # Databases (CloudNative-PG, Dragonfly)
 │   │   ├── rook-ceph/        # Storage cluster
 │   │   ├── security/         # Security tools (Authentik, External Secrets)
-│   │   ├── network/          # Network services (Cloudflare tunnel, DNS)
+│   │   ├── network/          # Network services (Cloudflare tunnel, Unifi DNS, Envoy)
 │   │   ├── media/            # Media servers
 │   │   ├── downloads/        # Download clients
-│   │   ├── ai/               # AI applications (Ollama, Open-WebUI, etc.)
+│   │   ├── ai/               # AI apps (open-webui, vllm, toolhive, agentgateway, ...)
 │   │   └── ...
 │   ├── components/     # Reusable Kustomize components
 │   │   ├── common/           # Common secrets, repos
+│   │   ├── alerts/           # Included by every namespace kustomization
 │   │   ├── volsync/          # Backup configurations
-│   │   ├── dragonfly/        # Dragonfly monitoring
-│   │   └── gatus/            # Monitoring configs
+│   │   └── dragonfly/        # Dragonfly monitoring (includes gatus.yaml)
 │   └── flux/           # Flux-specific configurations
 │       ├── cluster/          # Cluster-wide Flux resources
 │       └── meta/             # Flux meta resources (repos, etc.)
@@ -157,7 +157,6 @@ via `bootstrap/kustomize/apps/` (kustomize + vals pipeline).
 │   ├── machineconfig.yaml.j2 # Shared machine + cluster config template
 │   ├── schematic.yaml.j2     # Factory schematic template
 │   └── mod.just              # just talos recipe module
-├── scripts/            # Automation scripts
 ├── .taskfiles/         # Task automation organized by domain
 └── .mise.toml          # Development tool versions
 ```
@@ -237,31 +236,46 @@ All secrets are managed via `ExternalSecret` resources backed by the 1Password C
 
 ### Volsync Backup Strategy
 
-Volsync provides triple-redundant backups with different schedules:
+Volsync provides triple-redundant backups with different default schedules (see `kubernetes/components/volsync/Readme.md`):
 
-1. **NAS MinIO** - Hourly (`0 * * * *`) to S3-compatible storage
-2. **NAS NFS** - Hourly (`15 * * * *`) to REST server
-3. **Cloudflare R2** - Daily (`30 0 * * *`) to cloud storage
+1. **Local Ceph S3** (`ceph/`) - every 4 hours (`0 */4 * * *`)
+2. **NAS MinIO** (`minio/`) - every 6 hours (`30 */6 * * *`)
+3. **Cloudflare R2** (`r2/`) - daily at 02:00 (`0 2 * * *`)
 
-To enable backups for an app:
+There is no NFS/REST destination. Per-app `VOLSYNC_SCHEDULE_CEPH` / `VOLSYNC_SCHEDULE_MINIO` / `VOLSYNC_SCHEDULE_R2` overrides go on the Flux `ks.yaml` `postBuild.substitute` map.
+
+To enable backups for an app, include the component on the **Flux Kustomization** (`ks.yaml`), not `app/kustomization.yaml`:
 
 ```yaml
-# In app's kustomization.yaml
-components:
-  - ../../../components/volsync
+# kubernetes/apps/{namespace}/{app}/ks.yaml
+spec:
+  components:
+    - ../../../../components/volsync
+  dependsOn:
+    - name: volsync
+      namespace: system
+  postBuild:
+    substitute:
+      APP: *app
+      VOLSYNC_CAPACITY: 10Gi
+      VOLSYNC_CACHE_CAPACITY: 5Gi
+      # optional schedule offsets:
+      # VOLSYNC_SCHEDULE_CEPH: "15 */4 * * *"
+      # VOLSYNC_SCHEDULE_MINIO: "45 */6 * * *"
+      # VOLSYNC_SCHEDULE_R2: "15 2 * * *"
 ```
 
-This creates ReplicationSource resources for automated backups and ReplicationDestination for manual restores.
+Example: `kubernetes/apps/media/immich/ks.yaml`. This creates three ReplicationSources (automated backups) and one ReplicationDestination (manual restore).
 
-**Cache sizing**: Set `VOLSYNC_CACHE_CAPACITY` to 20-50% of PVC size for optimal performance.
+**Cache sizing**: Set `VOLSYNC_CACHE_CAPACITY` to 20-50% of PVC size for optimal performance. Small PVCs need 50-100%.
 
 ### Network Architecture
 
-- **Cilium CNI**: Layer 2 announcements via BGP, LoadBalancer mode enabled
-- **Gateway API**: HTTPRoutes with `internal` (private) and `external` (public) gateways
+- **Cilium CNI**: native routing, kube-proxy replacement, BGP control plane advertising LoadBalancer IPs. L2 announcements are disabled.
+- **Gateway API**: HTTPRoutes with `envoy-internal` (private) and `envoy-external` (public) gateways in `network`
 - **Cloudflare Tunnel**: Secure ingress for public services without port forwarding
-- **External-DNS**: Automatic DNS record creation in Cloudflare
-- **Split DNS**: k8s_gateway provides internal DNS resolution
+- **External-DNS**: Public names via `network/cloudflare-dns`
+- **Split DNS**: External-DNS Unifi webhook (`network/unifi-dns`) publishes internal records to the Unifi DNS server. Public names go through `cloudflare-dns` + the external gateway.
 
 ### Storage Architecture
 
@@ -298,12 +312,7 @@ This creates ReplicationSource resources for automated backups and ReplicationDe
    - Create `ExternalSecret` resource referencing OnePassword
    - **Never store secrets in Git**
 
-4. Enable backups (optional):
-   ```yaml
-   # In app/kustomization.yaml
-   components:
-     - ../../../components/volsync
-   ```
+4. Enable backups (optional): add `spec.components: [../../../../components/volsync]`, `dependsOn: volsync` (namespace `system`), and `VOLSYNC_*` substitute keys on the Flux `ks.yaml`. See Volsync Backup Strategy above.
 
 5. Add to namespace kustomization:
    ```yaml
@@ -427,7 +436,7 @@ Review and merge Renovate PRs to keep dependencies current. Check the Dependency
 
 1. **All secrets via ExternalSecret + 1Password** - never store secrets in Git (no SOPS files, no plaintext)
 
-2. **All commits must pass pre-commit validation** - ensure commit messages follow semantic format
+2. **All commits must pass pre-commit file/security checks** - commitlint is not currently a hook
 
 3. **Flux reconciles automatically** - changes pushed to Git are applied within ~1 minute
 

--- a/README.md
+++ b/README.md
@@ -1,457 +1,84 @@
-# ⛵ Cluster Template
-
-Welcome to my template designed for deploying a single Kubernetes cluster. Whether you're setting up a cluster at home on bare-metal or virtual machines (VMs), this project aims to simplify the process and make Kubernetes more accessible. This template is inspired by my personal [home-ops](https://github.com/onedr0p/home-ops) repository, providing a practical starting point for anyone interested in managing their own Kubernetes environment.
-
-At its core, this project leverages [makejinja](https://github.com/mirkolenz/makejinja), a powerful tool for rendering templates. By reading configuration files—such as [cluster.yaml](./cluster.sample.yaml) and [nodes.yaml](./nodes.sample.yaml)—Makejinja generates the necessary configurations to deploy a Kubernetes cluster with the following features:
-
-- Easy configuration through YAML files.
-- Compatibility with home setups, whether on physical hardware or VMs.
-- A modular and extensible approach to cluster deployment and management.
-
-With this approach, you'll gain a solid foundation to build and manage your Kubernetes cluster efficiently.
-
-## ✨ Features
-
-A Kubernetes cluster deployed with [Talos Linux](https://github.com/siderolabs/talos) and an opinionated implementation of [Flux](https://github.com/fluxcd/flux2) using [GitHub](https://github.com/) as the Git provider, [1Password](https://1password.com/) + [External Secrets Operator](https://external-secrets.io/) to manage secrets and [cloudflared](https://github.com/cloudflare/cloudflared) to access applications external to your local network.
-
-- **Required:** Some knowledge of [Containers](https://opencontainers.org/), [YAML](https://noyaml.com/), [Git](https://git-scm.com/), and a **Cloudflare account** with a **domain**.
-- **Included components:** [flux](https://github.com/fluxcd/flux2), [cilium](https://github.com/cilium/cilium), [cert-manager](https://github.com/cert-manager/cert-manager), [spegel](https://github.com/spegel-org/spegel), [reloader](https://github.com/stakater/Reloader), [external-dns](https://github.com/kubernetes-sigs/external-dns) and [cloudflared](https://github.com/cloudflare/cloudflared).
-
-**Other features include:**
-
-- Dev env managed w/ [mise](https://mise.jdx.dev/)
-- Workflow automation w/ [GitHub Actions](https://github.com/features/actions)
-- Dependency automation w/ [Renovate](https://www.mend.io/renovate)
-- Flux `HelmRelease` and `Kustomization` diffs w/ [flux-local](https://github.com/allenporter/flux-local)
-
-Does this sound cool to you? If so, continue to read on! 👇
-
-## 🚀 Let's Go!
-
-There are **5 stages** outlined below for completing this project, make sure you follow the stages in order.
-
-### Stage 1: Machine Preparation
-
-> [!IMPORTANT]
-> If you have **3 or more nodes** it is recommended to make 3 of them controller nodes for a highly available control plane. This project configures **all nodes** to be able to run workloads. **Worker nodes** are therefore **optional**.
->
-> **Minimum system requirements**
-> | Role    | Cores    | Memory        | System Disk               |
-> |---------|----------|---------------|---------------------------|
-> | Control/Worker | 4 | 16GB | 256GB SSD/NVMe |
-
-1. Head over to the [Talos Linux Image Factory](https://factory.talos.dev) and follow the instructions. Be sure to only choose the **bare-minimum system extensions** as some might require additional configuration and prevent Talos from booting without it. You can always add system extensions after Talos is installed and working.
-
-2. This will eventually lead you to download a Talos Linux ISO (or for SBCs a RAW) image. Make sure to note the **schematic ID** you will need this later on.
-
-3. Flash the Talos ISO or RAW image to a USB drive and boot from it on your nodes.
-
-4. Verify with `nmap` that your nodes are available on the network. (Replace `192.168.1.0/24` with the network your nodes are on.)
-
-    ```sh
-    nmap -Pn -n -p 50000 192.168.1.0/24 -vv | grep 'Discovered'
-    ```
-
-### Stage 2: Local Workstation
-
-> [!TIP]
-> It is recommended to set the visibility of your repository to `Public` so you can easily request help if you get stuck.
-
-1. Create a new repository by clicking the green `Use this template` button at the top of this page, then clone the new repo you just created and `cd` into it. Alternatively you can us the [GitHub CLI](https://cli.github.com/) ...
-
-    ```sh
-    export REPONAME="home-ops"
-    gh repo create $REPONAME --template onedr0p/cluster-template --disable-wiki --public --clone && cd $REPONAME
-    ```
-
-2. **Install** the [Mise CLI](https://mise.jdx.dev/getting-started.html#installing-mise-cli) on your workstation.
-
-3. **Activate** Mise in your shell by following the [activation guide](https://mise.jdx.dev/getting-started.html#activate-mise).
-
-4. Use `mise` to install the **required** CLI tools:
-
-    ```sh
-    mise trust
-    pip install pipx
-    mise install
-    ```
-
-   📍 _**Having trouble installing the tools?** Try unsetting the `GITHUB_TOKEN` env var and then run these commands again_
-
-   📍 _**Having trouble compiling Python?** Try running `mise settings python.compile=0` and then run these commands again_
-
-5. Logout of GitHub Container Registry (GHCR) as this may cause authorization problems when using the public registry:
-
-    ```sh
-    docker logout ghcr.io
-    helm registry logout ghcr.io
-    ```
-
-### Stage 3: Cloudflare configuration
-
-> [!WARNING]
-> If any of the commands fail with `command not found` or `unknown command` it means `mise` is either not install or configured incorrectly.
-
-1. Create a Cloudflare API token for use with cloudflared and external-dns by reviewing the official [documentation](https://developers.cloudflare.com/fundamentals/api/get-started/create-token/) and following the instructions below.
-
-   - Click the blue `Use template` button for the `Edit zone DNS` template.
-   - Name your token `kubernetes`
-   - Under `Permissions`, click `+ Add More` and add permissions `Zone - DNS - Edit` and `Account - Cloudflare Tunnel - Read`
-   - Limit the permissions to a specific account and/or zone resources and then click `Continue to Summary` and then `Create Token`.
-   - **Save this token somewhere safe**, you will need it later on.
-
-2. Create the Cloudflare Tunnel:
-
-    ```sh
-    cloudflared tunnel login
-    cloudflared tunnel create --credentials-file cloudflare-tunnel.json kubernetes
-    ```
-
-### Stage 4: Cluster configuration
-
-1. Generate the config files from the sample files:
-
-    ```sh
-    task init
-    ```
-
-2. Fill out `cluster.yaml` and `nodes.yaml` configuration files using the comments in those file as a guide.
-
-3. Template out the kubernetes and talos configuration files, if any issues come up be sure to read the error and adjust your config files accordingly.
-
-    ```sh
-    task configure
-    ```
-
-4. Push your changes to git:
-
-    ```sh
-    git add -A
-    git commit -m "chore: initial commit :rocket:"
-    git push
-    ```
-
-> [!TIP]
-> Using a **private repository**? Make sure to paste the public key from `github-deploy.key.pub` into the deploy keys section of your GitHub repository settings. This will make sure Flux has read/write access to your repository.
-
-### Stage 5: Bootstrap Talos, Kubernetes, and Flux
-
-> [!WARNING]
-> It might take a while for the cluster to be setup (10+ minutes is normal). During which time you will see a variety of error messages like: "couldn't get current server API group list," "error: no matching resources found", etc. 'Ready' will remain "False" as no CNI is deployed yet. **This is a normal.** If this step gets interrupted, e.g. by pressing <kbd>Ctrl</kbd> + <kbd>C</kbd>, you likely will need to [reset the cluster](#-reset) before trying again
-
-1. Install Talos:
-
-    ```sh
-    task bootstrap:talos
-    ```
-
-2. Push your changes to git:
-
-    ```sh
-    git add -A
-    git commit -m "chore: add talhelper encrypted secret :lock:"
-    git push
-    ```
-
-3. Install cilium, coredns, spegel, flux and sync the cluster to the repository state:
-
-    ```sh
-    task bootstrap:apps
-    ```
-
-4. Watch the rollout of your cluster happen:
-
-    ```sh
-    kubectl get pods --all-namespaces --watch
-    ```
-
-## 📣 Post installation
-
-### ✅ Verifications
-
-1. Check the status of Cilium:
-
-    ```sh
-    cilium status
-    ```
-
-2. Check the status of Flux and if the Flux resources are up-to-date and in a ready state:
-
-   📍 _Run `task reconcile` to force Flux to sync your Git repository state_
-
-    ```sh
-    flux check
-    flux get sources git flux-system
-    flux get ks -A
-    flux get hr -A
-    ```
-
-3. Check TCP connectivity to both the internal and external gateways:
-
-   📍 _The variables are only placeholders, replace them with your actual values_
-
-    ```sh
-    nmap -Pn -n -p 443 ${cluster_gateway_addr} ${cloudflare_gateway_addr} -vv
-    ```
-
-4. Check you can resolve DNS for `echo`, this should resolve to `${cloudflare_gateway_addr}`:
-
-   📍 _The variables are only placeholders, replace them with your actual values_
-
-    ```sh
-    dig @${cluster_dns_gateway_addr} echo.${cloudflare_domain}
-    ```
-
-5. Check the status of your wildcard `Certificate`:
-
-    ```sh
-    kubectl -n kube-system describe certificates
-    ```
-
-### 🌐 Public DNS
-
-> [!TIP]
-> Use the `external` gateway on `HTTPRoutes` to make applications public to the internet.
-
-The `external-dns` application created in the `network` namespace will handle creating public DNS records. By default, `echo` and the `flux-webhook` are the only subdomains reachable from the public internet. In order to make additional applications public you must **set the correct gateway** like in the HelmRelease for `echo`.
-
-### 🏠 Home DNS
-
-> [!TIP]
-> Use the `internal` gateway on `HTTPRoutes` to make applications private to your network. If you're having trouble with internal DNS resolution check out [this](https://github.com/onedr0p/cluster-template/discussions/719) GitHub discussion.
-
-`k8s_gateway` will provide DNS resolution to external Kubernetes resources (i.e. points of entry to the cluster) from any device that uses your home DNS server. For this to work, your home DNS server must be configured to forward DNS queries for `${cloudflare_domain}` to `${cluster_dns_gateway_addr}` instead of the upstream DNS server(s) it normally uses. This is a form of **split DNS** (aka split-horizon DNS / conditional forwarding).
-
-_... Nothing working? That is expected, this is DNS after all!_
-
-### 🪝 Github Webhook
-
-By default Flux will periodically check your git repository for changes. In-order to have Flux reconcile on `git push` you must configure Github to send `push` events to Flux.
-
-1. Obtain the webhook path:
-
-   📍 _Hook id and path should look like `/hook/12ebd1e363c641dc3c2e430ecf3cee2b3c7a5ac9e1234506f6f5f3ce1230e123`_
-
-    ```sh
-    kubectl -n flux-system get receiver github-webhook --output=jsonpath='{.status.webhookPath}'
-    ```
-
-2. Piece together the full URL with the webhook path appended:
-
-    ```text
-    https://flux-webhook.${cloudflare_domain}/hook/12ebd1e363c641dc3c2e430ecf3cee2b3c7a5ac9e1234506f6f5f3ce1230e123
-    ```
-
-3. Navigate to the settings of your repository on Github, under "Settings/Webhooks" press the "Add webhook" button. Fill in the webhook URL and your token from `github-push-token.txt`, Content type: `application/json`, Events: Choose Just the push event, and save.
-
-## 💥 Reset
-
-> [!CAUTION]
-> **Resetting** the cluster **multiple times in a short period of time** could lead to being **rate limited by DockerHub or Let's Encrypt**.
-
-There might be a situation where you want to destroy your Kubernetes cluster. The following command will reset your nodes back to maintenance mode.
-
-```sh
-task talos:reset
+# home-ops
+
+GitOps repository for a 3-node Talos Linux Kubernetes cluster, continuously reconciled by Flux v2.
+
+This is a live cluster, not an upstream template. There is no Makejinja render step, no `cluster.yaml` / `nodes.yaml`, and no `task init` / `task configure` / `task bootstrap:talos` workflow. Operator commands live in the files listed below.
+
+## Stack
+
+- **OS:** Talos Linux (3 control-plane nodes, all schedulable)
+- **GitOps:** Flux v2
+- **CNI:** Cilium (native routing, kube-proxy replacement, BGP advertising LoadBalancer IPs; L2 announcements disabled)
+- **Storage:** Rook-Ceph (`ceph-block` RWO, `ceph-filesystem` RWX) plus `openebs-hostpath` for local volumes
+- **Secrets:** 1Password + External Secrets Operator. Bootstrap and Talos secrets are injected by `vals` from vault `Home-Lab`
+- **Ingress:** Gateway API (`envoy-internal` / `envoy-external` in `network`) plus Cloudflare Tunnel
+- **DNS:** External-DNS to Cloudflare (public) and the Unifi webhook (`network/unifi-dns`, internal)
+- **Backup:** Volsync to local Ceph S3, NAS MinIO, and Cloudflare R2
+
+## Operator docs
+
+| Topic | File |
+|---|---|
+| Day-to-day commands, app layout, secrets, Volsync | [`CLAUDE.md`](CLAUDE.md) |
+| Talos templates, render/apply/upgrade | [`talos/AGENTS.md`](talos/AGENTS.md) |
+| First-time / disaster-recovery bootstrap | [`bootstrap/AGENTS.md`](bootstrap/AGENTS.md) |
+| Agent-facing conventions and anti-patterns | [`AGENTS.md`](AGENTS.md) |
+| Docs index | [`docs/reference.md`](docs/reference.md) |
+
+## Layout
+
+```
+.
+├── kubernetes/
+│   ├── apps/           # Flux apps, one directory per namespace
+│   ├── components/     # Reusable Kustomize components (alerts, common, dragonfly, volsync)
+│   └── flux/           # cluster-meta / cluster-apps entry plus Helm/OCI sources
+├── talos/              # minijinja machine config, node overlays, factory schematic
+├── bootstrap/          # just bootstrap stages (nodes, k8s, base, apps)
+├── .taskfiles/         # task recipes (flux, rook, k8s, network, 1password, actions-runner)
+├── docs/               # runbooks and incident history
+└── .mise.toml          # workstation tool versions
 ```
 
-## 🛠️ Talos and Kubernetes Maintenance
+## Workstation
 
-### ⚙️ Updating Talos node configuration
+```bash
+mise trust
+mise install
+task setup-dev-env          # pre-commit hooks
+```
 
-> [!TIP]
-> Ensure you have updated `talos/machineconfig.yaml.j2`, the per-node overlay in `talos/nodes/`, or `talos/schematic.yaml.j2` with your updated configuration. In some cases you **not only need to apply the configuration but also upgrade Talos** to apply new configuration.
+1Password auth for Talos render and bootstrap is `OP_SERVICE_ACCOUNT_TOKEN` in gitignored `.secrets.env` (see `.secrets.env.example`) or an interactive `op signin`. The token must be scoped to the `Home-Lab` vault. `kubeconfig` and `talos/talosconfig` are also gitignored.
 
-```sh
-# Render a node's machine config to stdout for review (node = talos-1|talos-2|talos-3)
+## Common commands
+
+```bash
+# Flux
+task reconcile
+task flux:test:ns NAMESPACE=monitoring
+
+# Talos (node names, not IPs: talos-1|talos-2|talos-3)
 just talos render-config talos-1
-
-# Validate the rendered config
-just talos render-config talos-1 | talosctl validate -m metal -c /dev/stdin
-
-# Preview the diff before applying
 just talos apply-node talos-1 --dry-run
-
-# Apply the config to the node
 just talos apply-node talos-1
-```
-
-### ⬆️ Updating Talos and Kubernetes versions
-
-> [!TIP]
-> Ensure the installer image version in `talos/machineconfig.yaml.j2` (Renovate-managed) is up-to-date with the Talos version you wish to upgrade to before running the upgrade below.
-
-```sh
-# Upgrade Talos on a node (install image derived from the rendered config)
 just talos upgrade-node talos-1
-# e.g. just talos upgrade-node talos-1
-```
-
-```sh
-# Upgrade the Kubernetes version on the cluster
 just talos upgrade-k8s v1.36.1
-# e.g. just talos upgrade-k8s v1.36.1
+
+# Bootstrap is DR / first-time only. Never run against a healthy cluster.
+just bootstrap cluster
 ```
 
-## 🤖 Renovate
+Do not pass the control-plane VIP `10.10.10.10` as a node target. Node addresses are `10.10.10.11/12/13`. See [`talos/AGENTS.md`](talos/AGENTS.md) and [`bootstrap/AGENTS.md`](bootstrap/AGENTS.md) for the full recipes and the DR warning.
 
-[Renovate](https://www.mend.io/renovate) is a tool that automates dependency management. It is designed to scan your repository around the clock and open PRs for out-of-date dependencies it finds. Common dependencies it can discover are Helm charts, container images, GitHub Actions and more! In most cases merging a PR will cause Flux to apply the update to your cluster.
+## Adding an app
 
-To enable Renovate, click the 'Configure' button over at their [Github app page](https://github.com/apps/renovate) and select your repository. Renovate creates a "Dependency Dashboard" as an issue in your repository, giving an overview of the status of all updates. The dashboard has interactive checkboxes that let you do things like advance scheduling or reattempt update PRs you closed without merging.
+1. Create `kubernetes/apps/{namespace}/{app}/` with `ks.yaml` plus an `app/` directory.
+2. Register `./{app}/ks.yaml` in the namespace `kustomization.yaml`.
+3. Secrets go in `externalsecret.yaml` against ClusterSecretStore `onepassword`. Never commit plaintext or SOPS files.
+4. Optional backups: add `spec.components: [../../../../components/volsync]`, `dependsOn: volsync` (namespace `system`), and `VOLSYNC_*` substitute keys on the Flux `ks.yaml`. Example: `kubernetes/apps/media/immich/ks.yaml`.
 
-The base Renovate configuration in your repository can be viewed at [.renovaterc.json5](.renovaterc.json5). By default it is scheduled to be active with PRs every weekend, but you can [change the schedule to anything you want](https://docs.renovatebot.com/presets-schedule), or remove it if you want Renovate to open PRs immediately.
+Flux reconciles from Git. After a merge, `task reconcile` forces a sync.
 
-## 🐛 Debugging
+## Renovate
 
-Below is a general guide on trying to debug an issue with an resource or application. For example, if a workload/resource is not showing up or a pod has started but in a `CrashLoopBackOff` or `Pending` state. These steps do not include a way to fix the problem as the problem could be one of many different things.
-
-1. Check if the Flux resources are up-to-date and in a ready state:
-
-   📍 _Run `task reconcile` to force Flux to sync your Git repository state_
-
-    ```sh
-    flux get sources git -A
-    flux get ks -A
-    flux get hr -A
-    ```
-
-2. Do you see the pod of the workload you are debugging:
-
-    ```sh
-    kubectl -n <namespace> get pods -o wide
-    ```
-
-3. Check the logs of the pod if its there:
-
-    ```sh
-    kubectl -n <namespace> logs <pod-name> -f
-    ```
-
-4. If a resource exists try to describe it to see what problems it might have:
-
-    ```sh
-    kubectl -n <namespace> describe <resource> <name>
-    ```
-
-5. Check the namespace events:
-
-    ```sh
-    kubectl -n <namespace> get events --sort-by='.metadata.creationTimestamp'
-    ```
-
-Resolving problems that you have could take some tweaking of your YAML manifests in order to get things working, other times it could be a external factor like permissions on a NFS server. If you are unable to figure out your problem see the support sections below.
-
-## 🧹 Tidy up
-
-Once your cluster is fully configured and you no longer need to run `task configure`, it's a good idea to clean up the repository by removing the [templates](./templates) directory and any files related to the templating process. This will help eliminate unnecessary clutter from the upstream template repository and resolve any "duplicate registry" warnings from Renovate.
-
-1. Tidy up your repository:
-
-    ```sh
-    task template:tidy
-    ```
-
-2. Push your changes to git:
-
-    ```sh
-    git add -A
-    git commit -m "chore: tidy up :broom:"
-    git push
-    ```
-
-## ❔ What's next
-
-There's a lot to absorb here, especially if you're new to these tools. Take some time to familiarize yourself with the tooling and understand how all the components interconnect. Dive into the documentation of the various tools included — they are a valuable resource. This shouldn't be a production environment yet, so embrace the freedom to experiment. Move fast, break things intentionally, and challenge yourself to fix them.
-
-Below are some optional considerations you may want to explore.
-
-### DNS
-
-The template uses [k8s_gateway](https://github.com/ori-edge/k8s_gateway) to provide DNS for your applications, consider exploring [external-dns](https://github.com/kubernetes-sigs/external-dns) as an alternative.
-
-External-DNS offers broad support for various DNS providers, including but not limited to:
-
-- [Pi-hole](https://github.com/kubernetes-sigs/external-dns/blob/master/docs/tutorials/pihole.md)
-- [UniFi](https://github.com/kashalls/external-dns-unifi-webhook)
-- [Adguard Home](https://github.com/muhlba91/external-dns-provider-adguard)
-- [Bind](https://github.com/kubernetes-sigs/external-dns/blob/master/docs/tutorials/rfc2136.md)
-
-This flexibility allows you to integrate seamlessly with a range of DNS solutions to suit your environment and offload DNS from your cluster to your router, or external device.
-
-### Secrets
-
-SOPs is an excellent tool for managing secrets in a GitOps workflow. However, it can become cumbersome when rotating secrets or maintaining a single source of truth for secret items.
-
-For a more streamlined approach to those issues, consider [External Secrets](https://external-secrets.io/latest/). This tool allows you to move away from SOPs and leverage an external provider for managing your secrets. External Secrets supports a wide range of providers, from cloud-based solutions to self-hosted options.
-
-### Storage
-
-If your workloads require persistent storage with features like replication or connectivity to NFS, SMB, or iSCSI servers, there are several projects worth exploring:
-
-- [rook-ceph](https://github.com/rook/rook)
-- [longhorn](https://github.com/longhorn/longhorn)
-- [openebs](https://github.com/openebs/openebs)
-- [democratic-csi](https://github.com/democratic-csi/democratic-csi)
-- [csi-driver-nfs](https://github.com/kubernetes-csi/csi-driver-nfs)
-- [csi-driver-smb](https://github.com/kubernetes-csi/csi-driver-smb)
-- [synology-csi](https://github.com/SynologyOpenSource/synology-csi)
-
-These tools offer a variety of solutions to meet your persistent storage needs, whether you’re using cloud-native or self-hosted infrastructures.
-
-### Community Repositories
-
-Community member [@whazor](https://github.com/whazor) created [Kubesearch](https://kubesearch.dev) to allow searching Flux HelmReleases across Github and Gitlab repositories with the `kubesearch` topic.
-
-## 🙋 Support
-
-### Community
-
-- Make a post in this repository's Github [Discussions](https://github.com/onedr0p/cluster-template/discussions).
-- Start a thread in the `#support` or `#cluster-template` channels in the [Home Operations](https://discord.gg/home-operations) Discord server.
-
-### GitHub Sponsors
-
-If you're having difficulty with this project, can't find the answers you need through the community support options above, or simply want to show your appreciation while gaining deeper insights, I’m offering one-on-one paid support through GitHub Sponsors for a limited time. Payment and scheduling will be coordinated through [GitHub Sponsors](https://github.com/sponsors/onedr0p).
-
-<details>
-
-<summary>Click to expand the details</summary>
-
-<br>
-
-- **Rate**: $50/hour (no longer than 2 hours / day).
-- **What’s Included**: Assistance with deployment, debugging, or answering questions related to this project.
-- **What to Expect**:
-  1. Sessions will focus on specific questions or issues you are facing.
-  2. I will provide guidance, explanations, and actionable steps to help resolve your concerns.
-  3. Support is limited to this project and does not extend to unrelated tools or custom feature development.
-
-</details>
-
-## 🙌 Related Projects
-
-If this repo is too hot to handle or too cold to hold check out these following projects.
-
-- [ajaykumar4/cluster-template](https://github.com/ajaykumar4/cluster-template) - _A template for deploying a Talos Kubernetes cluster including Argo for GitOps_
-- [khuedoan/homelab](https://github.com/khuedoan/homelab) - _Fully automated homelab from empty disk to running services with a single command._
-- [mitchross/k3s-argocd-starter](https://github.com/mitchross/k3s-argocd-starter) - starter kit for k3s, argocd
-- [ricsanfre/pi-cluster](https://github.com/ricsanfre/pi-cluster) - _Pi Kubernetes Cluster. Homelab kubernetes cluster automated with Ansible and FluxCD_
-- [techno-tim/k3s-ansible](https://github.com/techno-tim/k3s-ansible) - _The easiest way to bootstrap a self-hosted High Availability Kubernetes cluster. A fully automated HA k3s etcd install with kube-vip, MetalLB, and more. Build. Destroy. Repeat._
-
-## ⭐ Stargazers
-
-<div align="center">
-
-<a href="https://star-history.com/#onedr0p/cluster-template&Date">
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=onedr0p/cluster-template&type=Date&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=onedr0p/cluster-template&type=Date" />
-    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=onedr0p/cluster-template&type=Date" />
-  </picture>
-</a>
-
-</div>
-
-## 🤝 Thanks
-
-Big shout out to all the contributors, sponsors and everyone else who has helped on this project.
+Renovate opens PRs for container images, Helm charts, GitHub Actions, and mise tools. Config is [`.renovaterc.json5`](.renovaterc.json5).

--- a/bootstrap/AGENTS.md
+++ b/bootstrap/AGENTS.md
@@ -63,7 +63,13 @@ duplication — Renovate bumps the OCIRepository tag and helmfile picks it up au
 Example: `cilium` in `kube-system` → reads `kubernetes/apps/kube-system/cilium/app/ocirepository.yaml`.
 
 > `grafana-operator` has no OCIRepository in `kubernetes/apps/` so its `crds.yaml`
-> entry keeps explicit `chart:` / `version:` fields.
+> entry keeps explicit `chart:` / `version:` fields. Bootstrap still extracts
+> grafana-operator CRDs (pinned in `helmfile/crds.yaml`). Several apps ship
+> `kind: GrafanaDashboard` CRs (cilium, spegel, envoy-gateway, cloudflare-tunnel,
+> cert-manager, toolhive, external-secrets), but there is no grafana-operator
+> HelmRelease or OCIRepository under `kubernetes/apps/`. Grafana itself loads
+> file-sidecar dashboards. Confirm on the live cluster whether the operator is
+> an unmanaged leftover from bootstrap or those CRs are orphaned.
 
 ## SECRETS
 
@@ -90,4 +96,6 @@ seeded post-bootstrap by ESO and must NOT be added here.
 
 - `mod.just` evaluates `controller`/`nodes` from `talosctl config info` at load, so a valid
   `TALOSCONFIG` must exist for `just -l bootstrap`.
-- The `base` stage depends on `ready` (waits for nodes to be not-Ready before proceeding).
+- The `base` stage depends on `ready`. That recipe succeeds immediately if nodes
+  are already Ready=True; otherwise it waits for Ready=False (post-bootstrap
+  not-Ready) before proceeding.

--- a/docs/flux-migration-validation-report.md
+++ b/docs/flux-migration-validation-report.md
@@ -1,5 +1,12 @@
 # Flux Migration Validation Report
 
+> **Historical snapshot as of 2026-03-29. Do not treat FAILs as open.**
+> Last git touch of this file as a live report was 2026-04-02. The three
+> FAILs (Syncthing tag pin, Immich `targetNamespace`, Immich Volsync) are
+> already fixed. Warnings about `kubernetes/components/gatus` refer to a
+> component that no longer exists (Gatus is `kubernetes/apps/monitoring/gatus`).
+> Image tags quoted below are also stale.
+
 Date: 2026-03-29
 
 ## Summary

--- a/docs/hardware-incidents.md
+++ b/docs/hardware-incidents.md
@@ -82,7 +82,7 @@ After OOMConfig patch (15:04, trigger 50%/30s): ZERO OOMController events throug
 - **cilium-agent → Guaranteed QoS** (requests == limits) — ranking weight 0.0, network plane can no longer be the OOM victim.
 - **`NotIn [talos-1]` node affinities on 7 heavy burstables** (coder, changedetection, rsshub, readarr, seerr, flaresolverr, emqx-exporter) - **RAM RMA complete 2026-08-21 (96 GB dual-channel restored on all 3 nodes).** Remaining GitOps follow-up: revert these affinities.
 - **node-exporter re-enabled + PrometheusRule alerts**: `Talos1MemoryPressure`, `NodeMemoryPSIHigh`, `CephOsdPodTerminalError`, `CephPodCrashLooping` — closes the detection gap.
-- **ceph-mon → Guaranteed QoS** (mon + logcollector requests == limits, 2Gi/500m) — mon quorum can no longer be the OOM victim. OSDs stay Burstable for now: Guaranteed would have reserved 14Gi×2 on talos-1's 48 GB single-stick window (RMA complete 2026-08-21; all 3 nodes now 96 GB). **TODO (post-RMA): promote `resources.osd` to 14Gi==14Gi Guaranteed; evaluate MDS (blocked on `mds_cache_memory_limit` 8Gi — Guaranteed at 10Gi×4 pods is unaffordable, and a tighter limit risks cgroup OOM against the cache; standby-replay makes MDS kills tolerable meanwhile).**
+- **ceph-mon → Guaranteed QoS** (mon + logcollector requests == limits, 2Gi/500m) - mon quorum can no longer be the OOM victim. OSDs stay Burstable for now: Guaranteed would have reserved 14Gi×2 on talos-1's 48 GB single-stick window (RMA complete 2026-08-21; all 3 nodes now 96 GB). **TODO (post-RMA): promote `resources.osd` to 14Gi==14Gi Guaranteed; evaluate MDS (blocked on `mds_cache_memory_limit` 8Gi - Guaranteed at 10Gi×4 pods is unaffordable, and a tighter limit risks cgroup OOM against the cache; standby-replay makes MDS kills tolerable meanwhile).**
 
 Cross-reference: [`ceph-cluster-changelog.md` [2026-07-03]](./ceph-cluster-changelog.md) for the OOMConfig change record, the min_size=1 windows, and the noout window.
 
@@ -357,18 +357,20 @@ After:  h264_qsv-true-true,   hevc_qsv-true-true,   hevc_vaapi-true-true
 
 ### Resolution
 
-Added kernel arg `i915.enable_dc=0` to `talos/schematic.yaml` (disables iGPU display controller power gating). New factory schematic ID: `ac2b7006014bfd57ed2ee6bce766bfe1d3a18f02e2a5f3a6fc4f5265c77e99ee`.
+At the time of the incident, kernel arg `i915.enable_dc=0` was added to the factory schematic (disables iGPU display controller power gating). Factory schematic ID then: `ac2b7006014bfd57ed2ee6bce766bfe1d3a18f02e2a5f3a6fc4f5265c77e99ee`.
 
-Rolled out via `task talos:upgrade-node` to all 3 nodes one at a time, waiting for Ceph to rebalance between each (kept it from going degraded). After the upgrade:
+Rolled out via Talos node upgrade to all 3 nodes one at a time, waiting for Ceph to rebalance between each (kept it from going degraded). After the upgrade:
 - talos-1 GuC reached `0xf0`, all encoders show `true-true`
-- The pre-existing slow-OSD warning on talos-3's `osd.4` cleared after that node's reboot — likely the same BlueStore PM stall pattern
-- All 3 nodes now have all known PM races disabled
+- The pre-existing slow-OSD warning on talos-3's `osd.4` cleared after that node's reboot - likely the same BlueStore PM stall pattern
+- All 3 nodes then had all known PM races disabled
 
 ```
 NVMe:  nvme_core.default_ps_max_latency_us=0    (fixed 2026-03-16)
 PCIe:  pcie_aspm=off                             (fixed 2026-03-16)
-iGPU:  i915.enable_dc=0                          (fixed 2026-04-14)
+iGPU:  i915.enable_dc=0                          (fixed 2026-04-14; superseded)
 ```
+
+**Superseded 2026-06-09** (`73c9e3da`, `feat(talos): migrate Intel GPU driver from i915 to xe`): i915 kernel args (`i915.enable_guc=3`, `i915.enable_dc=0`) and the `siderolabs/i915` extension were removed because xe handles GuC automatically. Current schematic is `talos/schematic.yaml.j2` with `siderolabs/xe`. **Do not re-add `i915.enable_dc=0`.** Node upgrades are `just talos upgrade-node talos-N`, not `task talos:upgrade-node`.
 
 ### Pattern observation
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1,1 +1,26 @@
-https://github.com/kashalls/home-cluster
+# Docs index
+
+Start with the operator files, then the topic notes under `docs/`.
+
+## Operator
+
+| File | What it covers |
+|---|---|
+| [`CLAUDE.md`](../CLAUDE.md) | Day-to-day commands, app layout, secrets, Volsync, networking |
+| [`talos/AGENTS.md`](../talos/AGENTS.md) | Talos templates, render/apply/upgrade |
+| [`bootstrap/AGENTS.md`](../bootstrap/AGENTS.md) | First-time / disaster-recovery bootstrap |
+| [`AGENTS.md`](../AGENTS.md) | Agent-facing conventions and anti-patterns |
+| [`README.md`](../README.md) | Cluster overview |
+
+## Topic notes
+
+| Path | Topic |
+|---|---|
+| [`talosctl.md`](talosctl.md) | Node IPs and a short `talosctl` pointer |
+| [`hardware-incidents.md`](hardware-incidents.md) | Hardware / Talos incident log |
+| [`ceph/`](ceph/) | Ceph OSD recovery, toolbox, backups |
+| [`networking/bgp.md`](networking/bgp.md) | Cilium BGP |
+| [`organisation-services-1password-setup.md`](organisation-services-1password-setup.md) | 1Password setup |
+| [`kubernetes/components/volsync/Readme.md`](../kubernetes/components/volsync/Readme.md) | Volsync schedules and restore |
+
+[`flux-migration-validation-report.md`](flux-migration-validation-report.md) is a historical snapshot from 2026-03-29. Do not treat its FAILs as open work.

--- a/docs/talosctl.md
+++ b/docs/talosctl.md
@@ -1,155 +1,21 @@
-get all otpions `talosctl -n 10.10.3.11 get rd`
+# talosctl
+
+Operator recipes are in [`talos/AGENTS.md`](../talos/AGENTS.md), invoked as `just talos <recipe>`.
+
+Node addresses (not the VIP):
+
+| Node | Address |
+|---|---|
+| talos-1 | `10.10.10.11` |
+| talos-2 | `10.10.10.12` |
+| talos-3 | `10.10.10.13` |
+| control-plane VIP | `10.10.10.10` (do not pass as `-n` for node apply/upgrade) |
+
+```bash
+just talos render-config talos-1
+just talos apply-node talos-1 --dry-run
+just talos apply-node talos-1
+talosctl -n 10.10.10.11 get rd
 ```
-vscode ➜ /workspaces/home-ops (main) $ talosctl -n 10.10.3.11 get rd
-NODE         NAMESPACE   TYPE                 ID                                                 VERSION   ALIASES
-10.10.3.11   meta        ResourceDefinition   acquireconfigspecs.v1alpha1.talos.dev              1         acquireconfigspec acs
-10.10.3.11   meta        ResourceDefinition   acquireconfigstatuses.v1alpha1.talos.dev           1         acquireconfigstatus acs
-10.10.3.11   meta        ResourceDefinition   addressspecs.net.talos.dev                         1         addressspec as
-10.10.3.11   meta        ResourceDefinition   addressstatuses.net.talos.dev                      1         address addresses addressstatus as
-10.10.3.11   meta        ResourceDefinition   adjtimestatuses.v1alpha1.talos.dev                 1         adjtimestatus as
-10.10.3.11   meta        ResourceDefinition   admissioncontrolconfigs.kubernetes.talos.dev       1         admissioncontrolconfig acc accs
-10.10.3.11   meta        ResourceDefinition   affiliates.cluster.talos.dev                       1         affiliate
-10.10.3.11   meta        ResourceDefinition   apicertificates.secrets.talos.dev                  1         apicertificate ac acs
-10.10.3.11   meta        ResourceDefinition   apiserverconfigs.kubernetes.talos.dev              1         apiserverconfig apisc apiscs
-10.10.3.11   meta        ResourceDefinition   auditpolicyconfigs.kubernetes.talos.dev            1         auditpolicyconfig apc apcs
-10.10.3.11   meta        ResourceDefinition   authorizationconfigs.kubernetes.talos.dev          1         authorizationconfig ac acs
-10.10.3.11   meta        ResourceDefinition   blockdevices.block.talos.dev                       1         blockdevice bd bds
-10.10.3.11   meta        ResourceDefinition   blocksymlinks.block.talos.dev                      1         blocksymlink bs
-10.10.3.11   meta        ResourceDefinition   bootstrapmanifestsconfigs.kubernetes.talos.dev     1         bootstrapmanifestsconfig bmc bmcs
-10.10.3.11   meta        ResourceDefinition   certsans.secrets.talos.dev                         1         certsan csan csans
-10.10.3.11   meta        ResourceDefinition   configstatuses.kubernetes.talos.dev                1         configstatus cs
-10.10.3.11   meta        ResourceDefinition   controllermanagerconfigs.kubernetes.talos.dev      1         controllermanagerconfig cmc cmcs
-10.10.3.11   meta        ResourceDefinition   cpustats.perf.talos.dev                            1         cpustat cpus
-10.10.3.11   meta        ResourceDefinition   deviceconfigspecs.net.talos.dev                    1         deviceconfigspec dcs
-10.10.3.11   meta        ResourceDefinition   devicesstatuses.runtime.talos.dev                  1         devicesstatus ds
-10.10.3.11   meta        ResourceDefinition   diagnostics.runtime.talos.dev                      1         diagnostic
-10.10.3.11   meta        ResourceDefinition   discoveredvolumes.block.talos.dev                  1         discoveredvolume dv dvs
-10.10.3.11   meta        ResourceDefinition   discoveryconfigs.cluster.talos.dev                 1         discoveryconfig dc dcs
-10.10.3.11   meta        ResourceDefinition   discoveryrefreshrequests.block.talos.dev           1         discoveryrefreshrequest drr drrs
-10.10.3.11   meta        ResourceDefinition   discoveryrefreshstatuses.block.talos.dev           1         discoveryrefreshstatus drs
-10.10.3.11   meta        ResourceDefinition   disks.block.talos.dev                              1         disk
-10.10.3.11   meta        ResourceDefinition   dnsresolvecaches.net.talos.dev                     1         dnsresolvecach dnsrc dnsrcs
-10.10.3.11   meta        ResourceDefinition   dnsupstreams.net.talos.dev                         1         dnsupstream dnsu dnsus
-10.10.3.11   meta        ResourceDefinition   endpoints.kubernetes.talos.dev                     1         endpoint
-10.10.3.11   meta        ResourceDefinition   etcdconfigs.etcd.talos.dev                         1         etcdconfig ec ecs
-10.10.3.11   meta        ResourceDefinition   etcdmembers.etcd.talos.dev                         1         etcdmember em ems
-10.10.3.11   meta        ResourceDefinition   etcdrootsecrets.secrets.talos.dev                  1         etcdrootsecret ers
-10.10.3.11   meta        ResourceDefinition   etcdsecrets.secrets.talos.dev                      1         etcdsecret es
-10.10.3.11   meta        ResourceDefinition   etcdspecs.etcd.talos.dev                           1         etcdspec es
-10.10.3.11   meta        ResourceDefinition   etcfilespecs.files.talos.dev                       1         etcfilespec efs
-10.10.3.11   meta        ResourceDefinition   etcfilestatuses.files.talos.dev                    1         etcfilestatus efs
-10.10.3.11   meta        ResourceDefinition   ethernetspecs.net.talos.dev                        1         ethernetspec es
-10.10.3.11   meta        ResourceDefinition   ethernetstatuses.net.talos.dev                     1         ethtool ethernetstatus es
-10.10.3.11   meta        ResourceDefinition   eventsinkconfigs.runtime.talos.dev                 1         eventsinkconfig esc escs
-10.10.3.11   meta        ResourceDefinition   extensionserviceconfigs.runtime.talos.dev          1         extensionserviceconfig esc escs
-10.10.3.11   meta        ResourceDefinition   extensionserviceconfigstatuses.runtime.talos.dev   1         extensionserviceconfigstatus escs
-10.10.3.11   meta        ResourceDefinition   extensionstatuses.runtime.talos.dev                1         extensions extensionstatus es
-10.10.3.11   meta        ResourceDefinition   extramanifestsconfigs.kubernetes.talos.dev         1         extramanifestsconfig emc emcs
-10.10.3.11   meta        ResourceDefinition   hardwareaddresses.net.talos.dev                    1         hardwareaddress ha has
-10.10.3.11   meta        ResourceDefinition   hostdnsconfigs.net.talos.dev                       1         hostdnsconfig hdnsc hdnscs
-10.10.3.11   meta        ResourceDefinition   hostnamespecs.net.talos.dev                        1         hostnamespec hs
-10.10.3.11   meta        ResourceDefinition   hostnamestatuses.net.talos.dev                     1         hostname hostnamestatus hs
-10.10.3.11   meta        ResourceDefinition   identities.cluster.talos.dev                       1         identity
-10.10.3.11   meta        ResourceDefinition   imagecacheconfigs.cri.talos.dev                    1         imagecacheconfig icc iccs
-10.10.3.11   meta        ResourceDefinition   infos.cluster.talos.dev                            1         info
-10.10.3.11   meta        ResourceDefinition   kernelmodulespecs.runtime.talos.dev                1         modules kernelmodulespec kms
-10.10.3.11   meta        ResourceDefinition   kernelparamdefaultspecs.runtime.talos.dev          1         kernelparamdefaultspec kpds
-10.10.3.11   meta        ResourceDefinition   kernelparamspecs.runtime.talos.dev                 1         kernelparamspec kps
-10.10.3.11   meta        ResourceDefinition   kernelparamstatuses.runtime.talos.dev              1         sysctls kernelparameters kernelparams kernelparamstatus kps
-10.10.3.11   meta        ResourceDefinition   kmsglogconfigs.runtime.talos.dev                   1         kmsglogconfig klc klcs
-10.10.3.11   meta        ResourceDefinition   kubeletconfigs.kubernetes.talos.dev                1         kubeletconfig kc kcs
-10.10.3.11   meta        ResourceDefinition   kubeletlifecycles.kubernetes.talos.dev             1         kubeletlifecycle kl kls
-10.10.3.11   meta        ResourceDefinition   kubeletsecrets.secrets.talos.dev                   1         kubeletsecret ks
-10.10.3.11   meta        ResourceDefinition   kubeletspecs.kubernetes.talos.dev                  1         kubeletspec ks
-10.10.3.11   meta        ResourceDefinition   kubeprismconfigs.kubernetes.talos.dev              1         kubeprismconfig kpc kpcs
-10.10.3.11   meta        ResourceDefinition   kubeprismendpoints.kubernetes.talos.dev            1         kubeprismendpoint kpe kpes
-10.10.3.11   meta        ResourceDefinition   kubeprismstatuses.kubernetes.talos.dev             1         kubeprismstatus kps
-10.10.3.11   meta        ResourceDefinition   kubernetesaccessconfigs.cluster.talos.dev          1         kubernetesaccessconfig kac kacs
-10.10.3.11   meta        ResourceDefinition   kubernetesdynamiccerts.secrets.talos.dev           1         kubernetesdynamiccert kdc kdcs
-10.10.3.11   meta        ResourceDefinition   kubernetesrootsecrets.secrets.talos.dev            1         kubernetesrootsecret krs
-10.10.3.11   meta        ResourceDefinition   kubernetessecrets.secrets.talos.dev                1         kubernetessecret ks
-10.10.3.11   meta        ResourceDefinition   kubespanconfigs.kubespan.talos.dev                 1         kubespanconfig ksc kscs
-10.10.3.11   meta        ResourceDefinition   kubespanendpoints.kubespan.talos.dev               1         kubespanendpoint kse kses
-10.10.3.11   meta        ResourceDefinition   kubespanidentities.kubespan.talos.dev              1         kubespanidentity ksi ksis
-10.10.3.11   meta        ResourceDefinition   kubespanpeerspecs.kubespan.talos.dev               1         kubespanpeerspec ksps
-10.10.3.11   meta        ResourceDefinition   kubespanpeerstatuses.kubespan.talos.dev            1         kubespanpeerstatus ksps
-10.10.3.11   meta        ResourceDefinition   linkrefreshes.net.talos.dev                        1         linkrefresh lr lrs
-10.10.3.11   meta        ResourceDefinition   linkspecs.net.talos.dev                            1         linkspec ls
-10.10.3.11   meta        ResourceDefinition   linkstatuses.net.talos.dev                         1         link links linkstatus ls
-10.10.3.11   meta        ResourceDefinition   machineconfigs.config.talos.dev                    1         machineconfig mc mcs
-10.10.3.11   meta        ResourceDefinition   machineresetsignals.runtime.talos.dev              1         machineresetsignal mrs
-10.10.3.11   meta        ResourceDefinition   machinestatuses.runtime.talos.dev                  1         machinestatus ms
-10.10.3.11   meta        ResourceDefinition   machinetypes.config.talos.dev                      1         machinetype mt mts
-10.10.3.11   meta        ResourceDefinition   maintenancerootsecrets.secrets.talos.dev           1         maintenancerootsecret mrs
-10.10.3.11   meta        ResourceDefinition   maintenanceservicecertificates.secrets.talos.dev   1         maintenanceservicecertificate msc mscs
-10.10.3.11   meta        ResourceDefinition   maintenanceserviceconfigs.runtime.talos.dev        1         maintenanceserviceconfig msc mscs
-10.10.3.11   meta        ResourceDefinition   maintenanceservicerequests.runtime.talos.dev       1         maintenanceservicerequest msr msrs
-10.10.3.11   meta        ResourceDefinition   manifests.kubernetes.talos.dev                     1         manifest
-10.10.3.11   meta        ResourceDefinition   manifeststatuses.kubernetes.talos.dev              1         manifeststatus ms
-10.10.3.11   meta        ResourceDefinition   members.cluster.talos.dev                          1         member
-10.10.3.11   meta        ResourceDefinition   memorymodules.hardware.talos.dev                   1         memorymodules ram memorymodule mm mms
-10.10.3.11   meta        ResourceDefinition   memorystats.perf.talos.dev                         1         memorystat ms
-10.10.3.11   meta        ResourceDefinition   metakeys.runtime.talos.dev                         1         meta metakey mk mks
-10.10.3.11   meta        ResourceDefinition   metaloads.runtime.talos.dev                        1         metaload ml mls
-10.10.3.11   meta        ResourceDefinition   mountrequests.block.talos.dev                      1         mountrequest mr mrs
-10.10.3.11   meta        ResourceDefinition   mountstatuses.block.talos.dev                      1         mountstatus ms
-10.10.3.11   meta        ResourceDefinition   mountstatuses.runtime.talos.dev                    1         mounts
-10.10.3.11   meta        ResourceDefinition   namespaces.meta.cosi.dev                           1         ns namespace
-10.10.3.11   meta        ResourceDefinition   networkstatuses.net.talos.dev                      1         netstatus netstatuses networkstatus ns
-10.10.3.11   meta        ResourceDefinition   nftableschains.net.talos.dev                       1         chain chains nftableschain ntc ntcs
-10.10.3.11   meta        ResourceDefinition   nodeaddresses.net.talos.dev                        1         nodeaddress na nas
-10.10.3.11   meta        ResourceDefinition   nodeaddressfilters.net.talos.dev                   1         nodeaddressfilter naf nafs
-10.10.3.11   meta        ResourceDefinition   nodeaddresssortalgorithms.net.talos.dev            1         nodeaddresssortalgorithm nasa nasas
-10.10.3.11   meta        ResourceDefinition   nodeannotationspecs.k8s.talos.dev                  1         nodeannotationspec nas
-10.10.3.11   meta        ResourceDefinition   nodecordonedspecs.k8s.talos.dev                    1         nodecordonedspec ncs
-10.10.3.11   meta        ResourceDefinition   nodeipconfigs.kubernetes.talos.dev                 1         nodeipconfig nipc nipcs
-10.10.3.11   meta        ResourceDefinition   nodeips.kubernetes.talos.dev                       1         nodeip nip nips
-10.10.3.11   meta        ResourceDefinition   nodelabelspecs.k8s.talos.dev                       1         nodelabelspec nls
-10.10.3.11   meta        ResourceDefinition   nodenames.kubernetes.talos.dev                     1         nodename
-10.10.3.11   meta        ResourceDefinition   nodestatuses.kubernetes.talos.dev                  1         nodestatus ns
-10.10.3.11   meta        ResourceDefinition   nodetaintspecs.k8s.talos.dev                       1         nodetaintspec nts
-10.10.3.11   meta        ResourceDefinition   operatorspecs.net.talos.dev                        1         operatorspec os
-10.10.3.11   meta        ResourceDefinition   osrootsecrets.secrets.talos.dev                    1         osrootsecret osrs
-10.10.3.11   meta        ResourceDefinition   pcidevices.hardware.talos.dev                      1         devices device pcidevice pcid pcids
-10.10.3.11   meta        ResourceDefinition   pcidriverrebindconfigs.runtime.talos.dev           1         pcidriverrebindconfig pcidrc pcidrcs
-10.10.3.11   meta        ResourceDefinition   pcidriverrebindstatuses.runtime.talos.dev          1         pcidriverrebinds pcidriverrebindstatus pcidrs
-10.10.3.11   meta        ResourceDefinition   pcrstatuses.hardware.talos.dev                     1         pcrstatus pcrs
-10.10.3.11   meta        ResourceDefinition   pkistatuses.etcd.talos.dev                         1         pkistatus pkis
-10.10.3.11   meta        ResourceDefinition   platformmetadatas.talos.dev                        1         platformmetadata pm pms
-10.10.3.11   meta        ResourceDefinition   probespecs.net.talos.dev                           1         probespec ps
-10.10.3.11   meta        ResourceDefinition   probestatuses.net.talos.dev                        1         probe probes probestatus ps
-10.10.3.11   meta        ResourceDefinition   processors.hardware.talos.dev                      1         cpus cpu processor
-10.10.3.11   meta        ResourceDefinition   registryconfigs.cri.talos.dev                      1         registryconfig rc rcs
-10.10.3.11   meta        ResourceDefinition   resolverspecs.net.talos.dev                        1         resolverspec rs
-10.10.3.11   meta        ResourceDefinition   resolverstatuses.net.talos.dev                     1         resolvers resolverstatus rs
-10.10.3.11   meta        ResourceDefinition   resourcedefinitions.meta.cosi.dev                  1         api-resources resourcedefinition rd rds
-10.10.3.11   meta        ResourceDefinition   routespecs.net.talos.dev                           1         routespec rs
-10.10.3.11   meta        ResourceDefinition   routestatuses.net.talos.dev                        1         route routes routestatus rs
-10.10.3.11   meta        ResourceDefinition   schedulerconfigs.kubernetes.talos.dev              1         schedulerconfig sc scs
-10.10.3.11   meta        ResourceDefinition   seccompprofiles.cri.talos.dev                      1         seccompprofile sp sps
-10.10.3.11   meta        ResourceDefinition   secretstatuses.kubernetes.talos.dev                1         secretstatus ss
-10.10.3.11   meta        ResourceDefinition   securitystates.talos.dev                           1         securitystate ss
-10.10.3.11   meta        ResourceDefinition   services.v1alpha1.talos.dev                        1         svc service
-10.10.3.11   meta        ResourceDefinition   siderolinkconfigs.siderolink.talos.dev             1         siderolinkconfig sc scs
-10.10.3.11   meta        ResourceDefinition   siderolinkstatuses.siderolink.talos.dev            1         siderolinkstatus ss
-10.10.3.11   meta        ResourceDefinition   siderolinktunnels.siderolink.talos.dev             1         siderolinktunnel st sts
-10.10.3.11   meta        ResourceDefinition   staticpods.kubernetes.talos.dev                    1         staticpod sp sps
-10.10.3.11   meta        ResourceDefinition   staticpodserverstatuses.kubernetes.talos.dev       1         staticpodserverstatus spss
-10.10.3.11   meta        ResourceDefinition   staticpodstatuses.kubernetes.talos.dev             1         podstatus staticpodstatus sps
-10.10.3.11   meta        ResourceDefinition   systemdisks.block.talos.dev                        1         systemdisk sd sds
-10.10.3.11   meta        ResourceDefinition   systeminformations.hardware.talos.dev              1         systeminformation systeminformation si sis
-10.10.3.11   meta        ResourceDefinition   timeserverspecs.net.talos.dev                      1         timeserverspec tss
-10.10.3.11   meta        ResourceDefinition   timeserverstatuses.net.talos.dev                   1         timeserver timeservers timeserverstatus tss
-10.10.3.11   meta        ResourceDefinition   timestatuses.v1alpha1.talos.dev                    1         timestatus ts
-10.10.3.11   meta        ResourceDefinition   trustdcertificates.secrets.talos.dev               1         trustdcertificate tc tcs
-10.10.3.11   meta        ResourceDefinition   uniquemachinetokens.runtime.talos.dev              1         uniquemachinetoken umt umts
-10.10.3.11   meta        ResourceDefinition   userdiskconfigstatuses.block.talos.dev             1         userdiskconfigstatus udcs
-10.10.3.11   meta        ResourceDefinition   versions.runtime.talos.dev                         1         version
-10.10.3.11   meta        ResourceDefinition   volumeconfigs.block.talos.dev                      1         volumeconfig vc vcs
-10.10.3.11   meta        ResourceDefinition   volumelifecycles.block.talos.dev                   1         volumelifecycle vl vls
-10.10.3.11   meta        ResourceDefinition   volumemountrequests.block.talos.dev                1         volumemountrequest vmr vmrs
-10.10.3.11   meta        ResourceDefinition   volumemountstatuses.block.talos.dev                1         volumemountstatus vms
-10.10.3.11   meta        ResourceDefinition   volumestatuses.block.talos.dev                     1         volumestatus vs
-10.10.3.11   meta        ResourceDefinition   watchdogtimerconfigs.runtime.talos.dev             1         watchdogtimerconfig wtc wtcs
-10.10.3.11   meta        ResourceDefinition   watchdogtimerstatuses.runtime.talos.dev            1         watchdogtimerstatus wts
-```
+
+`talosconfig` is `talos/talosconfig` (gitignored).


### PR DESCRIPTION
## Intent

Fix root/Talos documentation from the homeops-docs-audit-root-talos report (F1-F18). Fix all findings except C1 (commit-message convention - handled separately by a sibling task; do not touch .commitlintrc.yaml or .pre-commit-config.yaml).

Highest priority: F1. README.md is still the upstream cluster-template README (Makejinja, task init/task configure, cluster.yaml/nodes.yaml - none of which exist in this repo). Full rewrite as a home-ops overview pointing at CLAUDE.md / talos/AGENTS.md / bootstrap/AGENTS.md for actual operator commands. This is the single highest-value fix in the whole audit sweep - a reader following the current README cannot do anything with it.

Also fix F2 through F18 per the report: AGENTS.md Talos/bootstrap commands that don't exist, Volsync include location, CLAUDE.md schedule/destination, split-DNS mechanism, Cilium L2/BGP, the stale SOPS/talhelper description, flux test variable name, a false claim that commitlint is enforced (this one you DO fix - it's a factual claim, distinct from C1's convention-choice question), the superseded iGPU kernel arg, a dead node address in docs/talosctl.md, stale inventory counts, the directory tree and bootstrap warning in CLAUDE.md, a vault-path contradiction, the stale flux migration validation report, docs/reference.md, and one gap in bootstrap/AGENTS.md.

The report's "Files that are in good shape" section names what NOT to touch (including talos/AGENTS.md). Its "What should ship" section has the full prioritized punch list - follow it. Commit incrementally per finding group rather than one giant commit.

Deliberate choices while implementing:
- Rewrote root AGENTS.md against current HEAD as a pointer-plus-conventions file (no generator exists) instead of patching the 2026-04-09 dump in place. Dropped SOPS/age/talhelper, task talos:*, scripts/, and the gatus component.
- For F9, stopped claiming commitlint is enforced in CLAUDE.md/AGENTS.md rather than re-enabling the hook, because C1 owns the convention choice and this task must not touch .commitlintrc.yaml or .pre-commit-config.yaml.
- Replaced docs/talosctl.md with a short pointer to just talos and live node IPs rather than keeping the codespaces resource-definition dump.
- Replaced docs/reference.md with a short docs index rather than deleting it.
- Bannered docs/flux-migration-validation-report.md as a historical snapshot rather than deleting it.
- Did not take the optional punch-list item to include .taskfiles/postgres in Taskfile.yaml or drop unused SCRIPTS_DIR / makejinja; this task stays docs-only.
- Did not resolve live-cluster grafana-operator leftover vs orphaned GrafanaDashboard CRs; documented the gap in bootstrap/AGENTS.md as the report asked.
- Left AGENTS.md and CLAUDE.md as distinct real files (they serve different roles); did not convert CLAUDE.md into a symlink.
- F17 August TODOs in hardware-incidents.md were rewritten without a passed month; affinities in app HelmReleases were not reverted (ops follow-up, not this docs task).

## What Changed

- Fully rewrote `README.md` from the upstream cluster-template boilerplate (Makejinja, `task init`/`task configure`, `cluster.yaml`/`nodes.yaml`) into a home-ops overview that points readers at `CLAUDE.md`, `talos/AGENTS.md`, and `bootstrap/AGENTS.md` for real operator commands; rewrote root `AGENTS.md` as a pointer-plus-conventions file against current HEAD, dropping references to SOPS/age/talhelper, `task talos:*`, `scripts/`, and the gatus component that no longer apply.
- Corrected `CLAUDE.md` (Volsync include location, backup schedules/destinations, split-DNS mechanism, Cilium L2/BGP description, and removed the false claim that commitlint is enforced), `bootstrap/AGENTS.md` (documented the grafana-operator CRD/CR gap and clarified the `ready` stage behavior), and `.secrets.env.example` (fixed the 1Password vault name/path contradiction between vals and ESO Connect).
- Replaced `docs/talosctl.md`'s stale codespaces resource dump with a short pointer to `just talos` and live node IPs, rewrote `docs/reference.md` as a docs index instead of a dead upstream link, banner-flagged `docs/flux-migration-validation-report.md` as a historical snapshot, and fixed the superseded i915→xe iGPU kernel arg note plus stale TODO dates in `docs/hardware-incidents.md`.

## Risk Assessment

✅ Low: Docs-only change; every factual claim I spot-checked (node IPs, Cilium BGP/L2 config, Volsync schedules, taskfiles list, namespace/repo counts, GrafanaDashboard CR locations, vault names, bootstrap stage behavior) matches the actual source, and the explicit forbidden files (.commitlintrc.yaml, .pre-commit-config.yaml) are untouched.

## Testing

Since this is a docs-only change, I manually verified every concrete factual claim in the diff against the actual repository state rather than running a test suite: all referenced commands/recipes exist (`task reconcile`, `task setup-dev-env`, `task flux:test:ns`, `just talos render-config/apply-node/upgrade-node/upgrade-k8s`, `just bootstrap cluster`), all referenced files/paths exist (CLAUDE.md, talos/AGENTS.md, bootstrap/AGENTS.md, docs/reference.md, docs/networking/bgp.md, docs/ceph/, kubernetes/components/volsync/Readme.md, kubernetes/apps/media/immich/ks.yaml), node IPs 10.10.10.11/12/13 match talos/mod.just, Volsync schedules (ceph every 4h, minio every 6h, r2 daily 02:00) match the actual ReplicationSource cron defaults, Cilium config (native routing, kube-proxy replacement, BGP control plane, L2 disabled) matches the live HelmRelease, the commitlint-not-enforced claim matches the commented-out hook in .pre-commit-config.yaml, the i915-superseded-by-xe claim matches talos/schematic.yaml.j2 and commit 73c9e3da, the grafana-operator/GrafanaDashboard gap claim matches the actual app tree, namespace count (19) and flux meta repos count (12 files + kustomization.yaml) match `ls` output, and Renovate's mortyops extends match .renovaterc.json5. I also confirmed talos/AGENTS.md (named "in good shape" in the audit) was left untouched, and the forbidden .commitlintrc.yaml / .pre-commit-config.yaml files were not modified. Working tree is clean with no leftover artifacts. Every checked claim held up; no discrepancies found.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"9d7652680e33c4bc0326f8f2c1212a25715ff8ef","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `git diff --stat d72f5b5a..9d765268 (confirmed scope: README.md, AGENTS.md, CLAUDE.md, bootstrap/AGENTS.md, docs/talosctl.md, docs/reference.md, docs/flux-migration-validation-report.md, docs/hardware-incidents.md, .secrets.env.example)`
- `verified referenced files/commands exist: CLAUDE.md, talos/AGENTS.md, bootstrap/AGENTS.md, AGENTS.md, docs/reference.md, .secrets.env.example, .renovaterc.json5, kubernetes/apps/media/immich/ks.yaml`
- `grep -n reconcile/setup-dev-env/test:ns in Taskfile.yaml and .taskfiles/flux/Taskfile.yaml`
- `grep -n render-config/apply-node/upgrade-node/upgrade-k8s in talos/mod.just and cluster/nodes recipes in bootstrap/mod.just`
- `grep -rn '10.10.10.1[123]' talos/mod.just to confirm node IP mapping`
- `grep -n schedule in kubernetes/components/volsync/{ceph,minio,r2}/replicationsource.yaml`
- `grep -n bgpControlPlane/l2announcements/routingMode/kubeProxyReplacement in kubernetes/apps/kube-system/cilium/app/helmrelease.yaml`
- `grep -n commitlint in .pre-commit-config.yaml to confirm hook is commented out`
- `grep -n xe/i915 in talos/schematic.yaml.j2 and git show 73c9e3da to confirm the i915->xe migration commit`
- `grep -rl 'kind: GrafanaDashboard' kubernetes/apps/ and checked for grafana-operator HelmRelease/OCIRepository absence`
- `ls kubernetes/apps | wc -l (19 namespaces) and ls kubernetes/flux/meta/repos (12 files + kustomization.yaml)`
- `ls .github/workflows and grep extends in .renovaterc.json5`
- `git diff d72f5b5a..9d765268 -- talos/AGENTS.md .commitlintrc.yaml .pre-commit-config.yaml (confirmed empty/untouched)`
- `git status --short (confirmed clean worktree, no leftover artifacts)`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
