### PR TITLE
docs(network): rewrite BGP/Cilium docs as current-state, fix comfyui gatus check

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -271,11 +271,11 @@ Example: `kubernetes/apps/media/immich/ks.yaml`. This creates three ReplicationS
 
 ### Network Architecture
 
-- **Cilium CNI**: native routing, kube-proxy replacement, BGP control plane advertising LoadBalancer IPs. L2 announcements are disabled.
+- **Cilium CNI**: native routing, kube-proxy replacement, BGP control plane peers with UniFi for LoadBalancer IP advertisement. L2 announcements are disabled. See `docs/networking/bgp.md`.
 - **Gateway API**: HTTPRoutes with `envoy-internal` (private) and `envoy-external` (public) gateways in `network`
 - **Cloudflare Tunnel**: Secure ingress for public services without port forwarding
 - **External-DNS**: Public names via `network/cloudflare-dns`
-- **Split DNS**: External-DNS Unifi webhook (`network/unifi-dns`) publishes internal records to the Unifi DNS server. Public names go through `cloudflare-dns` + the external gateway.
+- **Split DNS**: External-DNS Unifi webhook (`network/unifi-dns`) publishes internal records to the Unifi DNS server. Public names go through `cloudflare-dns` + the external gateway. There is no `k8s-gateway` app.
 
 ### Storage Architecture
 

--- a/docs/network/cmd.md
+++ b/docs/network/cmd.md
@@ -1,4 +1,56 @@
-🌐 Networking
+# Node networking snapshot (2025-08-16)
+
+**This file is a historical capture, not current node networking.**
+
+Captured 2025-08-16 (`648600cb`) during the `10.10.3.0/24` → `10.10.10.0/24`
+cutover. The node was dual-homed (`bond0/10.10.10.11` **and**
+`enp89s0/10.10.3.11`). Interface names are pre-alias X710 ports
+(`enp2s0f0np0` / `enp2s0f1np1`) plus onboard `enp87s0` / `enp89s0`. There are
+no `bond0.3` / `bond0.90` links in this dump.
+
+Do **not** use `talosctl -n 10.10.3.11` as the default node in runbooks.
+Current node IPs are `10.10.10.11/12/13`. Current Talos API / Kubernetes node
+IP is the `bond0` address (`nodeIP.validSubnets: 10.10.10.0/24`).
+
+The `talosctl get links` / `get ethtool` / `get addresses` **verbs** are still
+valid (`docs/talosctl.md` ResourceDefinitions: `link links linkstatus`,
+`ethtool ethernetstatus`, `address addresses`). The target node and expected
+output below are not.
+
+Even as a snapshot the two 2025-08 captures disagree: `get ethtool` shows
+`enp89s0 LINK=false` while `get addresses` shows it addressed.
+
+---
+
+## Current (from Talos git, 2026-08)
+
+Live `talosctl` was **not** captured in this worktree (empty `talosconfig`).
+Expected layout from `talos/nodes/talos-1.yaml.j2` and
+`talos/machineconfig.yaml.j2`:
+
+| Link | Role |
+|------|------|
+| `net0` / `net1` | i40e ports aliased so the bond survives PCIe bus renumber (`pci=assign-busses`) |
+| `bond0` | 802.3ad LACP, MTU 9000, DHCPv4, node IP `10.10.10.11/24`, VIP `10.10.10.10` |
+| `bond0.3` | VLAN 3, no Address/DHCP on the node (Multus IoT macvlan master) |
+| `bond0.90` | VLAN 90, no Address/DHCP on the node (Multus VPN macvlan master) |
+
+NIC-name cutover: `a67806b5` (2026-06-10). Aliases `get links` and
+`get linkstatus` both work; there is no `get link status` verb.
+
+```
+talosctl -n 10.10.10.11 get links
+talosctl -n 10.10.10.11 get ethtool
+talosctl -n 10.10.10.11 get addresses
+```
+
+Expect `bond0` addressed on `10.10.10.0/24`, plus `bond0.3` and `bond0.90`
+present **without** node IPs. `enp89s0/10.10.3.11` should be gone. Confirm
+with the commands above when a `talosconfig` is available.
+
+---
+
+## Historical capture (talos-1 via `10.10.3.11`, 2025-08-16)
 
 interfaces → All network interfaces (physical + bonds + tunnels).
 
@@ -6,11 +58,9 @@ routes → Kernel routing table.
 
 endpoints → Cluster API endpoints.
 
-links / linkstatus → Link state info (you used this earlier).
+links / linkstatus → Link state info.
 
-
-
-get link status `talosctl -n 10.10.3.11 get links`
+`talosctl -n 10.10.3.11 get links`
 
 ```
 vscode ➜ /workspaces/home-ops (main) $ talosctl -n 10.10.3.11 get links
@@ -27,7 +77,6 @@ NODE         NAMESPACE   TYPE         ID            VERSION   TYPE       KIND   
 10.10.3.11   network     LinkStatus   teql0         1         void                                                                  down         false
 10.10.3.11   network     LinkStatus   tunl0         1         ipip       ipip     00:00:00:00                                       down         false
 ```
-
 
 ```
 vscode ➜ /workspaces/home-ops (main) $ talosctl -n 10.10.3.11 get ethtool

--- a/docs/network/envoy-gateway-internal-domains-analysis-2026-07.md
+++ b/docs/network/envoy-gateway-internal-domains-analysis-2026-07.md
@@ -1,5 +1,24 @@
 # Envoy Gateway Internal-Domain Reachability — 2026-07-03/04 Analysis
 
+> **Snapshot 2026-07-03/04.** Do not use this file as the source of current
+> chart versions or hostname counts. Git as of 2026-08: gateway-helm is
+> **v1.8.3** (`kubernetes/apps/network/envoy-gateway/app/ocirepository.yaml`);
+> data plane `envoyproxy/envoy:v1.39.0`. Upstream **Envoy Gateway v1.9.0**
+> exists ([announcement](https://gateway.envoyproxy.io/news/releases/v1.9/),
+> 2026-07-29). Re-evaluate Option B against v1.9 notes before acting.
+>
+> Option A (drop `GatewayNamespaceMode`) is still open - HelmRelease still has
+> `deploy.type: GatewayNamespace`.
+>
+> Split DNS in-cluster is UniFi + external-dns (`network/unifi-dns`), not
+> `k8s_gateway` (that app was deleted 2025-10-19). Hypothesis 4 below is
+> historical wording; the evidence used the UniFi resolver, which is still
+> the path.
+>
+> The 58/60 hostname matrix is a 2026-07-04 01:10–01:25 UTC probe window, not
+> a current inventory. The residual gatus table is 2026-07-04; `ai/comfyui`
+> parked-503 was still true in git at the 2026-08 audit.
+
 | Field | Value |
 |-------|-------|
 | **Reported symptom** | "Internal domains unreachable" — apps behind the `envoy-internal` Gateway (VIP 10.50.0.26) during/after the 2026-06-30 → 07-03 Ceph/OOM outage and its recovery |
@@ -64,7 +83,7 @@ Every hypothesis from the diagnosis plan, with the evidence line that decides it
 
 ## Residual failures (pre-existing, app-level — make the status page LOOK broken)
 
-Five gatus checks sat at **0.000000% 24 h uptime**, i.e. failing since *before* this incident. None are gateway faults:
+Five gatus checks sat at **0.000000% 24 h uptime**, i.e. failing since *before* this incident. None are gateway faults. **Table as of 2026-07-04** (do not treat hermes-webui / agentmemory / authentik-outpost / mcp-gateway rows as current without a live probe):
 
 | Check | Status | Actual cause | Follow-up |
 |-------|--------|--------------|-----------|

--- a/docs/networking/bgp.md
+++ b/docs/networking/bgp.md
@@ -1,2 +1,36 @@
-## Resources
+# BGP (Cilium + UniFi)
+
+Short index of **this** cluster. The Cilium objects live in
+[`kubernetes/apps/kube-system/cilium/app/networking.yaml`](../../kubernetes/apps/kube-system/cilium/app/networking.yaml).
+Operator notes and the last git copy of the UniFi snippet:
+[`kubernetes/apps/kube-system/cilium/Readme.md`](../../kubernetes/apps/kube-system/cilium/Readme.md).
+
+| Fact | Value |
+|------|-------|
+| k8s ASN | `64514` |
+| UniFi ASN | `64513` |
+| Cilium peer / UniFi BGP router-id | `10.0.0.1` |
+| Node neighbors | `10.10.10.11`, `10.10.10.12`, `10.10.10.13` |
+| LB pool | `10.50.0.0/24` |
+| L2 announcements | disabled (`l2announcements.enabled: false`) |
+| Cluster config | `CiliumBGPClusterConfig/l3-bgp-cluster-config` |
+| Peer config | `CiliumBGPPeerConfig/l3-bgp-peer-config` (`ebgpMultihop: 4`) |
+| Advertisement | `CiliumBGPAdvertisement/l3-bgp-advertisement` (Service `LoadBalancerIP`) |
+
+`10.0.0.1` (BGP peer / LAN resolver) and `10.10.10.1` (node nameserver / VLAN
+gateway) are both UniFi addresses. Docs should not collapse them.
+
+UniFi BGP is not Flux-reconciled. Git cannot prove the UDM is running the last
+checked-in snippet. A live `vtysh` `show bgp summary` closes that (C1 in the
+Cilium readme). Do not treat 2025-08 dumps of `10.10.3.11-13` / `10.10.3.0/24`
+as current.
+
+Split DNS for internal hostnames is UniFi + external-dns
+(`kubernetes/apps/network/unifi-dns`). There is no `k8s-gateway` app.
+
+Node underlay snapshot vs current Talos: [`docs/network/cmd.md`](../network/cmd.md)
+(labeled as a 2025-08 capture).
+
+## Further reading
+
 - https://sneekes.app/posts/advanced-kubernetes-networking-bgp-with-cilium-and-udm-pro/

--- a/kubernetes/apps/ai/comfyui/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/comfyui/app/helmrelease.yaml
@@ -105,7 +105,9 @@ spec:
           gatus.home-operations.com/endpoint: |-
             url: https://comfyui.${SECRET_DOMAIN}/
             conditions:
-              - "[STATUS] == 200"
+              # replicas: 0 is the default (parked). Envoy then returns 503;
+              # 200 is healthy when scaled up for an image session.
+              - "[STATUS] == any(200, 503)"
             group: ai
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"

--- a/kubernetes/apps/kube-system/cilium/Readme.md
+++ b/kubernetes/apps/kube-system/cilium/Readme.md
@@ -1,6 +1,53 @@
-## UniFi BGP
+# Cilium + UniFi BGP
 
-```sh
+Current GitOps picture. Source of truth for Cilium is
+[`app/networking.yaml`](./app/networking.yaml) plus the HelmRelease
+(`bgpControlPlane.enabled`, `l2announcements.enabled: false`, `devices: bond+`).
+Chart pin: `1.18.6` in [`app/ocirepository.yaml`](./app/ocirepository.yaml).
+
+UniFi BGP is **not** reconciled by Flux. The snippet below is the last git copy of
+`cilium/unifi/bgp.conf` (inlined here when that file was deleted on 2025-10-18).
+A live `vtysh` `show bgp summary` on the UDM is the only way to confirm the
+device is still running this config. See **C1** at the end.
+
+## Current topology
+
+| Role | Value |
+|------|-------|
+| k8s ASN | `64514` (`CiliumBGPClusterConfig/l3-bgp-cluster-config`) |
+| UniFi ASN | `64513` |
+| Cilium BGP peer / UniFi router-id | `10.0.0.1` |
+| Node neighbors (UniFi side) | `10.10.10.11`, `.12`, `.13` (`bond0` on `10.10.10.0/24`) |
+| Control-plane VIP | `10.10.10.10` on `bond0` |
+| Node nameserver / VLAN gateway | `10.10.10.1` (do **not** collapse this with `10.0.0.1`) |
+| LB pool | `10.50.0.0/24` (`CiliumLoadBalancerIPPool/pool`) |
+| Advertisement | `CiliumBGPAdvertisement/l3-bgp-advertisement` → all `LoadBalancerIP`s |
+| Peer config | `CiliumBGPPeerConfig/l3-bgp-peer-config` (`ebgpMultihop: 4`, graceful restart 15s) |
+| L2 announcements | **off** (no `CiliumL2AnnouncementPolicy`) |
+| Cilium devices | `bond+` (`bond0`, `bond0.3`, `bond0.90`) |
+
+`ebgpMultihop: 4` is required because the UniFi peer `10.0.0.1` is off-subnet
+from the node IPs on `10.10.10.0/24`. Same-VLAN peering on `10.10.3.0/24` is
+the old layout, not current Talos.
+
+Private 16-bit ASNs are `64512-65534` (RFC 6996; `65535` is reserved).
+
+### Node underlay (Talos)
+
+From `talos/nodes/talos-{1,2,3}.yaml.j2` and `talos/machineconfig.yaml.j2`:
+
+- i40e ports aliased to `net0`/`net1`, bonded as `bond0` (802.3ad, MTU 9000)
+- DHCPv4 on `bond0` only; kubelet `nodeIP.validSubnets: 10.10.10.0/24`
+- `bond0.3` (VLAN 3) and `bond0.90` (VLAN 90) exist for Multus. Nodes do **not**
+  take addresses on them. IoT macvlan gateway `10.40.0.1`; VPN macvlan gateway
+  `192.168.90.1`.
+
+Talos will not put `10.10.3.11` on a node unless some out-of-band DHCP/NIC
+still exists.
+
+## UniFi config (last git copy)
+
+```
 router bgp 64513
   bgp router-id 10.0.0.1
   no bgp ebgp-requires-policy
@@ -20,208 +67,81 @@ router bgp 64513
 exit
 ```
 
-## BGP Configuration Guide
-
-This document explains the BGP (Border Gateway Protocol) configuration for establishing peering with Kubernetes nodes.
-
-## Configuration Overview
-
-This BGP configuration establishes a peering relationship between a router (AS 64513) and Kubernetes nodes (AS 64514) for route advertisement and network connectivity.
-
-## Detailed Configuration Breakdown
-
-### Router Basic Configuration
-
-```
-router bgp 64513
-```
-- **Purpose**: Initiates BGP process and defines the local Autonomous System (AS) number
-- **AS 64513**: Private AS number (range 64512-65534) used for internal networks
-- **Effect**: Creates the BGP routing process instance
-
-```
-bgp router-id 10.10.3.1
-```
-- **Purpose**: Sets a unique identifier for this BGP router
-- **Value**: 10.10.3.1 (typically matches a loopback or stable interface IP)
-- **Importance**: Used for BGP session identification and loop prevention
-
-### BGP Policy Configuration
-
-```
-no bgp ebgp-requires-policy
-```
-- **Purpose**: Disables the requirement for explicit route policies on eBGP sessions
-- **Default Behavior**: Modern BGP implementations require explicit policies
-- **Effect**: Allows routes to be advertised/received without route-maps or prefix-lists
-- **⚠️ Security Note**: Use with caution in production environments
-
-```
-no bgp default ipv4-unicast
-```
-- **Purpose**: Disables automatic IPv4 unicast address family activation
-- **Benefit**: Provides explicit control over which address families are active
-- **Best Practice**: Prevents accidental route advertisement before proper configuration
-
-```
-no bgp network import-check
-```
-- **Purpose**: Disables route existence verification in local routing table
-- **Effect**: Allows advertising networks not present in the local RIB
-- **Use Case**: Useful for route aggregation or redistribution scenarios
-
-### Peer Group Configuration
-
-```
-neighbor k8s peer-group
-```
-- **Purpose**: Creates a template for multiple neighbors with identical configuration
-- **Benefit**: Simplifies configuration and reduces errors for similar peers
-- **Name**: "k8s" indicates these are Kubernetes node peers
-
-```
-neighbor k8s remote-as 64514
-```
-- **Purpose**: Defines the AS number of the peer group members
-- **AS 64514**: Private AS assigned to Kubernetes nodes
-- **Relationship**: eBGP (External BGP) since local AS (64513) ≠ remote AS (64514)
-
-### BGP Timers Configuration
-
-```
-neighbor k8s timers 10 30
-```
-- **Keepalive**: 10 seconds (how often keepalive messages are sent)
-- **Hold Timer**: 30 seconds (time to wait before declaring neighbor down)
-- **⚠️ Aggressive**: Default is typically 60/180 seconds
-- **Trade-off**: Faster convergence vs. increased CPU/bandwidth usage
-
-```
-neighbor k8s timers connect 30
-```
-- **Purpose**: Sets BGP connection retry timer to 30 seconds
-- **Effect**: Time to wait before attempting to re-establish a failed BGP session
-- **Default**: Usually 120 seconds
-
-### Session Configuration
-
-```
-neighbor k8s activate
-```
-- **Purpose**: Enables the BGP session for the peer group
-- **Note**: This appears to be outside address-family (legacy command)
-- **Modern Equivalent**: Should be under `address-family ipv4 unicast`
-
-```
-neighbor k8s soft-reconfiguration inbound
-```
-- **Purpose**: Stores unmodified routes received from peers
-- **Benefit**: Allows policy changes without session reset
-- **Memory Impact**: Increases memory usage but improves operational flexibility
-
-### Individual Peer Configuration
-
-```
-neighbor 10.10.3.11 peer-group k8s
-neighbor 10.10.3.12 peer-group k8s
-neighbor 10.10.3.13 peer-group k8s
-```
-- **Purpose**: Assigns specific IP addresses to the k8s peer group template
-- **IPs**: Kubernetes node addresses (10.10.3.11, 10.10.3.12, 10.10.3.13)
-- **Inheritance**: Each neighbor inherits all k8s peer-group settings
-
-### Address Family Configuration
-
-```
-address-family ipv4 unicast
-```
-- **Purpose**: Enters IPv4 unicast address family configuration mode
-- **Scope**: All subsequent commands apply only to IPv4 unicast routing
-
-```
-redistribute connected
-```
-- **Purpose**: Advertises directly connected network routes into BGP
-- **Effect**: Makes local subnets reachable from Kubernetes nodes
-- **Use Case**: Essential for pod-to-external-service connectivity
-
-```
-neighbor k8s next-hop-self
-```
-- **Purpose**: Sets this router as the next-hop for routes advertised to k8s peers
-- **Benefit**: Simplifies routing by avoiding multi-hop scenarios
-- **Requirement**: Essential when this router acts as a gateway
-
-```
-neighbor k8s activate
-```
-- **Purpose**: Activates IPv4 unicast address family for k8s peer group
-- **Requirement**: Necessary for route exchange in this address family
-
-```
-exit-address-family
-```
-- **Purpose**: Exits the IPv4 unicast address family configuration mode
-- **Effect**: Returns to global BGP configuration mode
-
-## Network Topology
+Timers, `no bgp default ipv4-unicast`, `no bgp network import-check`, and a
+global `neighbor k8s activate` were stripped from this config in `c3160f11`
+(2025-08-11). Do not re-add them from older prose.
 
 ```
 ┌─────────────────┐    eBGP     ┌─────────────────┐
-│   This Router   │◄──────────► │ Kubernetes Node │
-│   AS 64513      │             │   AS 64514      │
-│  10.10.3.1      │             │  10.10.3.11     │
+│  UniFi (UDM)    │◄──────────► │ talos-1         │
+│  AS 64513       │             │ AS 64514        │
+│  10.0.0.1       │             │ 10.10.10.11     │
 └─────────────────┘             └─────────────────┘
                                 ┌─────────────────┐
-                                │ Kubernetes Node │
-                                │   AS 64514      │
-                                │  10.10.3.12     │
-                                └─────────────────┘
-                                ┌─────────────────┐
-                                │ Kubernetes Node │
-                                │   AS 64514      │
-                                │  10.10.3.13     │
+                                │ talos-2 / .12   │
+                                │ talos-3 / .13   │
                                 └─────────────────┘
 ```
 
-## Security Considerations
+## Cilium CRs
 
-1. **Private AS Numbers**: Using private AS range (64512-65535) for internal networks
-2. **No Policy Requirement**: `no bgp ebgp-requires-policy` reduces security - consider implementing explicit policies
-3. **Aggressive Timers**: Fast convergence but increased resource usage
-4. **Route Redistribution**: `redistribute connected` exposes local networks
+All in [`app/networking.yaml`](./app/networking.yaml):
 
-## Troubleshooting Commands
+- `CiliumLoadBalancerIPPool/pool` - `10.50.0.0/24`
+- `CiliumBGPAdvertisement/l3-bgp-advertisement` - advertise Service `LoadBalancerIP`
+- `CiliumBGPPeerConfig/l3-bgp-peer-config` - peer to UniFi
+- `CiliumBGPClusterConfig/l3-bgp-cluster-config` - local ASN 64514, peer `unifi` at `10.0.0.1` ASN 64513
+- `Service/kube-api` - `lbipam.cilium.io/ips: 10.50.0.121`
 
-```bash
-# Check BGP summary
-show ip bgp summary
+### Expected advertised prefixes (from git `lbipam.cilium.io/ips`)
 
-# Verify neighbor status
-show ip bgp neighbors
+A current UniFi `show bgp ipv4 unicast` should list `/32`s in `10.50.0.0/24`
+with nexthops `10.10.10.11-13`, not the old `10.10.3.0/24` pool. More than five
+prefixes.
 
-# Check received routes
-show ip bgp neighbors 10.10.3.11 received-routes
+| IP | Service |
+|----|---------|
+| `10.50.0.21` | envoy-external |
+| `10.50.0.26` | envoy-internal |
+| `10.50.0.27` / `.28` / `.29` | agentgateway (internal / internal-noauth / public) |
+| `10.50.0.30` | emqx |
+| `10.50.0.50` / `.52` / `.54` | jellyfin / plex / tdarr |
+| `10.50.0.51` | syncthing |
+| `10.50.0.121` | kube-api |
 
-# Verify advertised routes
-show ip bgp neighbors 10.10.3.11 advertised-routes
+## Verify on UniFi (FRR / vtysh)
 
-# Check BGP table
-show ip bgp
+Enable SSH on the UniFi controller, connect, then `vtysh`. Use FRR commands
+(not Cisco `show ip bgp ...`):
+
+```
+show bgp summary
+show bgp ipv4 unicast
+show bgp neighbors 10.10.10.11
 ```
 
-## Best Practices
+Expect three neighbors `10.10.10.11-13` in AS 64514, router identifier
+`10.0.0.1`, local AS 64513, and `10.50.0.x/32` prefixes as above.
 
-1. **Implement Route Filtering**: Use prefix-lists or route-maps for security
-2. **Monitor BGP Sessions**: Set up alerts for session state changes
-3. **Document Changes**: Maintain configuration change logs
-4. **Test Failover**: Verify behavior when individual peers fail
-5. **Review Timers**: Consider less aggressive timers for production stability
+## C1 - live UniFi vs git (open)
 
-## BGP Verification
-### Unifi Side
-Enable ssh in the unifi controller and connect to it. run `vtysh` i order to open the frr terminal.
-Run `show bgp summary`
+Git cannot prove the UDM is running the snippet above. This worktree can ping
+`10.0.0.1` and `10.10.10.11` but has no UniFi SSH credentials and no
+`talosconfig`, so the live session was not captured.
+
+- **Side A (git, likely current operator intent):** router-id `10.0.0.1`,
+  neighbors `10.10.10.11-13`, AS 64513↔64514, pool `10.50.0.0/24`.
+- **Side B (older captures in this file's history):** neighbors `10.10.3.11-13`,
+  advertised `10.10.3.2-7/32`. Predates the 2025-08-16 subnet cutover
+  (`ade7b639`). Do not assume Side B is live.
+
+## Historical capture (~2025-08, pre-`10.50.0.0/24` pool)
+
+Neighbors `10.10.3.11-13` and five `/32`s in `10.10.3.0/24`. Kept only as a
+dated dump. Not current.
+
+`show bgp summary` (UniFi, FRR):
+
 ```
 IPv4 Unicast Summary:
 BGP router identifier 10.0.0.1, local AS number 64513 VRF default vrf-id 0
@@ -238,8 +158,7 @@ Neighbor        V         AS   MsgRcvd   MsgSent   TblVer  InQ OutQ  Up/Down Sta
 Total number of neighbors 3
 ```
 
-In order to the unicast you can use
-`show bgp ipv4 unicast`
+`show bgp ipv4 unicast` from the same session:
 
 ```
 BGP table version is 25, local router ID is 10.0.0.1, vrf id 0


### PR DESCRIPTION
## Intent

Fix networking documentation. Read data/homeops-docs-audit-networking/report.md in full first, specifically its "What should ship" section.

1. Rewrite the Cilium doc to a single current UniFi+Cilium picture, keeping at most one dated historical config dump clearly labeled as historical.
2. Relabel docs/network/cmd.md as a 2025-08 snapshot rather than current state.
3. Replace the docs/networking/bgp.md stub with a short current index.
4. Add a snapshot-date banner to the 2026-07 Envoy Gateway internal-domains analysis doc, noting the current chart version and that a v1.9 exists.
5. The small ComfyUI gatus health-check fix the report flags (a check expecting 200 on a 0-replica deployment) - fix if it's a trivial config change; if it touches live monitoring behavior in a way that needs a call, flag it rather than guessing.

Do NOT attempt to resolve C1 (the live UniFi BGP config discrepancy) or the optional live-verification items (vtysh show bgp summary, talosctl address checks) - the report is explicit these need live device/cluster access this task may or may not have. If those systems can be reached safely and read-only, do the verification and note the result; otherwise leave C1 flagged exactly as the report left it.

Implementation notes (deliberate, not accidents): Cilium Readme is the current GitOps picture (peer 10.0.0.1, neighbors 10.10.10.11-13, pool 10.50.0.0/24, ebgpMultihop 4, L2 off, FRR/vtysh only); one ~2025-08 dump kept and labeled historical. cmd.md keeps the 2025-08 dual-homed capture and adds current expected layout from Talos templates rather than a fabricated live dump (talosconfig empty). UniFi 10.0.0.1 and talos-1 10.10.10.11 ping but UniFi SSH and talosctl were unavailable, so C1 stays open. ComfyUI gatus uses [STATUS] == any(200, 503) so parked replicas:0 (Envoy 503) is not a failure and 200 still counts when scaled up; treated as the analysis-recommended trivial config change. Envoy incident narrative was not rewritten; banner only. Option A (drop GatewayNamespaceMode) remains documented as open, not implemented. Do not merge docs/network/ and docs/networking/.

## What Changed

- Rewrote `kubernetes/apps/kube-system/cilium/Readme.md` to a single current UniFi+Cilium BGP picture (peer `10.0.0.1`, node neighbors `10.10.10.11-13`, LB pool `10.50.0.0/24`, `ebgpMultihop: 4`, L2 announcements off, FRR/vtysh-only), keeping one ~2025-08 config dump clearly labeled historical.
- Replaced the `docs/networking/bgp.md` stub with a short current index (BGP facts table, links to the live Cilium config and Readme, note that UniFi BGP is not Flux-reconciled and C1 remains open).
- Relabeled `docs/network/cmd.md` as a 2025-08 snapshot and added the current expected node network layout derived from the Talos templates.
- Added a snapshot-date banner to `docs/network/envoy-gateway-internal-domains-analysis-2026-07.md` noting the current chart version and that a v1.9 release exists.
- Updated `CLAUDE.md`'s Network Architecture section to match the corrected BGP/split-DNS facts (no k8s_gateway, UniFi + External-DNS for split DNS).
- Fixed the ComfyUI gatus health check (`kubernetes/apps/ai/comfyui/app/helmrelease.yaml`) to accept `200` or `503`, since the deployment is parked at `replicas: 0` by default and Envoy returns 503 in that state.

## Risk Assessment

✅ Low: Pure documentation rewrite plus a one-line gatus condition change to an already-established `any(a, b)` pattern used elsewhere in the repo; every factual claim in the new docs (commit SHAs, chart versions, CR/field names, IP addresses) was verified against actual repo state and matches, and all required intent constraints (single current Cilium picture with one labeled historical dump, cmd.md relabeled as 2025-08 snapshot, bgp.md replaced with a short index, envoy doc banner with chart version and v1.9 note, comfyui trivial config fix, C1 left open, docs/network and docs/networking kept separate) are satisfied with no contradictions.

## Testing

All five commits were reviewed diff-by-diff against the user intent and cross-verified for factual accuracy against the live Kubernetes manifests and Talos templates they reference; every claim (chart versions, ASNs, BGP peer/pool addresses, ebgpMultihop, L2 announcement state, comfyui replicas:0) checked out, the ComfyUI gatus `any(200, 503)` condition matches an established repo-wide pattern and was confirmed to parse correctly as both outer and embedded YAML, C1 and the Option A/GatewayNamespaceMode item were correctly left open rather than resolved, and docs/network vs docs/networking remained unmerged. No test or config issues found.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"1d8aed634ffbca4d39eff644bf9494cc9a17a431","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`git diff d72f5b5a..9b19f81e -- kubernetes/apps/kube-system/cilium/Readme.md` reviewed against the &#39;single current picture + one labeled historical dump + C1 left open&#39; requirement</code>
- <code>`git diff ... -- docs/network/cmd.md` reviewed for 2025-08 relabeling plus added current-expected-layout section sourced from Talos templates (no fabricated live dump)</code>
- <code>`git diff ... -- docs/networking/bgp.md` reviewed for stub replacement with a short current index, cross-linking cilium Readme and cmd.md, C1 preserved</code>
- <code>`git diff ... -- docs/network/envoy-gateway-internal-domains-analysis-2026-07.md` reviewed for the snapshot-date banner noting current chart version (v1.8.3) and v1.9 existence, Option A left open</code>
- <code>`git diff ... -- kubernetes/apps/ai/comfyui/app/helmrelease.yaml` reviewed for the gatus condition change</code>
- `python3 yaml.safe_load_all on kubernetes/apps/ai/comfyui/app/helmrelease.yaml to confirm the manifest still parses as valid YAML after the edit`
- `python3 yaml.safe_load on the extracted gatus.home-operations.com/endpoint annotation string to confirm the embedded gatus config parses to conditions: ['[STATUS] == any(200, 503)']`
- <code>`grep -rn &#34;STATUS\] == any(&#34; kubernetes/` to confirm the any(200, 503) gatus syntax matches an established pattern already used by linkwarden, home-assistant, and hermes in this repo</code>
- `Cross-checked docs' factual claims (cilium chart tag 1.18.6, envoy-gateway chart tag v1.8.3, localASN 64514/peerASN 64513, peerAddress 10.0.0.1, LB pool cidr 10.50.0.0/24, ebgpMultihop 4, l2announcements.enabled false, comfyui replicas: 0) directly against kubernetes/apps/kube-system/cilium/app/networking.yaml, helmrelease.yaml, ocirepository.yaml, and kubernetes/apps/network/envoy-gateway/app/ocirepository.yaml`
- `Verified every file path referenced by the new docs exists in the repo (networking.yaml, ocirepository.yaml, talos node/machineconfig templates, unifi-dns app, docs/talosctl.md)`
- <code>`ls docs/network docs/networking` to confirm the two directories were not merged, per the explicit constraint</code>
- <code>`git status` before and after to confirm no stray artifacts were left in the worktree</code>

</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `.taskfiles/network/README.md` - Older 10.10.3.x subnet references remain in .taskfiles/network/README.md, .taskfiles/rook/README.md, and docs/talosctl.md (pre-2025-08 cutover addresses/captures), unrelated to this change&#39;s scope but part of the same class of staleness this pass addressed for docs/network/cmd.md and the Cilium readme. Worth a dedicated follow-up pass to snapshot-label or update these runbooks.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
