### PR TITLE
docs(ai): lift flash-attn/q8_0 KV prohibition on B70 after verification

### DIFF
--- a/docs/ai-gpu-changelog.md
+++ b/docs/ai-gpu-changelog.md
@@ -1,7 +1,7 @@
 # AI / B70 GPU Stack Change Log
 
 Track record of **deliberate configuration changes** to the `ai` namespace and the Intel
-Arc Pro B70 GPU it runs on — what changed, why, the evidence behind it, and how to roll it
+Arc Pro B70 GPU it runs on - what changed, why, the evidence behind it, and how to roll it
 back. Mirrors [`ceph-cluster-changelog.md`](./ceph-cluster-changelog.md) (deliberate Ceph
 changes) and [`hardware-incidents.md`](./hardware-incidents.md) (hardware failures), but for
 the GPU / LLM-serving stack. Goal: when something breaks, answer "what did we change
@@ -17,27 +17,30 @@ recently, and why?" without spelunking git.
 
 ---
 
-## Current baseline (2026-06-14)
+## Current baseline (2026-08-21)
 
 | Layer | Value |
 |-------|-------|
 | **GPU** | 1× Intel Arc Pro B70 (Battlemage G31, 32 GiB / 32656 MiB reported), on talos-3 via OCuLink |
-| **Device plugin** | `gpu.intel.com/xe: 99` shared units — a **scheduling token only, no VRAM fencing** |
-| **Co-resident** | `vllm` (chat) + `vllm-embed` + `comfyui` all share the one physical card |
+| **Device plugin** | `gpu.intel.com/xe: 99` shared units - a **scheduling token only, no VRAM fencing** |
+| **On the card** | chat (`vllm`) only. `vllm-embed` and `comfyui` are pinned `replicas: 0` |
+| **Chat image** | `ghcr.io/ggml-org/llama.cpp:server-intel-b9592` (pin is load-bearing; do not float to `server-intel`) |
+| **Chat window** | `--ctx-size 262144` (native max, no yarn), auto `n_parallel=4` + `kv_unified=true` |
+| **Chat KV / FA** | `--flash-attn on`, `--cache-type-k/-v q8_0` (accepted on this pin; see 2026-08-21) |
 
 ### Workloads on the B70
 
 | Pod | Image | Role | VRAM |
 |-----|-------|------|------|
-| `vllm` | `ghcr.io/ggml-org/llama.cpp:server-intel` | Chat — **llama.cpp SYCL**, `Qwen3.6-35B-A3B UD-Q4_K_M`. Keeps the `vllm` name so the service + gateway backend stay stable; real vLLM OOMs the MoE warmup (intel/llm-scaler#382). | ~21.4 GiB weights + KV |
-| `vllm-embed` | `intel/llm-scaler-vllm` | Embeddings — `Qwen3-VL-Embedding-2B`, `--gpu-memory-utilization 0.20` | ~6.5 GiB |
-| `comfyui` | `intel/llm-scaler-omni` | Image generation, on-demand model loads | multi-GB |
+| `vllm` | `ghcr.io/ggml-org/llama.cpp:server-intel-b9592` | Chat - **llama.cpp SYCL**, `Qwen3.6-35B-A3B UD-Q4_K_M`. Keeps the `vllm` name so the service + gateway backend stay stable; real vLLM OOMs the MoE warmup (intel/llm-scaler#382). | ~21.4 GiB weights + ~5.2 GiB KV @262k q8_0 |
+| `vllm-embed` | `intel/llm-scaler-vllm` | Embeddings - `Qwen3-VL-Embedding-2B`. **Default off** (`replicas: 0`); agentmemory moved to OpenRouter 2026-06-28. | (not resident) |
+| `comfyui` | `intel/llm-scaler-omni` | Image generation. **Default off** (`replicas: 0`). | (not resident) |
 
-### SYCL / Battlemage constraints (do **not** "optimize" into these)
+### SYCL / Battlemage constraints
 
-- ❌ **No flash attention** (`-fa`) — corrupts output on Intel Arc/Xe2 (ggml-org/llama.cpp#19276)
-- ❌ **No quantized KV cache** (`--cache-type-k/-v q8_0`) — segfaults on SYCL (it depends on FA); keep fp16
-- ✅ For heavy ComfyUI work, scale `vllm`→0 first — the card is shared with no memory fencing
+- ✅ **`--flash-attn on` + `--cache-type-k/-v q8_0`** are the live, measured baseline on `server-intel-b9592` (enabled 2026-06-17, verified 2026-08-21). The 2026-06-14 prohibition citing ggml-org/llama.cpp#19276 does **not** apply to this official SYCL build on the B70.
+- ⚠️ **Do not bump the llama.cpp tag without re-measuring.** Later SYCL FA/XMX and Q4_K MoE-reorder work landed after b9592; quality and hang reports on newer builds are a different stack (see 2026-08-21).
+- ✅ For heavy ComfyUI work, scale `vllm`→0 first - the card is shared with no memory fencing. Flux will return ComfyUI to `replicas: 0`.
 
 ---
 
@@ -49,6 +52,119 @@ When you merge an AI / GPU config change, prepend an entry (newest first):
 ## [YYYY-MM-DD] Short title  (PR #NNN)
 Change · Why · Evidence · Risk/rollback · Verify
 ```
+
+---
+
+## [2026-08-21] flash-attn + q8_0 KV accepted on `server-intel-b9592`
+
+**Change:** Docs only. Rewrote the current baseline to match live GitOps and **lifted
+the 2026-06-14 "do not enable flash-attn / q8_0 KV" prohibition.** HelmRelease args are
+unchanged (`kubernetes/apps/ai/vllm/app/helmrelease.yaml`: `--flash-attn on`,
+`--cache-type-k/-v q8_0`).
+
+**Why the 2026-06-14 prohibition was wrong for this stack:**
+- ggml-org/llama.cpp#19276 (the cited bug) was filed 2026-02-02 against the **IPEX-LLM
+  XPU container**, whose llama.cpp is a closed-source fork. intel/ipex-llm was archived
+  2026-01-28. Hardware in that report is an **Arrow Lake-H iGPU**, not this Arc Pro B70.
+  Maintainer NeoZhangJianyu: IPEX-LLM is unsupported. Closed 2026-03-14 as `not_planned`
+  (stale) - never confirmed, never fixed on official SYCL.
+- Official ggml-org SYCL already had flash-attention tile/vector kernels by 2026-04-09
+  (PR #21654 extends existing FA for head size 512). This cluster's chat server is
+  `ghcr.io/ggml-org/llama.cpp:server-intel-b9592` (published 2026-06-10), not IPEX-LLM
+  and not vLLM. Embeddings (`intel/llm-scaler-vllm`) never used these flags.
+- Same image at the prohibition (PR #982, 2026-06-14) and at enablement (`5d99d64f`,
+  2026-06-17). No llama.cpp or vLLM release in that three-day window "fixed" #19276;
+  the flags were turned on on the build the changelog had already pinned.
+
+**Evidence these flags are safe on this pin:**
+- Enabled 2026-06-17 (`5d99d64f` / `2eabcc67`) and still live 2026-08-21 - **two months**
+  of production. No home-ops issue, commit, alert, or AI-doc note of output corruption,
+  FA segfaults, or a revert of these flags. The 2026-06-26 tuning runbook
+  (`docs/ai/b70-llm-serving-tuning.md`) measured SYCL decode **~61 t/s** with
+  `q8_0/q8_0` + `--flash-attn on` and recorded **7 days, 4 slots, no SEGV**.
+- 2026-07-08 (`07fe6828`): `--ctx-size 262144` live-tested on the same flags, **0
+  restarts, 68.4 t/s decode**. q8_0 is required for that KV to fit (~5.2 GiB at 262k).
+- Completions used for those timings returned coherent `predicted_per_second` samples;
+  Hermes has used this server as the local chat backend throughout.
+
+**Not a reason to revert live config, but a reason not to float the tag:**
+- ggml-org/llama.cpp#25692 (open): FA + q8_0/q8_0 GPU hang (xe CCS engine reset) on a
+  B70 under concurrent load, on **newer master**, original host kernel 6.17.0-1028-oem.
+  Reporter could not reproduce after moving the same card to a newer xe kernel +
+  OCuLink; maintainer suspected that OEM kernel. This cluster is Talos + OCuLink on
+  b9592, and has not logged that hang.
+- ggml-org/llama.cpp#25761 (closed duplicate): Qwen3.6-35B-A3B thinking-mode gibberish
+  on a B70 in the **b9802 → b10034** window (after this pin). XMX FA (PR #25222,
+  2026-07-15) also landed after b9592.
+- ggml-org/llama.cpp#24168 (open): hybrid-model empty/gibberish on **B60** around
+  b9128-b9479. Does not match measured B70 / b9592 production.
+
+**Risk / rollback:** leave HelmRelease as-is. If a future image bump regresses quality
+or hangs, revert the tag to `server-intel-b9592` before touching FA/q8_0; those flags
+are required for 262k to fit.
+
+**Verify:** `kubectl -n ai exec deploy/vllm -c app -- sh -lc 'curl -s localhost:8000/props'`
+shows flash-attn on + q8_0 K/V; a short `/completion` returns coherent text and a
+non-zero `predicted_per_second` (see the tuning runbook reproduce block).
+
+---
+
+## [2026-07-08] vllm chat context 128k → 262144  (`07fe6828`)
+
+**Change:** `--ctx-size 131072` → `262144` in `kubernetes/apps/ai/vllm/app/helmrelease.yaml`.
+Native window, no yarn. Fits only because `vllm-embed` and `comfyui` are both `replicas: 0`.
+
+**Why:** 115 "failed to find free space in the KV cache" warnings at 131072 - four
+concurrent slots oversubscribing the shared unified pool, not one long chat.
+
+**Evidence:** live-tested on the empty card: clean load, 0 restarts, **68.4 t/s decode**.
+KV grows ~2.6 → ~5.2 GiB at q8_0. Recorded in `docs/ai/b70-llm-serving-tuning.md` §5.
+
+**Risk / rollback:** re-enabling embeddings or ComfyUI needs re-validation; step back
+toward 131072 on VRAM OOM.
+
+---
+
+## [2026-06-28] scale vllm-embed to 0  (PR #1098)
+
+**Change:** `vllm-embed` `replicas: 0`. Controller + PVC kept. agentmemory moved to
+OpenRouter embeddings (`text-embedding-3-small`).
+
+**Why:** free the B70 `gpu.intel.com/xe` slot and ~5-6.5 GiB VRAM so chat can own the
+card. Restoring local embeddings is a one-line revert (`replicas: 0` → `1`).
+
+---
+
+## [2026-06-26] B70 serving validated; ComfyUI default-off  (PR #1092)
+
+**Change:** Measured SYCL vs Vulkan and the live llama.cpp args on `server-intel-b9592`.
+Pinned ComfyUI `replicas: 0` in git. Full write-up: `docs/ai/b70-llm-serving-tuning.md`.
+
+**Evidence:** SYCL decode **~61 t/s** vs Vulkan ~36 t/s on the MoE chat model. `q8_0` KV
++ `--flash-attn on` kept (VRAM-bound, not a speed trade). Explicit `--parallel` /
+`--kv-unified` pin was tried and **reverted the next day** (PR #1093) - on b9592 the
+explicit flags overcommit KV and collapse decode to ~0.5 t/s; leave auto.
+
+**Isolation:** chat decode collapses ~38× (61 → 1.6 t/s) under an embeddings flood.
+The B70 has no hardware compute partition. Run ComfyUI only after scaling `vllm` to 0.
+
+---
+
+## [2026-06-17] enable flash-attn, q8_0 KV, cache-reuse, no-mmap  (`5d99d64f`)
+
+**Change:** in `kubernetes/apps/ai/vllm/app/helmrelease.yaml`:
+- `--flash-attn` (follow-up `2eabcc67` passes explicit `on`; the flag requires on|off|auto)
+- `--cache-type-k/-v q8_0`
+- `--cache-reuse 256`
+- `--no-mmap`
+- `UR_L0_ENABLE_RELAXED_ALLOCATION_LIMITS=1`, `SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1`
+
+**Why (commit rationale):** unlock KV quantization + better attention memory access;
+halve KV VRAM at 131k; prefix reuse for Hermes system prompts; avoid Ceph RBD
+page-fault jitter on load; Intel L0 alloc + dispatch opts.
+
+**Evidence at the time:** none recorded in this changelog (gap closed 2026-08-21).
+Subsequent production measurements are in the 2026-06-26 and 2026-08-21 entries.
 
 ---
 
@@ -72,8 +188,10 @@ Change · Why · Evidence · Risk/rollback · Verify
 `n_parallel is set to auto, using n_parallel = 4 and kv_unified = true`; warning
 `n_ctx_seq (32768) < n_ctx_train (262144)` confirmed 32k was the prior ceiling.
 
-**Deliberately NOT changed:** no `-fa`, no `q8_0` KV (both broken on SYCL — see baseline). KV is
-small enough without them.
+**Deliberately NOT changed at this commit:** no `-fa`, no `q8_0` KV. That choice was
+the 2026-06-14 belief (citing ggml-org/llama.cpp#19276). **Superseded 2026-06-17** when
+those flags were enabled on the same `server-intel-b9592` image; see 2026-08-21 for why
+#19276 does not apply here. KV at 128k was small enough without them (~2.6 GiB).
 
 **Risk / rollback:** a bigger KV pool narrows the VRAM headroom for ComfyUI + chat + embed running
 at peak together. On a VRAM OOM (`out of device memory` in the `vllm` pod, especially with ComfyUI


### PR DESCRIPTION
## Intent

Captain decision 2026-08-21: verify before deciding whether flash-attention and quantized q8_0 KV cache are safe on this Intel Arc Pro B70 GPU serving stack. Read data/homeops-docs-audit-ai-agents/report.md finding P0-2 in full.

docs/ai-gpu-changelog.md (dated 2026-06-14) said flash-attention and quantized q8_0 KV cache corrupt output / segfault on this Intel Arc/Xe2 hardware, citing upstream ggml-org/llama.cpp#19276. kubernetes/apps/ai/vllm/app/helmrelease.yaml and docs/ai/b70-llm-serving-tuning.md both have these settings enabled as of a later commit (5d99d64f, 2026-06-17), with no recorded corruption and measured ~61 t/s decode.

Verify:
1. Upstream ggml-org/llama.cpp#19276 current status - fixed, confirmed to apply to this exact build, or superseded?
2. vLLM/llama.cpp release notes between the changelog date and the enabling commit for anything indicating the corruption was fixed or never applicable to this backend/quantization combo.
3. Any evidence in this repo's own history (issues, commits, monitoring/alerting) of actual output corruption since 5d99d64f enabled these settings on 2026-06-17 - running 2+ months with no reported corruption is real evidence.

If the settings are safe: rewrite the changelog to remove the outdated prohibition, add a dated entry recording why it's now considered safe (cite the evidence). If there is real reason to doubt safety: say so plainly in a needs-decision rather than reverting live GPU serving config - that's a bigger call than this task's scope. Do not touch the HelmRelease either way without an explicit go-ahead.

Verification outcome (deliberate, already applied as docs-only): the settings are safe on the pinned image ghcr.io/ggml-org/llama.cpp:server-intel-b9592. #19276 does not apply (IPEX-LLM closed-source fork + Arrow Lake-H iGPU, closed not_planned/stale, never confirmed on official SYCL). Same image at prohibition and enablement; no llama.cpp/vLLM release in that window fixed it. Two months production with measured 61-68 t/s decode, no corruption reports. Changelog rewritten accordingly; HelmRelease left unchanged. Later-build upstream reports (#25692, #25761) are recorded as a reason not to float the image tag, not as a reason to disable current flags.

## What Changed

- Rewrote `docs/ai-gpu-changelog.md`'s "Current baseline" section to match live GitOps: chat-only on the B70 (`vllm-embed`/`comfyui` pinned `replicas: 0`), pinned image `ghcr.io/ggml-org/llama.cpp:server-intel-b9592`, `--ctx-size 262144`, and `--flash-attn on` / `--cache-type-k/-v q8_0` now listed as the live, verified baseline instead of prohibited settings.
- Added a dated `[2026-08-21]` entry documenting why the 2026-06-14 prohibition (citing ggml-org/llama.cpp#19276) does not apply to this build: #19276 was filed against the archived closed-source IPEX-LLM fork on different (Arrow Lake-H iGPU) hardware and was closed `not_planned`/stale, never confirmed on official SYCL; same `server-intel-b9592` image was in use at both the prohibition and the flag-enablement commits; two months of production (61-68 t/s decode, no restarts or corruption reports) support keeping the flags, while newer upstream reports (#25692, #25761) are recorded as a reason not to float the image tag rather than a reason to disable the current flags.
- Backfilled three previously-undocumented changelog entries (`5d99d64f` flash-attn/q8_0 enablement, `2026-06-26` B70 serving validation, `2026-06-28` vllm-embed scale-to-0) and updated the `2026-06-14` entry's "Deliberately NOT changed" note to point at the superseding 2026-06-17 change.
- Replaced remaining em dashes with plain dashes throughout the file.

No HelmRelease or other config changes are included; this is a docs-only update.

## Risk Assessment

✅ Low: Docs-only change that lifts a prior prohibition with well-sourced evidence (commit history and live upstream GitHub issue verification both corroborate every citation), leaves the HelmRelease untouched as required, and stays within the authorized scope of the user's intent.

## Testing

This is a documentation-only change (no HelmRelease/code touched) rewriting docs/ai-gpu-changelog.md to lift a prior flash-attn/q8_0-KV prohibition; there is no executable test surface, so verification consisted of cross-checking every factual claim (commit SHAs, PR numbers, image pin, absence of corruption incidents) against the repo's actual git history and incident log, all of which corroborate the changelog's claims. No findings.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"724dab8a06b69b0f8be766b486a61d532027133b","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`git diff d72f5b5a..724dab8a --stat` - confirmed only docs/ai-gpu-changelog.md changed, HelmRelease untouched</code>
- <code>`git show --stat 5d99d64f 2eabcc67 07fe6828` - confirmed cited commit SHAs and their content exist and match changelog claims</code>
- <code>`git log --oneline --all | grep -E &#39;#982|#1092|#1093|#1098&#39;` - confirmed cited PR numbers map to real commits</code>
- <code>`grep -n &#39;flash-attn|cache-type-k|cache-type-v|ctx-size|server-intel&#39; kubernetes/apps/ai/vllm/app/helmrelease.yaml` - confirmed HelmRelease still pins server-intel-b9592 with flash-attn/q8_0 as claimed, unchanged by this commit</code>
- <code>`grep -rn &#39;segfault|SEGV|corrupt&#39; docs/ai/ docs/ai-gpu-changelog.md docs/hardware-incidents.md` - confirmed no vllm/GPU-serving corruption incidents recorded since 2026-06-17 enablement</code>
- <code>`git log --oneline 5d99d64f..724dab8a -- kubernetes/apps/ai/vllm/` - confirmed no revert of flash-attn/q8_0 flags occurred since enablement</code>
- <code>`git status --porcelain` - confirmed working tree clean, no stray artifacts</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
