### PR TITLE
docs(ceph): rewrite storage recovery docs against live backup system and version baselines

### DIFF
--- a/.taskfiles/rook/templates/WipeDiskJob.tmpl.yaml
+++ b/.taskfiles/rook/templates/WipeDiskJob.tmpl.yaml
@@ -20,7 +20,8 @@ spec:
       hostNetwork: true
       containers:
         - name: main
-          image: quay.io/ceph/ceph:v19.2.3
+          # Pin to the same cephImage.tag as cluster/helmrelease.yaml (Tentacle).
+          image: quay.io/ceph/ceph:v20.2.3
           command: ["/bin/bash", "-c"]
           args:
             - |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,7 +63,7 @@ Gatus is an app under `kubernetes/apps/monitoring/gatus`, not a component. Endpo
 
 - **Flux variable substitution**: `postBuild.substituteFrom` references `cluster-secrets` Secret + inline `substitute` map
 - **Component composition**: Namespace `kustomization.yaml` includes `../../components/common` + `../../components/alerts` as components
-- **Volsync triple-backup**: Apps get 3 ReplicationSources (ceph/minio/r2) + 1 ReplicationDestination via a single component include on the Flux `ks.yaml` (`../../../../components/volsync`). Defaults: Ceph every 4h, MinIO every 6h, R2 daily at 02:00. Override with `VOLSYNC_SCHEDULE_*` on `ks.yaml`. See `kubernetes/components/volsync/Readme.md`
+- **Volsync triple-backup**: Apps get 3 ReplicationSources (ceph/minio/r2) + 1 ReplicationDestination via a single component include on the Flux `ks.yaml` (`../../../../components/volsync`). Defaults: Ceph every 4h, MinIO every 6h, R2 daily at 02:00. Per-app cron offsets live on `ks.yaml` `VOLSYNC_SCHEDULE_*` (not unique across every app). Live app list and retain settings: `kubernetes/components/volsync/Readme.md`
 - **VOLSYNC_CACHE_CAPACITY**: Must be sized 20-50% of PVC size - small PVCs need 50-100%
 - **dependsOn chains**: Many apps use `dependsOn` in ks.yaml - typically `onepassword-store` in `security` namespace
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,6 +92,7 @@ Talos nodes are `talos-1|talos-2|talos-3` mapping to `10.10.10.11/12/13`. Do not
 - Storage classes: `ceph-block` (RWO), `ceph-filesystem` (RWX), `openebs-hostpath` (local)
 - `.private/` directory for local-only files (gitignored)
 - Renovate ignores `**/*.sops.*` and `**/resources/**` paths
+- Ceph metadata CronJob (`rook-ceph-backup` / `ceph-backup-pvc`) is in-cluster `openebs-hostpath`, **not** last-resort DR; complete cluster/host wipe destroys it. Emergency steps: `kubernetes/apps/rook-ceph/rook-ceph/backup/RECOVERY-PROCEDURES.md`. Never restart all OSDs; see `docs/ceph/osd-device-path-recovery.md`.
 
 ## Maintaining this file
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ This is a **home-ops** infrastructure repository managing a self-hosted Kubernet
 - **Secrets**: OnePassword + External Secrets Operator (all secrets); bootstrap minimum via `vals` + `kustomize`
 - **External Access**: Cloudflare Tunnel (cloudflared)
 - **DNS**: External-DNS with Cloudflare integration
-- **Backup**: Volsync with three destinations (local Ceph S3, NAS MinIO, Cloudflare R2)
+- **Backup**: VolSync with three destinations (local Ceph S3, NAS MinIO, Cloudflare R2; no NFS)
 
 ## Common Commands
 
@@ -236,7 +236,7 @@ All secrets are managed via `ExternalSecret` resources backed by the 1Password C
 
 ### Volsync Backup Strategy
 
-Volsync provides triple-redundant backups with different default schedules (see `kubernetes/components/volsync/Readme.md`):
+VolSync provides triple-redundant backups. Authoritative schedules, retention, and the app list live in `kubernetes/components/volsync/Readme.md` and the three `replicationsource.yaml` files (`ceph/`, `minio/`, `r2/`). Component defaults:
 
 1. **Local Ceph S3** (`ceph/`) - every 4 hours (`0 */4 * * *`)
 2. **NAS MinIO** (`minio/`) - every 6 hours (`30 */6 * * *`)

--- a/docs/ceph-cluster-changelog.md
+++ b/docs/ceph-cluster-changelog.md
@@ -17,14 +17,14 @@ rather than hardware failures. The goal is that when something breaks we can ans
 
 ---
 
-## Current baseline (2026-06-14)
+## Current baseline (2026-08-16, GitOps)
 
 | Layer | Value |
 |-------|-------|
-| **Rook** | v1.20.0 (operator + cluster chart) — latest upstream, released 2026-06-02 |
+| **Rook** | v1.20.4 (operator + cluster chart tags in `operator/ocirepository.yaml` and `cluster/ocirepository.yaml`) |
 | **Ceph** | v20.2.3 **Tentacle** (GitOps `cephImage.tag` + all 17 daemons, verified 2026-08-21). Default `csi` subvolumegroup still broken; RWX stays on `ceph-filesystem-rwx` (see 2026-08-21 entry) |
 | **Talos** | v1.13.2 (kernel has `CONFIG_CEPH_FS=y`, `CONFIG_BLK_DEV_RBD=y`, `CONFIG_CEPH_LIB=y` — CephFS + krbd **built-in**) |
-| **Kubernetes** | v1.36.1 |
+| **Kubernetes** | GitOps pins disagree: `talos/machineconfig.yaml.j2` kubelet/apiserver images **v1.36.1**; tuppr `KubernetesUpgrade` **v1.36.3**. Changelog does not claim a running version without live `kubectl version`. |
 | **Cluster FSID** | `6562d9b0-883a-4e55-8b5d-899eaa7e0d10` |
 | **Topology** | 3 nodes (talos-1/2/3), 6 OSDs, all NVMe, `failureDomain: host`, size=3 |
 | **Network** | `provider: host`, `requireMsgr2: true`, no dedicated cluster/replication network |
@@ -134,6 +134,55 @@ ceph fs subvolume rm ceph-filesystem fm-verify-csi-1787308879 --group-name csi-r
 
 **Retirement rule:** image tag is not sufficient. Re-test with a throwaway `create`/`getpath`/`rm` against group `csi` on a future Ceph release; only migrate the 3 RWX PVCs after that probe is clean. Prefer a name you can leave behind if `create` EINVAL-leaks another empty dir.
 
+### [2026-08-16] Rook v1.20.3 → v1.20.4  (PR #1316)
+
+| Field | Value |
+|-------|-------|
+| **Change** | operator + cluster OCI tags `v1.20.4` |
+| **Why** | Renovate chart bump |
+| **Risk** | Operator/CSI roll; OSD updates stay serial (`storage.osdMaxUpdatesInParallel: 1`) |
+| **Rollback** | pin both `ocirepository.yaml` tags back to v1.20.3 |
+| **Verify** | `kubectl -n rook-ceph get ocirepository rook-ceph rook-ceph-cluster -o jsonpath='{.items[*].spec.ref.tag}'` |
+
+Keep `operator/csi-driver-rbac.yaml` (Rook #17644). v1.20.4 still does not ship CSI driver ServiceAccounts in the operator chart; removing that file breaks RBD/CephFS attach. See the 2026-06-12 Rook v1.20.0 entry.
+
+### [2026-08-11] Ceph v20.2.2 → v20.2.3  (PR #1293)
+
+| Field | Value |
+|-------|-------|
+| **Change** | `cephImage.tag: v20.2.3` |
+| **Why** | Tentacle point release |
+| **Risk** | OSD image roll (serial). Does **not** retire the `csi-rwx` workaround; that needs a live `ceph fs subvolume create/getpath` against group `csi` first. |
+| **Rollback** | pin `cephImage.tag` back to v20.2.2 |
+| **Verify** | `kubectl -n rook-ceph get cephcluster -o jsonpath='{.items[0].spec.cephVersion.image}'` |
+
+### [2026-08-06] Rook v1.20.2 → v1.20.3  (PR #1269)
+
+| Field | Value |
+|-------|-------|
+| **Change** | operator + cluster OCI tags `v1.20.3` |
+| **Why** | Renovate chart bump |
+| **Rollback** | pin both tags back to v1.20.2 |
+| **Verify** | OCIRepository tags `v1.20.3` |
+
+### [2026-07-14] Rook v1.20.1 → v1.20.2  (PR #1159)
+
+| Field | Value |
+|-------|-------|
+| **Change** | operator + cluster OCI tags `v1.20.2` |
+| **Why** | Renovate chart bump |
+| **Rollback** | pin both tags back to v1.20.1 |
+| **Verify** | OCIRepository tags `v1.20.2` |
+
+### [2026-07-03] Mon + logcollector Guaranteed QoS  (commit `e27686d0`)
+
+| Field | Value |
+|-------|-------|
+| **Change** | Mon and logcollector pods set to Guaranteed QoS so Talos OOMController does not pick quorum members as victims. |
+| **Why** | Companion to the 2026-07-03 OOM-outage recovery (same day). |
+| **Rollback** | revert the QoS block in `cluster/helmrelease.yaml` |
+| **Verify** | mon / logcollector pods show request==limit, QoS Class `Guaranteed` |
+
 ### [2026-07-03] OOM-outage recovery: Talos OOMConfig retuned (live + codified), transient `min_size=1` windows, noout window  (operational + `talos/machineconfig.yaml.j2`)
 
 | Field | Value |
@@ -146,6 +195,26 @@ ceph fs subvolume rm ceph-filesystem fm-verify-csi-1787308879 --group-name csi-r
 
 Companion durable fixes shipped with the recovery (GitOps): cilium-agent → **Guaranteed QoS** (OOM ranking weight 0.0), `NotIn [talos-1]` affinities on 7 heavy burstables (TODO 2026-08: revert after the talos-1 RAM RMA), node-exporter re-enabled + PrometheusRule alerts (`Talos1MemoryPressure`, `NodeMemoryPSIHigh`, `CephOsdPodTerminalError`, `CephPodCrashLooping`). Ruled out during root-cause: MGLRU (verified `0x0000` on all nodes), rook#17224 path drift (all OSDs re-activated cleanly after full reboots), store corruption/bad hardware (zero signatures through ~6 kill cycles).
 
+### [2026-06-22] Ceph v20.2.1 → v20.2.2  (PR #1021)
+
+| Field | Value |
+|-------|-------|
+| **Change** | `cephImage.tag: v20.2.2` |
+| **Why** | Tentacle point release |
+| **Note** | Did not retire `csi-rwx`. Workaround still in GitOps after later v20.2.3. |
+| **Rollback** | pin `cephImage.tag` back to v20.2.1 |
+| **Verify** | CephCluster image tag v20.2.2 |
+
+### [2026-06-21] Rook v1.20.0 → v1.20.1  (PR #1022)
+
+| Field | Value |
+|-------|-------|
+| **Change** | operator + cluster OCI tags `v1.20.1` |
+| **Why** | Renovate chart bump |
+| **Note** | CSI driver RBAC workaround `operator/csi-driver-rbac.yaml` stayed; v1.20.1 did not bake those ServiceAccounts into the operator chart. |
+| **Rollback** | pin both tags back to v1.20.0 |
+| **Verify** | OCIRepository tags `v1.20.1` |
+
 ### [2026-06-17] Multi-failure cascade + recovery; deep root-cause (B70 DMA theory EXONERATED)  (operational, no GitOps merge yet)
 
 | Field | Value |
@@ -157,10 +226,13 @@ Companion durable fixes shipped with the recovery (GitOps): cilium-agent → **G
 | **State** | **HEALTH_OK** (393 active+clean, 6/6, 3/3) on **temporary live mitigations (DRIFT, not in GitOps)** — see below. Cluster is patched, not permanently fixed. |
 | **Verify** | `ceph status` → 393 active+clean, 6/6 up, quorum h,i,m. `ceph osd stat`/`ceph mon stat`. |
 
-**⚠️ LIVE `ceph config set` DRIFT now in effect (formalize in GitOps or revert once hardware fixed):**
-`osd_mclock_profile=high_client_ops`, `osd_mclock_override_recovery_settings=true`, `osd_max_backfills=1`,
-`osd_recovery_max_active=1`, `osd_recovery_sleep_ssd=0.05`. Plus **MGLRU disabled on talos-3 is RUNTIME-ONLY
-(resets on reboot)**.
+**⚠️ 2026-06-17 live `ceph config set` drift vs GitOps (do not treat this list as current without a live dump):**
+GitOps `cephConfig` now has `osd_mclock_profile: high_client_ops` and `osd_recovery_max_active: "3"`.
+`osd_mclock_override_recovery_settings`, `osd_max_backfills=1`, and `osd_recovery_sleep_ssd=0.05` are
+**not** in the HelmRelease. Rook does not auto-`rm` unmanaged mon-DB keys, so those three may still
+overlay GitOps. Confirm with `ceph config dump` before assuming recovery is capped at 1 **or** at 3.
+Do not GitOps-ify or `config rm` them from this changelog pass. Plus **MGLRU disabled on talos-3 was
+RUNTIME-ONLY (resets on reboot)**.
 
 **Durable follow-ups (NOT done — the real fixes):** (1) **memtest86+ talos-1** — settle bad-RAM vs lying-980-PRO
 for the osd.0/mon corruption. (2) **Persistent MGLRU disable** (kernel past the 6.18.3 fix, or a boot DaemonSet
@@ -201,8 +273,6 @@ RAM/PCIe).** Logged as a hardware incident → see [`hardware-incidents.md`](./h
 | **Verify** | `kubectl -n rook-ceph get cephcluster -o jsonpath='{.items[0].spec.storage.osdMaxUpdatesInParallel}'` → `1`. `task rook:check-osd-device-paths` → drift audit + HEALTH_OK gate. |
 
 **Path correction (process note):** `osdMaxUpdatesInParallel` lives at **`spec.storage.osdMaxUpdatesInParallel`** (nested under `storage`), NOT `spec.osdMaxUpdatesInParallel`. #984 first set it at the wrong (spec) level → the API silently pruned it → inert; #985 then *mis*diagnosed the prune as "CRD drift" and reverted it. Investigated to ground truth: the **CRDs are current (v1.20.0)** — every "missing" field exists at its real nested path (`spec.storage.osdMaxUpdatesInParallel`, `spec.csi.readAffinity`). **No CRD drift, no CRD surgery needed.** #986 sets it at the correct path. Lesson: when `kubectl explain spec.X` says "field does not exist", search the full CRD schema for the real (possibly nested) path before concluding the CRD is stale.
-
-**Best-practice note:** raw mode + by-id device refs (what we run) **is** the Rook-recommended layout — raw is the modern default; LVM is legacy, reserved for encryption + `metadataDevice`, and risks LVM-tag corruption ([Rook ceph-volume design](https://github.com/rook/rook/blob/master/design/ceph/ceph-volume-provisioning.md)). So there is **no best-practice "permanent fix"** for #17224 short of the upstream code change; raw→LVM is a last-resort workaround only. **Keep OFF** (all at safe defaults): `upgradeOSDRequiresHealthyPGs` (deadlocks with #17224), `removeOSDsIfOutAndSafeToRemove` (could auto-purge a recoverable stale OSD), `skipUpgradeChecks`/`continueUpgradeAfterChecksEvenIfNotHealthy`. Storm **trigger** removed separately (SABnzbd tiny-file flood → ceph-block, PR #983). Guardrail: confirm HEALTH_OK + run the audit before `just talos upgrade-node`/`reboot-node`/`reset-node`.
 
 **Best-practice note:** raw mode + by-id device refs (what we run) **is** the Rook-recommended layout — raw is the modern default; LVM is legacy, reserved for encryption + `metadataDevice`, and risks LVM-tag corruption ([Rook ceph-volume design](https://github.com/rook/rook/blob/master/design/ceph/ceph-volume-provisioning.md)). So there is **no best-practice "permanent fix"** for #17224 short of the upstream code change; raw→LVM is a last-resort workaround only. **Keep OFF** (all at safe defaults): `upgradeOSDRequiresHealthyPGs` (deadlocks with #17224), `removeOSDsIfOutAndSafeToRemove` (could auto-purge a recoverable stale OSD), `skipUpgradeChecks`/`continueUpgradeAfterChecksEvenIfNotHealthy`. Storm **trigger** removed separately (SABnzbd tiny-file flood → ceph-block, PR #983). Guardrail: confirm HEALTH_OK + run the audit before `just talos upgrade-node`/`reboot-node`/`reset-node`.
 
@@ -274,7 +344,7 @@ Cross-ref: [CephFS Tentacle subvolumegroup bug](../) (memory). Do **not** retire
 |-------|-------|
 | **Change** | operator + cluster chart bumped to v1.20.0 |
 | **Why** | stay current; v1.20.0 is the latest release |
-| **Risk** | v1.20.0 ships the CSI driver RBAC outside the operator chart → needed a manual workaround (`operator/csi-driver-rbac.yaml`, [rook#17644](https://github.com/rook/rook/issues/17644)) — remove once v1.20.1+ ships it |
+| **Risk** | v1.20.0 ships the CSI driver RBAC outside the operator chart → needed a manual workaround (`operator/csi-driver-rbac.yaml`, [rook#17644](https://github.com/rook/rook/issues/17644)). Keep that file until a `ceph-csi-drivers` chart (or equivalent) is added to GitOps. Rook's fix was "install the CSI driver charts", not "v1.20.1 bakes RBAC into the operator chart". Charts are now v1.20.4 and the workaround is still required; deleting it reproduces `FailedCreate: serviceaccount not found` and breaks all RBD/CephFS attach. |
 | **Rollback** | pin `ocirepository.yaml` tag back to v1.19.6 |
 | **Verify** | `kubectl -n rook-ceph get deploy rook-ceph-operator -o jsonpath='{.spec.template.spec.containers[0].image}'` |
 
@@ -389,13 +459,22 @@ Sources are from the 2026-06-14 deep-research pass (Ceph Squid/Tentacle-era docs
   window catches it before clients wedge.
 - **Source:** docs.ceph.com `/rados/operations/health-checks/`; rook#15403.
 
-### P4 — Verify PG counts land near target (~100/OSD), keep autoscaler honest
+### P4 — Verify PG counts land near target (~100/OSD), keep autoscaler honest  (still unverified live)
 
-- **What:** confirm the `bulk: true` pools actually grew toward `mon_target_pg_per_osd` (100).
-  Docs recommend ~200 PGs/OSD for all but the smallest clusters; >500 risks peering/RAM.
-  With 6 OSDs, expect ~50–70 PG replicas/OSD initially with the balancer on.
-- **Verify:** `ceph osd pool autoscale-status`; `ceph osd df tree` (PGs column). If a pool is
-  stuck low, consider `pg_autoscale_mode: warn` + a manual `pg_num` bump.
+This changelog owns "what healthy looks like" for this cluster. Do not treat
+`docs/ceph/pg.md` generic 100-150 PGs/OSD, docs.ceph.com ~200, and this backlog
+as three current truths.
+
+- **GitOps target:** `mon_target_pg_per_osd` 100 with `bulk: true` on block +
+  cephfs-data0 (6 OSDs, `size=3`).
+- **Observed fingerprint after 2026-06-14 recovery:** **393 PGs active+clean**
+  (`ceph status` in the 2026-06-17 and 2026-07-03 entries). That is a point-in-time
+  number, not a pin.
+- **Upstream:** docs.ceph.com recommends ~200 PGs/OSD for all but the smallest
+  clusters; >500 risks peering/RAM.
+- **Still open:** confirm `ceph osd pool autoscale-status` / `ceph osd df tree`
+  after the next PG change. If a pool is stuck low, consider `pg_autoscale_mode:
+  warn` + a manual `pg_num` bump.
 - **Source:** docs.ceph.com `/rados/operations/placement-groups/`.
 
 ### P5 — (Optional, lower ROI) dedicated cluster/replication network

--- a/docs/ceph-cluster-changelog.md
+++ b/docs/ceph-cluster-changelog.md
@@ -316,7 +316,7 @@ Evidence captured 2026-06-14 (read-only): all CephFS mounts kernel-client; ceph-
 | **Rollback** | old PVs kept as `Retain` safety-net (delete when confident) |
 | **Verify** | apps healthy on `ceph-filesystem-rwx`, Ceph back to baseline |
 
-Cross-ref: [CephFS Tentacle subvolumegroup bug](../) (memory). Do **not** retire `csi-rwx` on image tag alone: live probe on v20.2.3 (2026-08-21) still fails `create`/`getpath` against the default `csi` group with `EINVAL: invalid value specified for ceph.dir.subvolume`. Keep `ceph-filesystem-rwx` until a future release passes that probe.
+Cross-ref: [`cephfs-rwx-subvolumegroup.yaml`](../kubernetes/apps/rook-ceph/rook-ceph/cluster/cephfs-rwx-subvolumegroup.yaml). Do **not** retire `csi-rwx` on image tag alone: live probe on v20.2.3 (2026-08-21) still fails `create`/`getpath` against the default `csi` group with `EINVAL: invalid value specified for ceph.dir.subvolume`. Keep `ceph-filesystem-rwx` until a future release passes that probe.
 
 ### [2026-06-12] CephFS CSI forced to autodetect → `ceph-fuse`  (PR — commit 17c7a9df, ae44b3ac)
 

--- a/docs/ceph-performance-review.md
+++ b/docs/ceph-performance-review.md
@@ -4,6 +4,18 @@
 **Cluster:** `6562d9b0-883a-4e55-8b5d-899eaa7e0d10` — Rook-Ceph v1.19.6, Ceph **v20.2.1 (tentacle)**, 3 nodes (talos-1/2/3), 6 OSDs, all NVMe.
 **Trigger for this review:** a multi-hour `HEALTH_WARN` slow-ops / `laggy` PG incident that wedged CephFS and RBD clients (sabnzbd stuck unkillable in `Terminating`).
 
+> **Snapshot of 2026-06-01. Do not re-apply.** Highest-impact config from §6.B
+> (compression `none`, drop `bluestore_cache_size`, `osd_memory_target` raised,
+> `high_client_ops`) is already in GitOps. PG growth was `bulk: true` +
+> autoscaler, not hardcoded 128/128/32. Line numbers cited in the body do not
+> match today's `cluster/helmrelease.yaml`. Current tunables live in
+> `docs/ceph-cluster-changelog.md` (baseline) and that HelmRelease.
+> Device nodes in §2 (`nvme0n1` / `nvme1n1`) were a point-in-time `lsblk`;
+> they are unstable (Rook #17224). Use `/dev/disk/by-id/...` from the HelmRelease
+> / `.taskfiles/rook/Taskfile.yaml` for any wipe. The StorageClass still *tags*
+> `compression_mode: aggressive` on new RBD images because the SC is immutable,
+> while the **pool** is `none`.
+
 > Scope note: settings referenced below live in
 > `kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml`. Changes must go
 > through that file (GitOps), not ad-hoc `ceph config set`, or Rook will revert them.

--- a/docs/ceph/backup-recovery-strategy.md
+++ b/docs/ceph/backup-recovery-strategy.md
@@ -1,164 +1,111 @@
 # Ceph Backup and Recovery Strategy
 
-## Problem Statement
-Rook-Ceph cluster failures have resulted in complete data loss 3 times in 5 weeks due to:
-1. Authentication corruption after node reboots
-2. No automated backup of monitor keyring and cluster metadata
-3. Inability to restore original FSID when monitors are lost
-4. Manual cleanup operations that destroy recovery options
+This document describes the **live** metadata backup, not a proposed
+CronJob. The implementation is
+[`kubernetes/apps/rook-ceph/rook-ceph/backup/backup-system.yaml`](../../kubernetes/apps/rook-ceph/rook-ceph/backup/backup-system.yaml),
+wired into the cluster Kustomization as `../backup`. Emergency steps live
+in
+[`kubernetes/apps/rook-ceph/rook-ceph/backup/RECOVERY-PROCEDURES.md`](../../kubernetes/apps/rook-ceph/rook-ceph/backup/RECOVERY-PROCEDURES.md).
 
-## Critical Backup Components
+## Problem this backup exists to solve
 
-### 1. Monitor Keyring and Cluster Metadata
-**Location**: `/var/lib/rook/rook-ceph/`
-**Critical Files**:
-- `mon-*/keyring` - Monitor authentication keys
-- `rook-ceph.config` - Cluster configuration
-- Kubernetes secrets: `rook-ceph-mon`, `rook-ceph-admin-keyring`
+Rook-Ceph failures here have destroyed clusters when monitor keyrings and
+the cluster FSID were not recoverable. The CronJob snapshots those
+Kubernetes objects daily so a **still-running cluster** can restore the
+original FSID after the CephCluster object or mon secrets were deleted.
 
-### 2. Automated Daily Backups
+It does **not** snapshot mon host-path directories (`/var/lib/rook/rook-ceph/`
+tarballs are never written). Restore paths that extract
+`mon-$NODE-YYYYMMDD.tar.gz` are fiction and will fail.
 
-Create a CronJob to backup critical Rook-Ceph metadata:
+## This is NOT a disaster-recovery backup of last resort
 
-```yaml
-apiVersion: batch/v1
-kind: CronJob
-metadata:
-  name: rook-ceph-backup
-  namespace: rook-ceph
-spec:
-  schedule: "0 2 * * *"  # Daily at 2 AM
-  jobTemplate:
-    spec:
-      template:
-        spec:
-          containers:
-          - name: backup
-            image: busybox
-            command:
-            - /bin/sh
-            - -c
-            - |
-              # Backup Kubernetes secrets
-              kubectl get secret rook-ceph-mon -o yaml > /backup/rook-ceph-mon-$(date +%Y%m%d).yaml
-              kubectl get secret rook-ceph-admin-keyring -o yaml > /backup/rook-ceph-admin-keyring-$(date +%Y%m%d).yaml
+PVC `ceph-backup-pvc` is 50Gi `openebs-hostpath` in namespace `rook-ceph`.
+It lives on the same cluster as the OSDs. Complete cluster loss, node
+rebuild, PVC delete, or a host wipe (`task rook:wipe-talos-N` /
+`task rook:reset-all-data` / `task rook:wipe-all-with-progress`) destroys
+the only copy. After that wipe there is nothing to restore. Off-cluster
+immutable copies (NAS MinIO / R2) of these YAML/FSID files were never
+implemented.
 
-              # Backup monitor data from each node
-              for node in talos-1 talos-2 talos-3; do
-                kubectl exec -n rook-ceph $(kubectl get pods -n rook-ceph -l app=rook-ceph-mon --field-selector spec.nodeName=$node -o name | head -1) -- tar czf - /var/lib/rook/rook-ceph/ > /backup/mon-$node-$(date +%Y%m%d).tar.gz
-              done
+If the cluster and its nodes are gone, OSD data is unrecoverable and a
+new FSID is required. All-mon-store loss also cannot be restored from an
+old backup; see `docs/ceph-cluster-changelog.md`. Copy a dated backup
+directory off-cluster **before** any wipe if you still need the original
+FSID.
 
-              # Keep only last 7 days
-              find /backup -name "*.yaml" -mtime +7 -delete
-              find /backup -name "*.tar.gz" -mtime +7 -delete
-            volumeMounts:
-            - name: backup-storage
-              mountPath: /backup
-          volumes:
-          - name: backup-storage
-            persistentVolumeClaim:
-              claimName: ceph-backup-pvc
-          restartPolicy: OnFailure
+## What the CronJob writes
+
+| Item | On disk under `/backup/<date>/` |
+|------|----------------------------------|
+| Secret `rook-ceph-mon` | `rook-ceph-mon.yaml` |
+| Secret `rook-ceph-admin-keyring` | `rook-ceph-admin-keyring.yaml` |
+| `CephCluster` list YAML | `cephcluster.yaml` |
+| ConfigMap `rook-ceph-mon-endpoints` | `mon-endpoints.yaml` |
+| FSID text | `cluster-fsid.txt` |
+| Status ConfigMap | applied with label `backup-type=ceph-metadata` |
+
+Schedule: `0 3 * * *` (daily 03:00, offset from R2 at 02:00). Retention:
+7 dated directories + 7 metadata ConfigMaps. Image: `alpine/k8s:1.36.2`
+(has `kubectl`). ServiceAccount `rook-ceph-backup` with a Role limited to
+secrets/configmaps/pods/cephclusters in `rook-ceph`.
+
+There is no `backup-pod` Deployment.
+
+## Inspecting backups
+
+```bash
+kubectl get cronjob,pvc -n rook-ceph rook-ceph-backup ceph-backup-pvc
+kubectl get cm -n rook-ceph -l backup-type=ceph-metadata --sort-by=.metadata.creationTimestamp
 ```
 
-### 3. Ceph Cluster Health Monitoring
+Mount the PVC in a debug pod to read files (RWO: no concurrent backup Job).
+Do not treat `kubectl create job --from=cronjob/rook-ceph-backup` as a
+reader; that Job only writes another dated dump. Exact reader YAML is in
+`RECOVERY-PROCEDURES.md`.
 
-Add comprehensive monitoring to detect issues early:
+## Restore
 
-```yaml
-# Prometheus alerts for Ceph cluster health
-- alert: CephMonitorDown
-  expr: up{job="rook-ceph-mgr"} == 0
-  for: 5m
-  annotations:
-    summary: "Ceph monitor is down"
+Follow `RECOVERY-PROCEDURES.md`:
 
-- alert: CephAuthenticationError
-  expr: increase(ceph_monitor_election_call_total[5m]) > 10
-  annotations:
-    summary: "Ceph authentication issues detected"
+1. **Mons still answer, auth looks wrong:** restart the operator only.
+   Never `kubectl delete pods -n rook-ceph -l app=rook-ceph-osd`. That
+   contradicts [`osd-device-path-recovery.md`](./osd-device-path-recovery.md)
+   (Rook #17224).
+2. **Mon DB / k8s objects lost, backup PVC still present:** copy the dated
+   directory off-cluster, restore the two secrets, recreate the
+   CephCluster via Flux. Do not extract tarballs; they are not produced.
+3. **Complete loss / host wipe:** new FSID, OSD data gone. The in-cluster
+   backup is already destroyed by the wipe.
 
-- alert: CephOSDDown
-  expr: ceph_osd_up == 0
-  for: 5m
-  annotations:
-    summary: "Ceph OSD {{ $labels.ceph_daemon }} is down"
-```
+## Monitoring
 
-### 4. Recovery Procedures
+Do not add the sample `CephMonitorDown` / `CephAuthenticationError` alerts
+that used to live in this file. They were wrong (`up{job="rook-ceph-mgr"}`
+is the mgr, not mons; `ceph_monitor_election_call_total` is not an auth
+signal).
 
-#### Quick Recovery (if monitors are healthy):
-1. Restart affected OSD pods
-2. Check authentication keys
-3. Verify cluster health
+Live rules:
 
-#### Full Recovery (if monitors are corrupted):
-1. **Stop all deletions immediately**
-2. Restore monitor secrets from backup:
-   ```bash
-   kubectl apply -f /backup/rook-ceph-mon-YYYYMMDD.yaml
-   kubectl apply -f /backup/rook-ceph-admin-keyring-YYYYMMDD.yaml
-   ```
-3. Restore monitor data to nodes:
-   ```bash
-   # For each node
-   kubectl exec -n rook-ceph $CLEANUP_POD -- tar xzf /backup/mon-$NODE-YYYYMMDD.tar.gz -C /var/lib/rook/
-   ```
-4. Restart rook-ceph-operator
-5. Wait for automatic OSD discovery
+- Custom: [`cluster/prometheusrules.yaml`](../../kubernetes/apps/rook-ceph/rook-ceph/cluster/prometheusrules.yaml)
+  (`CephOSDDown`, quorum, PG, disk prediction, and related).
+- Chart rules: `monitoring.createPrometheusRules: true` on the cluster
+  HelmRelease.
 
-### 5. Prevention Measures
+## Prevention
 
-#### Immediate Actions:
-1. **Never run cleanup operations without confirmed backups**
-2. **Always check for existing data before FSID changes**
-3. **Implement backup verification tests**
+1. Never run cleanup / wipe tasks without a copy of the backup directory
+   **outside** the cluster.
+2. Always check the live FSID before changing it.
+3. Confirm `task rook:check-osd-device-paths` is green before rebooting a
+   node or bouncing an OSD.
 
-#### Long-term Improvements:
-1. **External Ceph cluster** - Move critical data to managed Ceph service
-2. **Multi-cluster setup** - Replicate critical data across clusters
-3. **Immutable backups** - Store backups in object storage outside the cluster
+## Gaps (not implemented)
 
-### 6. Emergency Contacts and Procedures
+- Off-cluster (R2 / NAS MinIO) copies of the YAML/FSID files
+- Mon store snapshots from `/var/lib/rook/` (this cluster's mons use
+  `openebs-hostpath` PVCs; a host-path tar is a different design)
+- Staging recovery drills
 
-#### Before any major changes:
-1. Verify recent backups exist and are valid
-2. Document current cluster state
-3. Have rollback plan ready
-4. Test recovery procedure in staging
-
-#### If cluster fails:
-1. **DO NOT DELETE ANYTHING** until backup status is confirmed
-2. Check if monitors are still accessible
-3. Attempt authentication repair first
-4. Only clean host data as last resort with confirmed backups
-
-## Implementation Priority
-
-1. **Immediate (Today)**:
-   - Create backup CronJob
-   - Set up basic monitoring alerts
-   - Document current cluster FSID and secrets
-
-2. **This Week**:
-   - Test backup/restore procedure
-   - Implement automated health checks
-   - Create emergency runbook
-
-3. **This Month**:
-   - Evaluate external Ceph options
-   - Implement immutable backup storage
-   - Set up staging environment for testing
-
-## Cost of Current Approach vs Alternatives
-
-**Current Losses**: 3 complete cluster rebuilds = ~40+ hours of downtime
-**Backup Solution Cost**: ~2 hours setup + 1 hour/month maintenance
-**Managed Ceph Service**: Higher cost but eliminates cluster management overhead
-
-## Next Steps
-
-1. Let's implement the backup CronJob immediately after cluster recreation
-2. Set up monitoring alerts
-3. Create a staging environment to test disaster recovery
-4. Evaluate managed Ceph services for critical workloads
+Until those exist, treat this CronJob as an in-cluster convenience for
+secret/FSID recovery while the nodes are still up, not as last-resort DR.

--- a/docs/ceph/osd-store-corruption-recovery.md
+++ b/docs/ceph/osd-store-corruption-recovery.md
@@ -79,8 +79,11 @@ Replace `N` and `<by-id-disk>` with the affected OSD and its disk
    until wiped; otherwise the operator re-activates the corrupt store). Wipe **only that one
    disk** — never `task rook:wipe-talos-X` (that hits every OSD on the node):
    ```bash
-   task rook:reset-disk disk="<by-id-disk>" node="talos-X" --yes
+   task --yes rook:reset-disk disk="<by-id-disk>" node="talos-X"
    ```
+   The skip-prompt flag is the global `task --yes`, not `--yes` after the task name.
+   The wipe Job image is `quay.io/ceph/ceph:v20.2.3` (same `cephImage.tag` as the
+   cluster HelmRelease). Do not zap a Tentacle OSD with a Reef (v19) image.
    > On Windows the `reset-disk` task can choke on its `envsubst < <(...)` process
    > substitution + interactive prompt. Equivalent manual path: render
    > `.taskfiles/rook/templates/WipeDiskJob.tmpl.yaml` (substitute `${job}/${node}/${disk}`)
@@ -99,7 +102,10 @@ Replace `N` and `<by-id-disk>` with the affected OSD and its disk
    ```
    PGs should be `active+remapped+backfilling`, **not** `degraded` (peers keep full
    redundancy throughout). If the no-PLP OSDs (e.g. osd.3/osd.6) wedge on slow ops during
-   backfill, pace it: `ceph config set osd osd_max_backfills 1` (mClock per-OSD IOPS caps
+   backfill, pace it as an incident-only toolbox command and log it in
+   `docs/ceph-cluster-changelog.md` (GitOps owns Ceph config; live
+   `ceph config set` is not the standing path):
+   `ceph config set osd osd_max_backfills 1` (mClock per-OSD IOPS caps
    already apply).
 
 ## Verify

--- a/docs/ceph/pg.md
+++ b/docs/ceph/pg.md
@@ -1,6 +1,14 @@
 # Ceph Placement Groups (PG) Configuration Guide
 
-> **Note**: This guide covers both modern autoscaling (recommended) and legacy manual calculation methods for Ceph placement groups.
+> **This cluster:** 6 OSDs, `size=3`, `bulk: true` on block + cephfs-data0,
+> GitOps `mon_target_pg_per_osd` 100, autoscaler on. Healthy fingerprint from
+> the changelog is **393 PGs active+clean** (point-in-time, 2026-06-17 /
+> 2026-07-03). Backlog P4 (verify live `ceph osd pool autoscale-status`) is
+> still open. `docs/ceph-cluster-changelog.md` owns current truth; the tables
+> below are generic upstream notes, not this cluster's pin.
+>
+> Standing Ceph config is GitOps in `cluster/helmrelease.yaml`. Live
+> `ceph config set` is incident-only and must be logged in the changelog.
 
 ## 📊 Overview
 
@@ -18,7 +26,7 @@ Placement Groups (PGs) are fundamental to Ceph's data distribution and performan
 # Enable autoscaling for a specific pool
 ceph osd pool set <pool-name> pg_autoscale_mode on
 
-# Set default autoscaling for new pools
+# Set default autoscaling for new pools (incident-only; GitOps owns standing config)
 ceph config set global osd_pool_default_pg_autoscale_mode on
 
 # View autoscaling status and recommendations
@@ -38,9 +46,9 @@ ceph osd pool set mypool target_size_ratio 1.0
 ### Adjust PG Target (Optional)
 
 ```bash
-# Default: 100 PG replicas per OSD
-# Recommended for most clusters: 200
-ceph config set global mon_target_pg_per_osd 200
+# This cluster's GitOps target is 100 (not 200). Do not apply 200 live.
+# Upstream docs recommend ~200 for all but the smallest clusters.
+ceph config set global mon_target_pg_per_osd 100
 ```
 
 ---
@@ -48,6 +56,8 @@ ceph config set global mon_target_pg_per_osd 200
 ## 🔧 Legacy Manual Calculation
 
 For older Ceph versions or when autoscaling is disabled, you'll need to calculate PGs manually.
+The sample numbers below (3 OSDs, `size=2`) are generic tutorial values, **not** this
+cluster (6 OSDs, `size=3`).
 
 ### Prerequisites: Gather Cluster Information
 
@@ -191,10 +201,13 @@ ceph osd pool set <pool-name> target_size_ratio <ratio>
 
 ## 📈 Performance Guidelines
 
+Generic upstream ranges (not this cluster's pin):
+
 | Cluster Size | Target PGs/OSD | Notes |
 |--------------|----------------|-------|
 | Small (< 10 OSDs) | 100-150 | Conservative approach |
 | Medium (10-50 OSDs) | 150-200 | Balanced performance |
 | Large (50+ OSDs) | 200+ | Maximum parallelism |
 
-> **Note**: With balancer enabled, expect 50-100 PG replicas per OSD initially.
+> This cluster (6 OSDs): GitOps `mon_target_pg_per_osd` **100**; last recorded
+> healthy `ceph status` was **393 active+clean**. See changelog backlog P4.

--- a/docs/ceph/toolbox.md
+++ b/docs/ceph/toolbox.md
@@ -29,11 +29,16 @@ Then reconcile:
 flux reconcile hr rook-ceph-cluster -n rook-ceph
 ```
 
-### Temporary Pod
-For one-time operations:
+The cluster HelmRelease already enables a permanent toolbox (`toolbox.enabled: true`)
+that tracks the Rook chart tag (currently v1.20.4). Prefer that Deployment. Do not
+run a one-shot `rook/ceph` pod on an old tag (v1.17.1 tools talking to Tentacle mons
+are the wrong binary set for recovery).
+
+If you must run a throwaway pod, pin the same chart tag:
+
 ```bash
 kubectl run -i --tty --rm debug-ceph \
-  --image=rook/ceph:v1.17.1 \
+  --image=rook/ceph:v1.20.4 \
   --restart=Never \
   -n rook-ceph -- bash
 ```
@@ -170,14 +175,20 @@ ceph osd pool set <pool-name> <property> <value>
 ```
 
 ### Pool Properties
+All standing Ceph config is GitOps in
+`kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml`. Live
+`ceph osd pool set` / `ceph config set` / `injectargs` is incident-only and
+must be logged in `docs/ceph-cluster-changelog.md`. This cluster's pools are
+`compression_mode: none`; do not re-enable `aggressive`.
+
 ```bash
 # Set pool size (replication factor)
 ceph osd pool set <pool-name> size 3
 ceph osd pool set <pool-name> min_size 2
 
-# Enable compression
+# Compression (GitOps is `none` on all pools; do not apply aggressive here)
 ceph osd pool set <pool-name> compression_algorithm zstd
-ceph osd pool set <pool-name> compression_mode aggressive
+ceph osd pool set <pool-name> compression_mode none
 
 # Set PG autoscaler
 ceph osd pool set <pool-name> pg_autoscale_mode on
@@ -243,9 +254,11 @@ ceph fs subvolume info <fs-name> <subvol-name> --group-name <group-name>
 ## Object Storage Operations
 
 ### RGW Status
+This cluster is Rook, not cephadm. `ceph orch` is the wrong control plane.
+
 ```bash
 # List RGW instances
-ceph orch ls rgw
+kubectl -n rook-ceph get deploy -l app=rook-ceph-rgw
 
 # RGW statistics
 radosgw-admin user list
@@ -329,8 +342,12 @@ ceph osd unset nobackfill
 ```
 
 ### Recovery Tuning
+Incident-only. GitOps currently sets `osd_recovery_max_active: "3"` and
+`osd_mclock_profile: high_client_ops`. Log any live `injectargs` /
+`ceph config set` in the changelog.
+
 ```bash
-# Limit recovery operations
+# Limit recovery operations (temporary; Rook may revert unmanaged keys)
 ceph tell 'osd.*' injectargs --osd-max-backfills=1
 ceph tell 'osd.*' injectargs --osd-recovery-max-active=1
 

--- a/docs/pvc/pvc-health-checks.md
+++ b/docs/pvc/pvc-health-checks.md
@@ -54,6 +54,12 @@ spec:
 | `healthCheckExprs` | Waits for specific resource conditions |
 | `wait: true` | Makes Flux wait for health checks to pass |
 
+`healthCheckExprs` apply to objects in that Kustomization's inventory,
+not every PVC in the namespace. The VolSync component also injects a
+restore PVC named `${APP}` with `dataSourceRef` to `${APP}-dst`. pgAdmin
+Helm uses `existingClaim: pgadmin`, so that generated claim *is* the
+app PVC (the onedr0p pattern). Do not add a second PVC with the same name.
+
 ## 🧪 Testing the Configuration
 
 ### 1. Check Kustomization Status

--- a/kubernetes/apps/database/cloudnative-pg/Readme.md
+++ b/kubernetes/apps/database/cloudnative-pg/Readme.md
@@ -6,7 +6,7 @@ CNPG operator + the canonical `postgres-17` cluster, plus pgAdmin and the upstre
 
 | Subdir | Purpose |
 | ------ | ------- |
-| `operator/` | CNPG operator HelmRelease (chart `0.28.0`, app `1.29.0`). 2 replicas, PodMonitor enabled. Secret `cloudnative-pg-secret` (postgres superuser + MinIO S3 keys for Barman). |
+| `operator/` | CNPG operator HelmRelease (chart `0.29.0`, app `1.30.0`). 2 replicas, PodMonitor enabled. Secret `cloudnative-pg-secret` (postgres superuser + MinIO S3 keys for Barman). |
 | `cluster-17/` | The `postgres-17` Cluster CR (Postgres 17 + pgvecto.rs), its `ScheduledBackup` (`@daily`), `LoadBalancer` Service, Gatus probe, PrometheusRule (7 alerts), and Barman config (serverName `postgres17-v5`, MinIO bucket `s3://home-ops-postgres-cluster/`). |
 | `dashboard/` | OCI Helm chart `ghcr.io/cloudnative-pg/grafana-dashboards/cluster:0.0.5`. Sidecar-loaded into Grafana under the "Database" folder (alongside the Dragonfly operator dashboard). |
 | `pgadmin/` | pgAdmin 4 web UI behind Authentik OAuth at `pgadmin.${SECRET_DOMAIN}` and `pg.${SECRET_DOMAIN}`. Triple-redundant volsync backup (Ceph 4h / MinIO 6h / R2 daily). |

--- a/kubernetes/apps/database/cloudnative-pg/ks.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/ks.yaml
@@ -42,8 +42,8 @@ spec:
       namespace: security
   # Operational health gate: readyInstances + ContinuousArchiving (not the Ready
   # condition, which CNPG can latch False indefinitely even while the cluster
-  # serves reads/writes). readyInstances >= 1 because the cluster starts with
-  # 2 instances (talos-3 excluded; see cluster-17.yaml nodeAffinity).
+  # serves reads/writes). readyInstances >= 1 is a floor; cluster-17 runs 3
+  # instances (talos-3 BIOS issue resolved 2026-04-26).
   healthCheckExprs:
     - apiVersion: postgresql.cnpg.io/v1
       kind: Cluster

--- a/kubernetes/apps/database/dragonfly/Readme.md
+++ b/kubernetes/apps/database/dragonfly/Readme.md
@@ -6,7 +6,7 @@ Dragonfly DB operator and per-app cache instances. There is **no centrally-deplo
 
 | Subdir | Purpose |
 | ------ | ------- |
-| `operator/` | Dragonfly operator HelmRelease (chart `v1.5.0`, OCI). Manages the `Dragonfly` CRD, master/replica failover, per-cluster `PodDisruptionBudget` (`maxUnavailable: 1`), and per-cluster `NetworkPolicy` (peer-pods-only on `:9999`). Bundles the operator Grafana dashboard into the "Database" folder. |
+| `operator/` | Dragonfly operator HelmRelease (chart `v1.6.1`, OCI). Manages the `Dragonfly` CRD, master/replica failover, per-cluster `PodDisruptionBudget` (`maxUnavailable: 1`), and per-cluster `NetworkPolicy` (peer-pods-only on `:9999`). Bundles the operator Grafana dashboard into the "Database" folder. |
 
 The `cluster/` subdir was deleted as dead code (was commented out in `ks.yaml` for months and duplicated the real per-app component). All actual cluster config now lives in `kubernetes/components/dragonfly/`.
 
@@ -25,7 +25,6 @@ Current consumers and their endpoints:
 | --- | --------- | -------- |
 | `authentik` | security | `authentik-dragonfly.security.svc.cluster.local:6379` |
 | `immich` | media | `immich-dragonfly.media.svc.cluster.local:6379` |
-| `litellm` | ai | `litellm-dragonfly.ai.svc.cluster.local:6379` |
 | `open-webui` | ai | `open-webui-dragonfly.ai.svc.cluster.local:6379` |
 | `paperless-ngx` | selfhosted | `paperless-ngx-dragonfly.selfhosted.svc.cluster.local:6379` |
 | `rsshub` | selfhosted | `rsshub-dragonfly.selfhosted.svc.cluster.local:6379` |
@@ -33,7 +32,7 @@ Current consumers and their endpoints:
 
 ## Cluster overview (per instance, set in the component)
 
-- Image: `ghcr.io/dragonflydb/dragonfly:v1.38.0` — pinned in `components/dragonfly/cluster.yaml`, tracked by Renovate (`# renovate: datasource=docker depName=ghcr.io/dragonflydb/dragonfly`).
+- Image: `ghcr.io/dragonflydb/dragonfly:v1.40.1` — pinned in `components/dragonfly/cluster.yaml`, tracked by Renovate (`# renovate: datasource=docker depName=ghcr.io/dragonflydb/dragonfly`).
 - 2 replicas with `topologySpreadConstraints` enforcing `maxSkew=1` across `kubernetes.io/hostname` (each cluster spans 2 of talos-1/2/3).
 - Resources: `requests` and `limits` both at 250m CPU + 640Mi memory. The CR-level config qualifies for Guaranteed QoS, but the cluster-wide `k8tz` mutating webhook injects an empty-resources init container that drags every pod down to **Burstable** (see Operational notes).
 - Args: `--maxmemory=512Mi`, `--proactor_threads=2`, `--cluster_mode=emulated`, `--cache_mode=true`, `--default_lua_flags=allow-undeclared-keys`.
@@ -63,7 +62,7 @@ kubectl exec -n monitoring deploy/grafana -c grafana -- sh -c \
   | jq '.data.result[] | {job: .metric.job, value: .value[1]}'
 ```
 
-Expect 14 results (7 clusters × 2 replicas), all `value=1`. If any are `0`, check the additive `*-allow-prometheus` NetworkPolicy actually applied in that namespace.
+Expect 12 results (6 clusters × 2 replicas), all `value=1`. If any are `0`, check the additive `*-allow-prometheus` NetworkPolicy actually applied in that namespace.
 
 ### Check master/replica role
 
@@ -79,7 +78,7 @@ Expect exactly one `master` per `<app>-dragonfly` cluster, the rest `replica`.
 - **Cache-only policy.** Every cluster runs with `--cache_mode=true`; LRU eviction is the consistency model. Snapshot/RDB backup is **intentionally** disabled — consumers must tolerate full data loss on pod restart. Authentik's session cache, Immich's job state, etc. all reset on rollout.
 - **No password auth.** Mitigated by two NetworkPolicies in front of every pod: the operator-installed one (peer-pods + operator controller-manager only on `:9999`, and any pod in the same namespace on `:6379`) plus the additive `<app>-dragonfly-allow-prometheus` NP from the component.
 - **QoS lands as Burstable, not Guaranteed.** The CR-level `requests` and `limits` match exactly, but the cluster-wide `k8tz` mutating webhook injects an init container with empty resources into nearly every pod (only 1 pod cluster-wide is currently Guaranteed). Fixing this is a `k8tz` config change, not a Dragonfly one.
-- **Dragonfly v1.38.0 memory floor.** `--maxmemory` must be ≥ `256MiB × proactor_threads`. With our `--proactor_threads=2`, the floor is 512MiB. Don't drop `limits.memory` below 640Mi without first lowering `proactor_threads`, or pods crash-loop on startup with `"There are 2 threads, so 512.00MiB are required. Exiting..."`.
-- **Operator's NetworkPolicy is restrictive on `:9999`.** It only allows the operator controller-manager and peer Dragonfly replicas. Prometheus needs the additive `<app>-dragonfly-allow-prometheus` NP from `components/dragonfly/networkpolicy.yaml` — without it, all 14 scrape targets land in `health=down` (`context deadline exceeded`) and the Grafana dashboard is empty.
+- **Memory floor (since v1.38.0, still true at v1.40.1).** `--maxmemory` must be ≥ `256MiB × proactor_threads`. With our `--proactor_threads=2`, the floor is 512MiB. Don't drop `limits.memory` below 640Mi without first lowering `proactor_threads`, or pods crash-loop on startup with `"There are 2 threads, so 512.00MiB are required. Exiting..."`.
+- **Operator's NetworkPolicy is restrictive on `:9999`.** It only allows the operator controller-manager and peer Dragonfly replicas. Prometheus needs the additive `<app>-dragonfly-allow-prometheus` NP from `components/dragonfly/networkpolicy.yaml` — without it, all 12 scrape targets land in `health=down` (`context deadline exceeded`) and the Grafana dashboard is empty.
 - **Bundled operator Grafana dashboard is in the "Database" folder.** The grafana helm values used to also pull four `dragonfly-*` dashboards (gnetIds 15944/15945/21053/21054) — those are for **D7Y / Dragonfly P2P file distribution**, an unrelated CNCF project sharing the name. They have been removed from `apps/monitoring/grafana/app/helmrelease.yaml`; don't add them back.
 - **Renovate tracks both the operator chart and the Dragonfly image** automatically (the chart via Flux's OCIRepository manager, the image via the renovate annotation comment in `components/dragonfly/cluster.yaml`). Bumps appear in the Dependency Dashboard issue.

--- a/kubernetes/apps/database/emqx/Readme.md
+++ b/kubernetes/apps/database/emqx/Readme.md
@@ -19,7 +19,7 @@ EMQX 5.x MQTT broker for the home-ops cluster, deployed via the EMQX operator. T
 - PDB: `coreTemplate.spec.minAvailable: 1` (operator-managed).
 - Authentication: built_in_database with bcrypt; users bootstrapped from `/opt/init-user.json` (default admin + MQTT service account, both in 1Password).
 - Authorization: built_in_database + ACL file (`/opt/init-acl`); `no_match: deny` (default-deny).
-- API keys: bootstrapped from `/opt/init-api-keys` so the exporter can authenticate without manual setup.
+- Exporter API key: **not** bootstrapped from `/opt/init-api-keys` (the CR has no such mount). Create it in the dashboard and store it in 1Password; see Operational notes.
 
 ## MQTT clients
 

--- a/kubernetes/apps/database/emqx/exporter/externalsecret.yaml
+++ b/kubernetes/apps/database/emqx/exporter/externalsecret.yaml
@@ -14,9 +14,9 @@ spec:
     creationPolicy: Owner
     template:
       data:
-        # Same EMQX_EXPORTER_API_KEY/SECRET that the cluster-side
-        # init-api-keys bootstrap registers in EMQX. Both sides read from
-        # the same OnePassword item so they cannot drift.
+        # API key created in the EMQX dashboard (operator-owned bootstrap
+        # file cannot be extended via the CR). Store the key+secret in the
+        # same OnePassword item this ExternalSecret reads.
         config.yaml: |
           metrics:
             target: emqx-dashboard.database.svc.cluster.local:18083

--- a/kubernetes/apps/database/jetstream/Readme.md
+++ b/kubernetes/apps/database/jetstream/Readme.md
@@ -1,6 +1,8 @@
 # NATS JetStream
 
-NATS JetStream is a distributed messaging system with persistence, exactly-once semantics, and streaming capabilities.
+NATS JetStream is a distributed messaging system with persistence and
+streaming. Default delivery is **at-least-once** with explicit ack, not
+exactly-once.
 
 ## Components
 
@@ -12,26 +14,30 @@ NATS JetStream is a distributed messaging system with persistence, exactly-once 
 - 3-node cluster for quorum-based consensus
 - File-based storage on Ceph block storage (10Gi per node)
 - Memory store for ephemeral high-throughput (1Gi per node)
-- Pod anti-affinity ensures one replica per Kubernetes node
+- `topologySpreadConstraints` (`maxSkew: 1`, `whenUnsatisfiable: DoNotSchedule`
+  on `kubernetes.io/hostname`) spread replicas; this is not pod anti-affinity
 
 ## Usage
 
-### Creating a Stream
+The in-repo example Stream is `events` (`streams/example-stream.yaml`), not
+`my-stream`.
 
 ```yaml
 apiVersion: jetstream.nats.io/v1beta2
 kind: Stream
 metadata:
-  name: my-stream
+  name: events
   namespace: database
 spec:
-  name: my-stream
+  name: events
   subjects:
-    - "my.subject.>"
+    - "events.>"
   storage: file
   replicas: 3
   retention: limits
   maxAge: 168h
+  maxBytes: 5368709120
+  discard: old
 ```
 
 ### Creating a Consumer
@@ -40,11 +46,11 @@ spec:
 apiVersion: jetstream.nats.io/v1beta2
 kind: Consumer
 metadata:
-  name: my-consumer
+  name: events-durable
   namespace: database
 spec:
-  streamName: my-stream
-  durableName: my-consumer
+  streamName: events
+  durableName: events-durable
   deliverPolicy: all
   ackPolicy: explicit
   maxDeliver: 5
@@ -53,13 +59,14 @@ spec:
 
 ## Connection
 
-- Internal: `nats://nats.database.svc.cluster.local:4222`
-- Cluster: `nats://nats.database.svc.cluster.local:6222`
+- Client (ClusterIP): `nats://nats.database.svc.cluster.local:4222`
+- Cluster/gossip (port 6222) is on the **headless** Service the chart
+  creates, not `nats.database.svc.cluster.local:6222`
 
 ## Monitoring
 
 - Prometheus metrics available on port 7777
-- NATS dashboard available in Grafana
+- NATS dashboard available in Grafana (gnetId 16256)
 
 ## References
 

--- a/kubernetes/apps/rook-ceph/rook-ceph/Readme.md
+++ b/kubernetes/apps/rook-ceph/rook-ceph/Readme.md
@@ -125,4 +125,4 @@ kubectl logs -n rook-ceph -l app=rook-ceph-rgw -c rgw --tail=100
 ## References
 
 - Dashboard Templates: https://github.com/ceph/ceph/tree/main/monitoring/ceph-mixin/dashboards_out
-- Dashboard Settings: https://docs.ceph.com/en/squid/mgr/dashboard/#enabling-the-embedding-of-grafana-dashboards
+- Dashboard Settings: https://docs.ceph.com/en/tentacle/mgr/dashboard/#enabling-the-embedding-of-grafana-dashboards

--- a/kubernetes/apps/rook-ceph/rook-ceph/backup/RECOVERY-PROCEDURES.md
+++ b/kubernetes/apps/rook-ceph/rook-ceph/backup/RECOVERY-PROCEDURES.md
@@ -1,112 +1,235 @@
 # Rook-Ceph Recovery Procedures
 
-## Emergency Recovery Steps
+These steps match the live backup in
+[`backup-system.yaml`](./backup-system.yaml) and the device-path runbook
+[`docs/ceph/osd-device-path-recovery.md`](../../../../../docs/ceph/osd-device-path-recovery.md).
+Do not invent missing objects. There is no `backup-pod` Deployment, no
+`cleanup-all-nodes.yaml`, and no `initial-backup-job.yaml`.
 
-### 1. If Cluster Authentication is Corrupted (but monitors are accessible)
+Toolbox is a Deployment (`toolbox.enabled: true` in the cluster HelmRelease).
+Always exec that, never a guessed pod name:
 
 ```bash
-# DO NOT DELETE ANYTHING - Try recovery first
+kubectl exec -n rook-ceph deploy/rook-ceph-tools -- ceph status
+```
 
-# 1. Check if monitors are accessible
-kubectl exec -n rook-ceph rook-ceph-tools-xxx -- ceph status
+---
 
-# 2. If monitors respond but OSDs are down due to auth issues:
-kubectl exec -n rook-ceph rook-ceph-tools-xxx -- ceph auth list
+## What the in-cluster backup actually is
 
-# 3. Restart operator to regenerate auth
+CronJob `rook-ceph-backup` (`schedule: "0 3 * * *"`) writes dated directories
+onto PVC `ceph-backup-pvc` (50Gi, StorageClass `openebs-hostpath`, namespace
+`rook-ceph`). Each run dumps:
+
+- Secret `rook-ceph-mon`
+- Secret `rook-ceph-admin-keyring`
+- `CephCluster` YAML
+- ConfigMap `rook-ceph-mon-endpoints`
+- `cluster-fsid.txt` (from the mon secret)
+- a ConfigMap labeled `backup-type=ceph-metadata`
+
+It does **not** tar `/var/lib/rook/rook-ceph/` from mon pods. Those tarballs
+do not exist and cannot be restored.
+
+List what exists:
+
+```bash
+kubectl get cronjob,pvc -n rook-ceph rook-ceph-backup ceph-backup-pvc
+kubectl get cm -n rook-ceph -l backup-type=ceph-metadata --sort-by=.metadata.creationTimestamp
+```
+
+Read the files by mounting the PVC (the CronJob is a writer, not a reader).
+The PVC is RWO, so wait until no `rook-ceph-backup-*` Job pod is Running:
+
+```bash
+kubectl -n rook-ceph apply -f - <<'EOF'
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ceph-backup-reader
+  namespace: rook-ceph
+spec:
+  restartPolicy: Never
+  containers:
+    - name: reader
+      image: busybox:1.37
+      command: ["sleep", "3600"]
+      volumeMounts:
+        - name: backup
+          mountPath: /backup
+  volumes:
+    - name: backup
+      persistentVolumeClaim:
+        claimName: ceph-backup-pvc
+EOF
+
+kubectl -n rook-ceph exec ceph-backup-reader -- ls -la /backup
+kubectl -n rook-ceph exec ceph-backup-reader -- find /backup -name cluster-fsid.txt -exec cat {} \;
+# Copy a dated dir off the cluster before any wipe:
+# kubectl -n rook-ceph cp ceph-backup-reader:/backup/BACKUP_DATE ./ceph-backup-BACKUP_DATE
+kubectl -n rook-ceph delete pod ceph-backup-reader
+```
+
+Check the live FSID:
+
+```bash
+kubectl get secret rook-ceph-mon -n rook-ceph -o jsonpath='{.data.fsid}' | base64 -d; echo
+```
+
+### This is NOT a disaster-recovery backup of last resort
+
+`ceph-backup-pvc` lives on the same cluster, on a node's OpenEBS hostpath
+volume. Complete cluster loss, node rebuild, PVC delete, or a host wipe
+(`task rook:wipe-talos-N`, `task rook:reset-all-data`,
+`task rook:wipe-all-with-progress`) destroys that copy along with the OSD
+disks. After a host wipe there is nothing left to `kubectl apply`.
+
+Off-cluster copies of these YAML/FSID files were never implemented.
+`task rook:backup-rook-config` only dumps Ceph CRs to `/tmp` on the
+workstation; it does not save mon secrets or the FSID, and `/tmp` is not
+durable off-cluster storage.
+
+If the cluster and its nodes are gone, OSD data is unrecoverable and a
+new FSID is required. All-mon-store loss also cannot be restored from an
+old backup; see `docs/ceph-cluster-changelog.md` (mon RocksDB store
+corruption). Copy the backup directory off-cluster **before** any wipe if
+you still need the original FSID.
+
+---
+
+## 1. Authentication looks corrupted, monitors still respond
+
+Do **not** restart all OSD pods. GitOps sets
+`cephClusterSpec.storage.osdMaxUpdatesInParallel: 1` so operator-driven
+OSD rolls stay serial. Deleting every OSD at once
+(`kubectl delete pods -n rook-ceph -l app=rook-ceph-osd`) is the blast
+radius that runbook forbids: on a degraded cluster Rook #17224 relocate
+fallback returns empty and pods stick `Init:0/5`. See
+[`docs/ceph/osd-device-path-recovery.md`](../../../../../docs/ceph/osd-device-path-recovery.md).
+
+```bash
+# 1. Confirm mons answer
+kubectl exec -n rook-ceph deploy/rook-ceph-tools -- ceph status
+
+# 2. Inspect auth
+kubectl exec -n rook-ceph deploy/rook-ceph-tools -- ceph auth list
+
+# 3. Restart the operator only
 kubectl delete pod -n rook-ceph -l app=rook-ceph-operator
 
-# 4. Restart all OSD pods
-kubectl delete pods -n rook-ceph -l app=rook-ceph-osd
+# 4. If a single OSD is still stuck, audit paths first
+task rook:check-osd-device-paths
 ```
 
-### 2. If Monitor Database is Corrupted (CRITICAL RECOVERY)
+If `check-osd-device-paths` is green and one OSD still looks auth-stuck,
+bounce **that one** OSD. If paths are stale, use Case A in the device-path
+runbook (patch one `ROOK_BLOCK_PATH`, bounce one pod). Never bounce all
+six.
+
+---
+
+## 2. Monitor database corrupted (Kubernetes objects and the backup PVC still exist)
+
+Stop. Do not wipe host data. This path only works while `ceph-backup-pvc`
+still exists. If you already wiped nodes, go to section 3 and accept a
+new FSID.
 
 ```bash
-# STOP! Do not proceed without backups
+# 1. Confirm the PVC and a dated backup exist (mount the PVC as above)
+kubectl get cronjob,pvc -n rook-ceph rook-ceph-backup ceph-backup-pvc
+kubectl get cm -n rook-ceph -l backup-type=ceph-metadata --sort-by=.metadata.creationTimestamp
 
-# 1. Find latest backup
-kubectl get configmaps -n rook-ceph -l backup-type=ceph-metadata --sort-by=.metadata.creationTimestamp
+# 2. Copy the backup dir off-cluster, then identify the FSID you need
+#    (cluster-fsid.txt in that dated directory)
 
-# 2. Access backup data
-kubectl exec -it deployment/backup-pod -n rook-ceph -- ls -la /backup/
-
-# 3. Identify backup with correct FSID
-# Check each backup folder for cluster-fsid.txt
-
-# 4. If you have a backup with the original FSID:
-# Suspend HelmReleases
+# 3. Suspend HelmReleases
 flux suspend hr rook-ceph-cluster -n rook-ceph
 flux suspend hr rook-ceph -n rook-ceph
 
-# 5. Delete cluster but preserve secrets
+# 4. Delete the cluster object but keep the restored secrets
 kubectl delete cephcluster rook-ceph -n rook-ceph
-# Wait for deletion, remove finalizers if stuck
+# If it sticks: kubectl patch cephcluster rook-ceph -n rook-ceph --type=merge -p '{"metadata":{"finalizers":null}}'
 
-# 6. Restore secrets from backup
-kubectl delete secret rook-ceph-mon -n rook-ceph
-kubectl apply -f /backup/BACKUP_DATE/rook-ceph-mon.yaml
+# 5. Restore secrets from the copied YAML (not a path inside a missing pod)
+kubectl delete secret rook-ceph-mon rook-ceph-admin-keyring -n rook-ceph --ignore-not-found
+kubectl apply -f ./ceph-backup-BACKUP_DATE/rook-ceph-mon.yaml
+kubectl apply -f ./ceph-backup-BACKUP_DATE/rook-ceph-admin-keyring.yaml
+# If apply rejects resourceVersion/uid, strip those fields and retry.
 
-kubectl delete secret rook-ceph-admin-keyring -n rook-ceph
-kubectl apply -f /backup/BACKUP_DATE/rook-ceph-admin-keyring.yaml
-
-# 7. Resume HelmReleases
+# 6. Resume operator first, then the cluster
 flux resume hr rook-ceph -n rook-ceph
-# Wait for operator to be ready
+# wait until the operator is Ready
 flux resume hr rook-ceph-cluster -n rook-ceph
 ```
 
-### 3. Complete Cluster Loss (Last Resort)
+Do not restart all OSDs afterward. Let the operator bring them up one at
+a time. If an OSD sticks in `Init`, use the device-path runbook Case A.
+
+---
+
+## 3. Complete cluster loss (last resort: new FSID, OSD data gone)
+
+Use this only when there is no usable backup **or** host data has already
+been wiped (which also destroyed the in-cluster backup). This creates a
+**new** cluster. Original OSD contents cannot be recovered without the
+original FSID and the original BlueStore data still on disk. Wiping disks
+throws that data away.
+
+Copy anything still on `ceph-backup-pvc` off-cluster **before** the wipe.
+Once hostpath volumes are gone, the metadata backup is gone too.
 
 ```bash
-# Only if no backups exist or backups are unusable
-
-# 1. Accept data loss and create new cluster
+# 1. Accept data loss and a new FSID
 flux suspend hr rook-ceph-cluster -n rook-ceph
 flux suspend hr rook-ceph -n rook-ceph
 
-# 2. Clean everything
+# 2. Delete the CephCluster
 kubectl delete cephcluster rook-ceph -n rook-ceph
-# Remove finalizers if stuck
-kubectl patch cephcluster rook-ceph -n rook-ceph --type='merge' -p='{"metadata":{"finalizers":null}}'
+# If it sticks:
+kubectl patch cephcluster rook-ceph -n rook-ceph --type=merge -p '{"metadata":{"finalizers":null}}'
 
-# 3. Clean host data
-kubectl apply -f cleanup-all-nodes.yaml
-# Wait for completion
+# 3. Wipe OSD disks and /var/lib/rook via the Taskfile, not a missing YAML.
+#    Per node:  task rook:wipe-talos-1  (and talos-2, talos-3)
+#    All nodes + host rook dir:
+task rook:wipe-all-with-progress
+# Interactive prompts: the skip flag is global `task --yes rook:...`, not `--yes` after the task name.
 
-# 4. Resume HelmReleases
+# 4. Resume HelmReleases; Flux recreates an empty ceph-backup-pvc
 flux resume hr rook-ceph -n rook-ceph
 flux resume hr rook-ceph-cluster -n rook-ceph
-
-# 5. Run initial backup immediately
-kubectl apply -f initial-backup-job.yaml
 ```
 
-## Important Notes
-
-1. **FSID is critical** - Without the original FSID, OSDs with data cannot be recovered
-2. **Monitor secrets contain FSID** - These are the most critical backup files
-3. **Never clean host data without confirmed backups**
-4. **Test recovery procedures regularly in staging**
-
-## Backup Verification
+Do not apply `initial-backup-job.yaml`. The CronJob already exists
+(`0 3 * * *`). After the **new** cluster is healthy, optionally snapshot
+the new FSID:
 
 ```bash
-# Check backup status
-kubectl get configmaps -n rook-ceph -l backup-type=ceph-metadata
-
-# Verify backup contents
-kubectl exec -it deployment/backup-pod -n rook-ceph -- find /backup -name "cluster-fsid.txt" -exec cat {} \;
-
-# Check current cluster FSID
-kubectl get secret rook-ceph-mon -n rook-ceph -o jsonpath='{.data.fsid}' | base64 -d
+kubectl -n rook-ceph create job --from=cronjob/rook-ceph-backup manual-backup-$(date +%s)
 ```
 
-## Prevention Checklist
+That Job writes to the same in-cluster PVC. It is still not an
+off-cluster disaster-recovery copy.
 
-- [ ] Daily backups are running successfully
-- [ ] Backup storage has sufficient space
-- [ ] Recovery procedures tested in staging
-- [ ] Team knows emergency procedures
-- [ ] Monitoring alerts are configured
-- [ ] Documentation is up to date
+---
+
+## Important notes
+
+1. **FSID is critical.** Without the original FSID, OSDs with data cannot
+   be recovered.
+2. **Monitor secrets contain the FSID.** Those YAML files are the useful
+   part of this backup, and only while the PVC still exists.
+3. **Never wipe host data until the backup directory is copied off-cluster.**
+   The in-cluster copy does not survive the wipe.
+4. **Never restart all OSD pods** while the cluster is unhealthy. See
+   the #17224 runbook.
+5. Test recovery in staging if you have one. This cluster's metadata
+   backup is not a last-resort DR copy.
+
+## Prevention checklist
+
+- [ ] Daily CronJob `rook-ceph-backup` is succeeding
+- [ ] `ceph-backup-pvc` has space (50Gi, 7-day retention)
+- [ ] A recent dated directory has been copied **off-cluster** if you
+      care about FSID recovery after a wipe
+- [ ] `task rook:check-osd-device-paths` is green before any node reboot
+- [ ] This file still matches `backup-system.yaml`

--- a/kubernetes/apps/rook-ceph/rook-ceph/operator/csi-driver-rbac.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/operator/csi-driver-rbac.yaml
@@ -6,7 +6,11 @@
 # Vendored from ceph-csi-operator v1.0.1 deploy/multifile/csi-rbac.yaml (rbd + cephfs
 # subset only; nfs/nvmeof excluded), with the ServiceAccount names de-prefixed to match
 # rook's blank csiServiceAccountPrefix default and namespace set to rook-ceph.
-# Remove once rook ships the driver RBAC in the operator chart (likely v1.20.1+).
+# Keep until a ceph-csi-drivers chart (or equivalent) is added to GitOps.
+# Rook #17644 resolution was "install the CSI driver charts", not "v1.20.1
+# bakes RBAC into the operator chart". Charts are v1.20.4 and this file is
+# still required; deleting it reproduces FailedCreate: serviceaccount not
+# found and breaks all RBD/CephFS attach.
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/kubernetes/components/volsync/Readme.md
+++ b/kubernetes/components/volsync/Readme.md
@@ -20,7 +20,7 @@ kubernetes/components/volsync/
 - **Process**:
   - Takes snapshot of `${APP}` PVC
   - Uploads to local Ceph S3 bucket
-  - Retention: 24 hourly + 30 daily + 10 weekly + 6 monthly backups
+  - Retention: **6 hourly + 14 daily** + 10 weekly + 6 monthly backups (see `ceph/replicationsource.yaml`; reduced from 24/30)
   - Prunes old backups every 14 days
 
 ### 2. Remote NAS MinIO (`minio/`)
@@ -130,9 +130,10 @@ schedule: "0 5 * * *"    # Once daily at 5 AM
 ### Testing Schedule Changes
 
 ```bash
-# Manually trigger a backup to test
-kubectl create job test-backup-$(date +%s) \
-  --from=cronjob/volsync-${APP}-ceph
+# Manually trigger a backup (VolSync has no CronJob named volsync-${APP}-ceph;
+# the trigger lives on the ReplicationSource)
+kubectl patch replicationsource ${APP}-ceph --type merge \
+  -p "{\"spec\":{\"trigger\":{\"manual\":\"test-$(date +%s)\"}}}"
 
 # Check if the schedule is valid
 kubectl get replicationsource ${APP}-ceph -o yaml | grep schedule
@@ -163,7 +164,7 @@ kubectl patch replicationdestination ${APP}-dst \
 
 ## Daily Timeline Example
 
-With schedule distribution across 27 applications:
+With per-app schedules (38 Flux Kustomizations include this component):
 
 ```
 00:00 ──── [Ceph] 4-hour backup (apps at :00) ──── [MinIO] 6-hour backup (apps at :00) ─────
@@ -211,7 +212,8 @@ Common variables used across all configurations:
 | `VOLSYNC_COPYMETHOD` | `Snapshot` | How data is copied (Snapshot/Clone) | `Snapshot` |
 | `VOLSYNC_SNAPSHOTCLASS` | `csi-ceph-blockpool` | Volume snapshot class | `csi-ceph-blockpool` |
 | `VOLSYNC_STORAGECLASS` | `ceph-block` | Storage class for volumes | `ceph-block` |
-| `VOLSYNC_CACHE_CAPACITY` | `2Gi` | Cache volume size | **50% of PVC size** |
+| `VOLSYNC_CACHE_CAPACITY` | `2Gi` on sources, `1Gi` on the destination | Cache volume size | **50% of PVC size**; dest default is smaller than sources |
+| `VOLSYNC_CACHE_SNAPSHOTCLASS` | `ceph-block` | StorageClass for the cache PVC (name says SnapshotClass, value is a StorageClass) | Set this separately from `VOLSYNC_STORAGECLASS` |
 | `VOLSYNC_CAPACITY` | `5Gi` | Restored volume size | **Same as source PVC** |
 | `VOLSYNC_PUID` | `1000` | User ID for mover security context | `1000` |
 | `VOLSYNC_PGID` | `1000` | Group ID for mover security context | `1000` |
@@ -297,7 +299,11 @@ schedule: "0 2 * * *"
 
 ## Application Schedule Distribution
 
-To reduce IOPS contention and spread backup operations evenly, all 27 volsync-enabled applications have unique staggered schedules:
+38 Flux Kustomizations include `components/volsync`. Schedules are staggered
+but **not unique** (several apps share the same minute). Do not assume a
+2-3 app cap on simultaneous Ceph backups. Regenerated from
+`rg 'components/volsync' kubernetes/apps` plus each `ks.yaml` `VOLSYNC_SCHEDULE_*`
+(paperless-ngx uses component defaults). `litellm` is gone.
 
 | # | Namespace | Application | Ceph Schedule | MinIO Schedule | R2 Schedule | Priority |
 |---|-----------|-------------|---------------|----------------|-------------|----------|
@@ -308,38 +314,45 @@ To reduce IOPS contention and spread backup operations evenly, all 27 volsync-en
 | 5 | home-automation | matter-server | `20 */4 * * *` | `15 */6 * * *` | `20 1 * * *` | High |
 | 6 | ai | open-webui | `25 */4 * * *` | `30 */6 * * *` | `0 2 * * *` | High |
 | 7 | ai | qdrant | `30 */4 * * *` | `30 */6 * * *` | `5 2 * * *` | High |
-| 8 | ai | litellm | `35 */4 * * *` | `30 */6 * * *` | `10 2 * * *` | Medium |
+| 8 | ai | hermes | `35 */4 * * *` | `35 */6 * * *` | `10 2 * * *` | Medium |
 | 9 | ai | open-notebook | `40 */4 * * *` | `30 */6 * * *` | `15 2 * * *` | Medium |
 | 10 | ai | perplexica | `45 */4 * * *` | `45 */6 * * *` | `20 2 * * *` | Medium |
-| 11 | downloads | sonarr | `0 */4 * * *` | `45 */6 * * *` | `0 3 * * *` | Medium |
-| 12 | downloads | radarr | `5 */4 * * *` | `45 */6 * * *` | `5 3 * * *` | Medium |
-| 13 | downloads | lidarr | `10 */4 * * *` | `45 */6 * * *` | `10 3 * * *` | Medium |
-| 14 | downloads | readarr | `15 */4 * * *` | `0 */6 * * *` | `15 3 * * *` | Medium |
-| 15 | downloads | bazarr | `20 */4 * * *` | `0 */6 * * *` | `20 3 * * *` | Medium |
-| 16 | downloads | prowlarr | `25 */4 * * *` | `0 */6 * * *` | `25 3 * * *` | Medium |
-| 17 | downloads | sabnzbd | `30 */4 * * *` | `15 */6 * * *` | `30 3 * * *` | Medium |
-| 18 | downloads | qbittorrent | `35 */4 * * *` | `15 */6 * * *` | `35 3 * * *` | Medium |
-| 19 | downloads | cross-seed | `40 */4 * * *` | `15 */6 * * *` | `40 3 * * *` | Low |
-| 20 | downloads | autobrr | `45 */4 * * *` | `30 */6 * * *` | `45 3 * * *` | Low |
-| 21 | downloads | recyclarr | `50 */4 * * *` | `30 */6 * * *` | `50 3 * * *` | Low |
-| 22 | media | jellyfin | `55 */4 * * *` | `30 */6 * * *` | `0 4 * * *` | Medium |
-| 23 | media | calibre | `0 */4 * * *` | `45 */6 * * *` | `5 4 * * *` | Low |
-| 24 | media | calibre-web | `5 */4 * * *` | `45 */6 * * *` | `10 4 * * *` | Low |
-| 25 | selfhosted | n8n | `10 */4 * * *` | `45 */6 * * *` | `15 4 * * *` | Medium |
-| 26 | selfhosted | changedetection | `15 */4 * * *` | `0 */6 * * *` | `20 4 * * *` | Low |
-| 27 | selfhosted | rsshub | `20 */4 * * *` | `0 */6 * * *` | `25 4 * * *` | Low |
+| 11 | ai | agentmemory | `20 */4 * * *` | `20 */6 * * *` | `40 2 * * *` | Medium |
+| 12 | downloads | sonarr | `0 */4 * * *` | `45 */6 * * *` | `0 3 * * *` | Medium |
+| 13 | downloads | radarr | `5 */4 * * *` | `45 */6 * * *` | `5 3 * * *` | Medium |
+| 14 | downloads | lidarr | `10 */4 * * *` | `45 */6 * * *` | `10 3 * * *` | Medium |
+| 15 | downloads | readarr | `15 */4 * * *` | `0 */6 * * *` | `15 3 * * *` | Medium |
+| 16 | downloads | bazarr | `20 */4 * * *` | `0 */6 * * *` | `20 3 * * *` | Medium |
+| 17 | downloads | prowlarr | `25 */4 * * *` | `0 */6 * * *` | `25 3 * * *` | Medium |
+| 18 | downloads | sabnzbd | `30 */4 * * *` | `15 */6 * * *` | `30 3 * * *` | Medium |
+| 19 | downloads | qbittorrent | `35 */4 * * *` | `15 */6 * * *` | `35 3 * * *` | Medium |
+| 20 | downloads | cross-seed | `40 */4 * * *` | `15 */6 * * *` | `40 3 * * *` | Low |
+| 21 | downloads | autobrr | `45 */4 * * *` | `30 */6 * * *` | `45 3 * * *` | Low |
+| 22 | downloads | recyclarr | `50 */4 * * *` | `30 */6 * * *` | `50 3 * * *` | Low |
+| 23 | media | jellyfin | `55 */4 * * *` | `30 */6 * * *` | `0 4 * * *` | Medium |
+| 24 | media | calibre | `0 */4 * * *` | `45 */6 * * *` | `5 4 * * *` | Low |
+| 25 | media | calibre-web | `5 */4 * * *` | `45 */6 * * *` | `10 4 * * *` | Low |
+| 26 | media | plex | `35 */4 * * *` | `50 */6 * * *` | `35 3 * * *` | High |
+| 27 | media | seerr | `40 */4 * * *` | `55 */6 * * *` | `40 3 * * *` | Medium |
+| 28 | media | tdarr | `50 */4 * * *` | `20 */6 * * *` | `50 3 * * *` | Medium |
+| 29 | media | immich | `15 */4 * * *` | `45 */6 * * *` | `30 4 * * *` | High |
+| 30 | selfhosted | paperless-ngx | `0 */4 * * *` | `30 */6 * * *` | `0 2 * * *` | High |
+| 31 | selfhosted | n8n | `10 */4 * * *` | `45 */6 * * *` | `15 4 * * *` | Medium |
+| 32 | selfhosted | syncthing | `10 */4 * * *` | `45 */6 * * *` | `15 4 * * *` | Medium |
+| 33 | selfhosted | obsidian-livesync | `10 */4 * * *` | `45 */6 * * *` | `15 4 * * *` | Medium |
+| 34 | selfhosted | linkwarden | `10 */4 * * *` | `45 */6 * * *` | `15 4 * * *` | Medium |
+| 35 | selfhosted | changedetection | `15 */4 * * *` | `0 */6 * * *` | `20 4 * * *` | Low |
+| 36 | selfhosted | ntfy | `20 */4 * * *` | `50 */6 * * *` | `25 4 * * *` | Medium |
+| 37 | selfhosted | rsshub | `20 */4 * * *` | `0 */6 * * *` | `25 4 * * *` | Low |
+| 38 | selfhosted | rsshub-playwright | `25 */4 * * *` | `0 */6 * * *` | `30 4 * * *` | Low |
 
 ### Distribution Strategy
 
-- **Ceph (every 4 hours)**: Apps distributed across 12 time slots (5-minute intervals from :00 to :55)
-- **MinIO (every 6 hours)**: Apps distributed across 4 time slots (15-minute intervals: :00, :15, :30, :45)
-- **R2 (daily)**: Apps distributed across 5 hours (1:00 AM - 5:00 AM) in 5-minute intervals
+- **Ceph (every 4 hours)**: 5-minute slots from :00 to :55, but several apps share a slot (e.g. `:00` and `:10`)
+- **MinIO (every 6 hours)**: mostly :00/:15/:30/:45, with extra :20/:35/:50/:55 offsets
+- **R2 (daily)**: spread from 01:00 to 04:50, not a hard 5-hour unique grid
 
-This distribution ensures:
-- Maximum 2-3 apps backing up simultaneously to Ceph
-- Maximum 6-7 apps per MinIO window
-- Maximum 5-6 apps per R2 hour slot
-- Critical applications (databases, home-assistant) run earliest in backup windows
+Regenerate this table from git before trusting a "max N simultaneous" claim.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Intent

Fix Ceph/storage documentation from the homeops-docs-audit-storage report. This is production storage infrastructure; P0 findings are recovery procedures that would fail or cause harm if followed live.

P0-1: RECOVERY-PROCEDURES.md referenced objects that do not exist (deployment/backup-pod, cleanup-all-nodes.yaml, initial-backup-job.yaml). Rewrite against the live CronJob rook-ceph-backup and PVC ceph-backup-pvc in backup-system.yaml.

P0-2: the complete-loss / auth-corruption procedure restarted all OSDs (`kubectl delete pods -l app=rook-ceph-osd`) and contradicted docs/ceph/osd-device-path-recovery.md (Rook #17224). Verify against that runbook before rewriting. Do not restart all OSDs; operator-only then one OSD; point at Case A.

P0-3: backup-recovery-strategy.md described a restore path (mon-$NODE tarballs, busybox kubectl CronJob) that the live CronJob does not produce. Rewrite it as a description of backup-system.yaml and drop the tar/restore fiction. Do not leave both documents as if they were the same system.

P0-4: state explicitly, in the doc, that the in-cluster metadata backup is NOT a disaster-recovery backup of last resort. Complete cluster loss destroys it too, since ceph-backup-pvc lives on the same cluster (openebs-hostpath). Do not silently soften this into sounding safer than it is. Off-cluster copies were never implemented. After host wipe there is nothing to restore.

All P1/P2 findings from the audit: stale Rook/Ceph/Kubernetes version baseline (GitOps is Rook v1.20.4 / Ceph v20.2.3; Kubernetes machineconfig pin v1.36.1 vs tuppr v1.36.3 - document the pin conflict, do not claim a live kubectl version), missing changelog bump entries, CSI RBAC comment still saying remove at v1.20.1+ (keep until a ceph-csi-drivers chart is added; do not delete csi-driver-rbac.yaml), CephFS csi-rwx docs saying retire at v20.2.2+ while workaround remains on v20.2.3 (state that retirement is not implied by the image tag), OSD wipe Job image Reef v19.2.3 vs Tentacle v20.2.3, toolbox one-shot rook/ceph:v1.17.1, 2026-06-17 mClock drift vs GitOps (do not add ceph config set to GitOps until a live dump), EMQX README self-contradiction on /opt/init-api-keys bootstrap, performance-review still reading as a current action plan, VolSync retain/table/test-job wrong, CLAUDE.md hourly MinIO+NFS, Dragonfly/CNPG/JetStream README staleness, toolbox/pg.md teaching ad-hoc ceph config set, pg.md vs changelog P4, Squid grafana link, sample Prometheus alerts.

Do NOT touch the csi-rwx retirement question (C1 in the report) - that is being verified and handled separately by a sibling task. Do not delete ceph-filesystem-rwx or the csi-rwx subvolumegroup. Do not change any live cluster resource or PVC - documentation only, except pinning the WipeDiskJob template image to match cluster cephImage.tag so the recovery wipe uses Tentacle not Reef. Do not GitOps-ify the 2026-06-17 recovery throttles (C2).

## What Changed

- Rewrote `RECOVERY-PROCEDURES.md` and `docs/ceph/backup-recovery-strategy.md` to describe the live `rook-ceph-backup` CronJob and `ceph-backup-pvc` (`backup-system.yaml`) instead of nonexistent objects (`deployment/backup-pod`, `cleanup-all-nodes.yaml`, `initial-backup-job.yaml`) and a fictitious mon-tarball/busybox-CronJob restore path; replaced the complete-loss/auth-corruption procedure's blanket `kubectl delete pods -l app=rook-ceph-osd` restart with an operator-only-then-single-OSD sequence aligned to `docs/ceph/osd-device-path-recovery.md` (Case A), and added explicit statements that the in-cluster metadata backup is not a disaster-recovery backup of last resort since `ceph-backup-pvc` is `openebs-hostpath` on the same cluster and off-cluster copies were never implemented.
- Refreshed version/config baselines and staleness across docs: `docs/ceph-cluster-changelog.md`, `docs/ceph-performance-review.md`, `docs/ceph/osd-store-corruption-recovery.md`, `docs/ceph/pg.md`, `docs/ceph/toolbox.md`, `docs/pvc/pvc-health-checks.md`, `CLAUDE.md`, `AGENTS.md`, and the database READMEs (CloudNative-PG, Dragonfly, EMQX, JetStream) - correcting the Rook/Ceph/Kubernetes version baseline (Rook v1.20.4/Ceph v20.2.3, documenting the Talos v1.36.1 vs tuppr v1.36.3 pin conflict instead of a live kubectl claim), the VolSync retention/app-table/schedule description (Ceph 4h/MinIO 6h/R2 daily, no NFS source), and the EMQX exporter bootstrap comment.
- Updated in-repo code comments to reflect current state rather than removal deadlines: kept `csi-driver-rbac.yaml` with a note to remove only once a `ceph-csi-drivers` chart is added, and clarified the CephFS `csi-rwx` workaround/subvolumegroup comments to state retirement is not implied by the Ceph image tag (v20.2.3).
- Pinned `.taskfiles/rook/templates/WipeDiskJob.tmpl.yaml`'s image from `quay.io/ceph/ceph:v19.2.3` to `v20.2.3` to match the cluster's `cephImage.tag`, and updated the CloudNative-PG `ks.yaml` health-check comment for the resolved talos-3 BIOS issue (3 instances).

## Risk Assessment

✅ Low: Documentation-only change (plus one explicitly authorized image-tag pin in WipeDiskJob.tmpl.yaml); every factual claim I spot-checked against live GitOps manifests (versions, schedules, retention counts, consumer lists, mClock config, compression settings) was accurate, and all four P0 findings plus the enumerated P1/P2 items from the audit are addressed without touching live cluster resources or the csi-rwx workaround.

## Testing

This is a documentation-only change (plus one explicitly-permitted image tag pin), so there is no unit-test suite to run; I instead cross-checked every P0 and a sample of P1 claims in the rewritten docs directly against the live GitOps source of truth (backup-system.yaml, helmrelease/ocirepository tags, tuppr upgrade manifest, volsync replicationsource.yaml files, and the osd-device-path-recovery.md runbook) and found the documentation now accurately describes the real CronJob/PVC-backed backup system, correctly forbids the all-OSD-restart and points to Case A, explicitly states the in-cluster backup is not last-resort DR, and matches the current Rook/Ceph/Kubernetes version baseline including the machineconfig-vs-tuppr pin conflict. All modified YAML parses cleanly and the only non-comment/non-doc edit is the permitted WipeDiskJob image pin; no findings to report.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"963ecd92731c8e8c4f14103f1639f7bde769cb36","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `git diff --stat d72f5b5..963ecd9 to enumerate all changed files`
- `Read kubernetes/apps/rook-ceph/rook-ceph/backup/backup-system.yaml and confirmed CronJob rook-ceph-backup + PVC ceph-backup-pvc (openebs-hostpath, same-cluster) match RECOVERY-PROCEDURES.md and backup-recovery-strategy.md claims (P0-1, P0-3, P0-4)`
- `Read RECOVERY-PROCEDURES.md end-to-end: confirmed fictional objects (backup-pod Deployment, cleanup-all-nodes.yaml, initial-backup-job.yaml) and the mass-OSD-delete command appear only as explicit negations/warnings, never as runnable steps (P0-1, P0-2)`
- `grep osdMaxUpdatesInParallel across helmrelease.yaml/docs to confirm the 'operator-only then one OSD, point at Case A' rewrite matches the live spec.storage.osdMaxUpdatesInParallel:1 setting and docs/ceph/osd-device-path-recovery.md Case A section (P0-2)`
- `Read docs/ceph/backup-recovery-strategy.md end-to-end: confirmed it now describes backup-system.yaml (not tarball/busybox restore fiction) and states explicitly it is NOT a last-resort DR backup (P0-3, P0-4)`
- <code>Confirmed backup-system.yaml is wired into the live cluster Kustomization (`../backup` in cluster/kustomization.yaml), matching the doc&#39;s claim</code>
- `Cross-checked docs/ceph-cluster-changelog.md version-baseline table against kubernetes/apps/rook-ceph/rook-ceph/{operator,cluster}/ocirepository.yaml (Rook v1.20.4), cluster/helmrelease.yaml (cephImage.tag v20.2.3), and talos/machineconfig.yaml.j2 vs kubernetes/apps/system-upgrade/tuppr/upgrades/kubernetesupgrade.yaml (v1.36.1 pin vs tuppr v1.36.3) - all match, no live-kubectl-version claim made`
- `Diffed the non-markdown files (WipeDiskJob.tmpl.yaml, ks.yaml, externalsecret.yaml, cephfs-rwx-storageclass.yaml, cephfs-rwx-subvolumegroup.yaml, csi-driver-rbac.yaml) to confirm only comment text changed, except the WipeDiskJob image tag v19.2.3->v20.2.3 (the one explicitly permitted non-doc edit)`
- `Confirmed cephfs-rwx-storageclass.yaml, cephfs-rwx-subvolumegroup.yaml, and csi-driver-rbac.yaml were not deleted`
- `Cross-checked kubernetes/components/volsync/Readme.md retention table (6 hourly+14 daily+10 weekly+6 monthly for ceph; 14/8/6 for MinIO) against the actual ceph/replicationsource.yaml and minio/replicationsource.yaml values - exact match`
- `python3 -c "yaml.safe_load_all(...)" over every modified YAML file to confirm syntactic validity`
- `git status --short on the worktree to confirm no live cluster resource or stray file changes beyond the intended docs/comment/image-pin diff`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
