### PR TITLE
fix(actions-runner-system): correct false-firing alert and align docs with live state

### DIFF
--- a/docs/downloads/sabnzbd-disk-space-runbook.md
+++ b/docs/downloads/sabnzbd-disk-space-runbook.md
@@ -7,7 +7,7 @@ stalls. The disk that fills is the **2 Ti `shared-downloads` CephFS RWX PVC**
 `usenet/complete/` — *not* the RBD `sabnzbd-incomplete` scratch volume.
 
 - **Guardrails in Git** → `kubernetes/apps/downloads/maintenance/` (janitor CronJob + capacity alert, this incident's output)
-- **Prior art** → the 2026-06-24 `_UNPACK_` cleanup (memory/`reference_sabnzbd_complete_unpack_diskfull`)
+- **Prior art** → 2026-06-24 `_UNPACK_` cleanup (PR path not in this repo; see this runbook's incident notes and `kubernetes/apps/downloads/maintenance/`)
 - **Ceph-side context** → [`../ceph-cluster-changelog.md`](../ceph-cluster-changelog.md)
 
 ---
@@ -143,9 +143,12 @@ same as every other rule in this repo.)
 
 - **SAB's disk thresholds are runtime state, not GitOps.** `complete_free=100G`,
   `download_free=100G` and `direct_unpack=1` were set via the SAB API
-  (2026-06-24) and live in the sabnzbd **config PVC** — they survive restarts
-  but are invisible in Git. If the config PVC is ever rebuilt, re-apply them
-  via `api?mode=set_config`.
+  (2026-06-24) and live in the sabnzbd **config PVC** - they survive restarts
+  but are invisible in Git. Live-confirmed 2026-08-21:
+  `direct_unpack=true`, `complete_free=100G`, `download_free=100G`.
+  If the config PVC is ever rebuilt, re-apply them via `api?mode=set_config`.
+  TRaSH still recommends Direct Unpack OFF; this cluster's standing runtime
+  value is ON.
 - The Radarr-grabbed happy path is correctly configured and was NOT the leak
   (`enableCompletedDownloadHandling=true`, `autoRedownloadFailed=true`,
   `downloadClientWorkingFolders=_UNPACK_|_FAILED_`, SAB `fail_hopeless_jobs=1`).

--- a/docs/media-stack.md
+++ b/docs/media-stack.md
@@ -1,34 +1,44 @@
 # Media Stack
 
-Architecture and operational reference for the downloads, management, and media server pipeline. Covers Usenet acquisition, automated library management, quality control, subtitle management, and distributed GPU transcoding.
+Architecture and operational reference for the downloads, management, and media server pipeline. Covers Usenet acquisition, automated library management, quality control, subtitle management, and GPU transcoding.
 
 ---
 
 ## Overview
 
-The media stack is split across three Kubernetes namespaces:
+The media stack is split across two Kubernetes namespaces (`default` is empty):
 
 | Namespace | Purpose | Key Apps |
 |-----------|---------|----------|
-| `downloads` | Acquisition + library management | SABnzbd, Sonarr, Radarr, Lidarr, Readarr, Prowlarr, Bazarr, Recyclarr, Autobrr, FlareSolverr |
-| `media` | Media servers + post-processing | Jellyfin, Immich, Tdarr, Calibre-Web |
-| `default` | Ebook ingestion pipeline | Calibre-Web-Automated, Calibre-Downloader |
+| `downloads` | Acquisition + library management | SABnzbd, Sonarr, Radarr, Lidarr, Readarr, Prowlarr, Bazarr, Recyclarr, Autobrr, FlareSolverr, reading-glasses |
+| `media` | Media servers + post-processing | Jellyfin, Plex, Seerr, Immich, Tdarr, Calibre-Web-Automated, Calibre-Downloader |
 
-Flow: **Indexers** -> Prowlarr -> *arr apps -> SABnzbd -> imports to NAS -> Jellyfin serves -> Tdarr transcodes in place.
+`default/kustomization.yaml` has `resources: []`. CWA + Calibre-Downloader live under `media/calibre/` and Flux-target `media`.
+
+`media/calibre-web/` still exists on disk but is **not** listed in `media/kustomization.yaml`, so Flux never applies it (orphaned leftover next to CWA).
+
+In `downloads`, **autobrr is live**. `cross-seed` and `qbittorrent` are commented out in `downloads/kustomization.yaml`.
+
+Flow: **Indexers** -> Prowlarr -> *arr apps -> SABnzbd -> imports to NAS -> Jellyfin/Plex serve -> Tdarr transcodes in place to AV1.
 
 ---
 
 ## Storage Architecture
 
-Storage is intentionally split between CephFS (transient downloads) and NFS (permanent media):
+Storage is split between CephFS (complete downloads), Ceph block (SAB incomplete scratch), and NFS (permanent media):
 
 | Volume | Backing | Access | Size | Purpose |
 |--------|---------|--------|------|---------|
-| `shared-downloads-pvc` | CephFS (RWX) | RWX | 2 TiB | Active downloads, unpack workspace |
+| `shared-downloads` | `ceph-filesystem-rwx` (RWX) | RWX | 2 Ti | `usenet/complete/` and other download scratch |
+| `sabnzbd-incomplete` | `ceph-block` (RWO) | RWO | 1500 Gi | SAB article-assembly (`download_dir`); bind-mounted **over** `/data/downloads/usenet/incomplete` |
 | `{app}-config` | Ceph block (RWO) | RWO | 1-10 Gi | Per-app config PVCs with Volsync backup |
 | NFS `/mnt/storage/Media` | NAS (NFS) | RWX | ~40+ TiB | Permanent media library |
 | `immich-library` | CephFS (RWX) | RWX | 100 Gi | Photos |
 | `jellyfin-metadata` | Ceph block | RWO | 50 Gi | Jellyfin thumbnails/metadata |
+
+Manifests: `kubernetes/apps/downloads/pvc/app/shared-downloads.yaml` and `sabnzbd-incomplete.yaml`. There is no `shared-downloads-pvc.yaml`.
+
+Incomplete is **not** on the shared PVC. Since PR #983 it is a separate RBD volume overlaying that path in the sab pod. `du` inside sab will miss a ghost tree on CephFS under the mount. Full incident notes: [`downloads/sabnzbd-disk-space-runbook.md`](downloads/sabnzbd-disk-space-runbook.md). Do not duplicate incomplete-path settings here.
 
 ### Hardlink limitation
 
@@ -38,19 +48,20 @@ Downloads live on CephFS, media lives on NFS -- **hardlinks are impossible acros
 
 | Container path | Source |
 |----------------|--------|
-| `/data/downloads` | `shared-downloads-pvc` (all download + *arr apps) |
-| `/data/nas-media` | NFS mount `nas.${SECRET_DOMAIN}:/mnt/storage/Media` (read-write for *arr imports) |
+| `/data/downloads` | `shared-downloads` (all download + *arr apps) |
+| `/data/downloads/usenet/incomplete` | `sabnzbd-incomplete` overlay, **sab pod only** |
+| `/data/nas-media` | NFS mount `nas.${SECRET_DOMAIN}:/mnt/storage/Media` (read-write for *arr imports; read-only on Jellyfin) |
 | `/media` | Same NFS mount, alternative path used by Tdarr and Jellyfin |
 
 ---
 
 ## Application Reference
 
-### SABnzbd — Usenet download client
+### SABnzbd - Usenet download client
 
 **Namespace:** `downloads` | **Image:** `ghcr.io/home-operations/sabnzbd` | **Hostname:** `sabnzbd.${SECRET_DOMAIN}`
 
-Categories map to the *arr apps:
+Categories map to the *arr apps. The init container also creates audiobooks, comics, magazines, and other:
 
 | Category | Folder | Consumed by |
 |----------|--------|-------------|
@@ -61,16 +72,16 @@ Categories map to the *arr apps:
 
 **Critical UI settings (not in GitOps):**
 - Article Cache: **1 GB**
-- Direct Unpack: **OFF** (TRaSH recommendation)
+- Direct Unpack: **ON** (`direct_unpack=1`). Live-confirmed 2026-08-21 via SAB API; set 2026-06-24 with `complete_free=100G` / `download_free=100G`. TRaSH still recommends OFF; this cluster keeps ON as runtime state on the config PVC. See the [disk-space runbook](downloads/sabnzbd-disk-space-runbook.md).
 - Disable **ALL Sorting** (the *arr apps handle renaming)
 - Abort jobs that cannot be completed: **ON**
 - Action on encrypted RAR: **Abort**
-- Incomplete: `/data/downloads/usenet/incomplete`
-- Complete: `/data/downloads/usenet/complete`
+- Incomplete: `/data/downloads/usenet/incomplete` (RBD overlay)
+- Complete: `/data/downloads/usenet/complete` (`shared-downloads`)
 
 The init container pre-creates the category subdirectories on the shared PVC.
 
-### Prowlarr — Indexer manager
+### Prowlarr - Indexer manager
 
 Central proxy for all indexers. All *arr apps should be registered in `Settings > Apps` and pull indexer config from Prowlarr. Do **not** add indexers directly to Sonarr/Radarr/Lidarr.
 
@@ -80,7 +91,7 @@ Service DNS registered in Prowlarr:
 - `http://lidarr.downloads.svc.cluster.local:8080`
 - `http://readarr.downloads.svc.cluster.local:8787`
 
-### Sonarr / Radarr / Lidarr / Readarr — Library managers
+### Sonarr / Radarr / Lidarr / Readarr - Library managers
 
 All four follow the same pattern. Quality profiles and custom formats are managed declaratively by **Recyclarr** (see below).
 
@@ -112,7 +123,7 @@ Lidarr track format:
 - Propers and Repacks: **Do Not Prefer** (custom formats handle scoring)
 - Download clients point to `sabnzbd.downloads.svc.cluster.local:8080` with the matching category
 
-### Recyclarr — Declarative quality config
+### Recyclarr - Declarative quality config
 
 **File:** `kubernetes/apps/downloads/recyclarr/app/config/recyclarr.yml`
 **Schedule:** Daily CronJob (`@daily`)
@@ -132,14 +143,15 @@ kubectl -n downloads create job --from=cronjob/recyclarr recyclarr-manual-$(date
 | Radarr | SQP-1 (2160p) | Streaming quality 2160p with `min_format_score: 2000` |
 
 **Custom format categories applied:**
-- **Unwanted**: AV1, BR-DISK, LQ, x265 (HD), 3D, Bad Dual Groups, No-RlsGroup, Obfuscated, Retags, Scene
+- **Unwanted (Sonarr)**: AV1, BR-DISK, LQ, x265 (HD), Bad Dual Groups, No-RlsGroup, Obfuscated, Retags, Scene
+- **Unwanted (Radarr)**: the Sonarr set plus **3D** (Radarr-only; do not toggle 3D on Sonarr from this table)
 - **Repacks**: Repack/Proper, Repack2, Repack3
 - **Streaming services** (Sonarr): AMZN, ATVP, DCU, DSNP, HBO, HMAX, HULU, iT, MAX, NF, PCOK, PMTP, SHO, STAN
 - **Movie versions** (Radarr): Criterion Collection, Hybrid, Remaster, IMAX, IMAX Enhanced
 - **HDR** (WEB-2160p): DV (WEBDL)
 - **Trusted groups** (Radarr): hallowed
 
-### Bazarr — Subtitle management
+### Bazarr - Subtitle management
 
 **TRaSH-recommended scoring:**
 
@@ -150,28 +162,37 @@ kubectl -n downloads create job --from=cronjob/recyclarr recyclarr-manual-$(date
 
 Connects to Sonarr and Radarr for series/movie metadata. Provider priority: OpenSubtitles.com > Podnapisi > Supersubtitles > Addic7ed.
 
-### Cross-Seed + Autobrr
+### Autobrr
 
-Cross-Seed matches completed downloads against torrent indexers for seeding without re-download. Autobrr monitors release feeds for instant snatches. Both integrate with qBittorrent and SABnzbd (commented out in current kustomization but the infrastructure exists).
+Autobrr is deployed (`downloads/kustomization.yaml`). Cross-Seed and qBittorrent remain commented out; Autobrr's torrent-side integrations are unused until those are enabled.
 
 ---
 
-## Tdarr — Distributed transcoding
+## Tdarr - GPU transcoding
 
 **Namespace:** `media` | **Hostname:** `tdarr.${SECRET_DOMAIN}`
 
-Deployed as a single HelmRelease with two controllers:
+Not a DaemonSet. After the i915 -> xe migration, only talos-3 advertises GPU
+(`gpu.intel.com/xe: 99` on the B70; talos-1/2 report 0). See
+[`ai-gpu-changelog.md`](ai-gpu-changelog.md).
 
 | Controller | Type | Purpose | GPU |
 |-----------|------|---------|-----|
 | `tdarr` | Deployment (1 pod) | Web UI, orchestrator, database | No |
-| `tdarr-node` | DaemonSet (1 pod per K8s node) | Transcode workers | `gpu.intel.com/i915: 1` each |
+| `tdarr-node` | Deployment (`replicas: 1`) | Transcode worker on the xe node (talos-3 / B70) | `gpu.intel.com/xe: 1` |
 
-This gives **3 parallel GPU transcodes** across talos-1, talos-2, talos-3. The server has `internalNode=false` so it doesn't compete for GPU.
+Optional external Windows node via Service `tdarr-node-lb` (`10.50.0.54:8266`,
+`tdarr/app/externalservice.yaml`). Live UI (2026-08-21): k8s node `talos-3`
+(`transcodegpuWorkers=1`) plus `desktop-aviator` (`transcodegpuWorkers=2`).
+Stale registrations for talos-1/2 may still appear with GPU workers at 0.
+
+The server has `internalNode=false` so it doesn't compete for GPU. Expect
+1 `tdarr-*` server pod + 1 `tdarr-tdarr-node-*` worker on talos-3, not three
+workers.
 
 ### Worker environment
 
-Each worker pod gets:
+The k8s worker pod gets:
 ```
 serverIP=tdarr.media.svc.cluster.local
 serverPort=8266
@@ -181,30 +202,39 @@ transcodecpuWorkers=0      # Force GPU usage
 healthcheckgpuWorkers=1
 healthcheckcpuWorkers=1
 nodeName=<k8s pod nodeName> # Registers with pod's scheduling node
+ffmpegVersion=7
 ```
 
-### Plugin stack (configured in Tdarr UI)
+### Transcode flow (configured in Tdarr UI, not Git)
 
-Per library:
+Classic Boosh HEVC plugin stack is **not** in use (`pluginIDs` empty). Both
+libraries use Tdarr Flow `movies_av1_nvenc_v1`, named
+**Movies AV1 (QSV/B70 xe) - DV-safe v4**.
 
-1. `Migz-Remove Image Formats From File` — strip embedded thumbnails
-2. `Lmg1-Reorder Streams` — main audio/subtitle tracks first
-3. `Boosh-Transcode Using QSV GPU & FFMPEG` — HEVC transcode
-4. `New File Size Check` — verify output is smaller
+Libraries (2026-08-21):
 
-Boosh plugin configuration:
+| Library | Folder | Flow |
+|---------|--------|------|
+| Series | `/media/TV-Shows` | `movies_av1_nvenc_v1` |
+| Movies AV1 | `/media/Movies` | `movies_av1_nvenc_v1` |
+
+Flow encoder plugins (Community `ffmpegCommandSetVideoEncoder`):
 
 | Setting | Value |
 |---------|-------|
-| `encoder` | `hevc` |
-| `container` | `mkv` |
-| `target_bitrate_modifier` | `0.5` |
-| `encoder_speedpreset` | `slow` |
-| `enable_10bit` | `false` |
+| `outputCodec` | `av1` |
+| `hardwareType` | `qsv` |
+| `hardwareEncoding` / `hardwareDecoding` | `true` |
+| container | `mkv` |
+| quality ladders | cq24 / cq26 / cq28 (`ffmpegQuality` 22/23/24 with quality flag off; CQ via custom args) |
+
+The flow skips files that are already AV1 and has DV-detect / HDR-survival
+guards. The flow **id** still says `nvenc`; the live plugins are QSV on the B70.
 
 ### Library file type filter
 
-Tdarr cannot process disc images (`.iso`). Set allowed container extensions to:
+Tdarr cannot process disc images (`.iso`). Live `containerFilter` on both
+libraries:
 ```
 mkv,mp4,avi,ts,mov,m4v,wmv,flv,webm
 ```
@@ -218,11 +248,13 @@ BR-DISK and ISO files are blocked going forward:
 
 ---
 
-## Jellyfin — Media server
+## Jellyfin - Media server
 
-**Namespace:** `media` | **LoadBalancer IP:** `10.50.0.50` | **GPU:** `gpu.intel.com/i915: 1`
+**Namespace:** `media` | **LoadBalancer IP:** `10.50.0.50` | **GPU:** `gpu.intel.com/xe: 1`
 
 Single-pod deployment reading the NFS media mount read-only at `/data/nas-media`. Intel GPU handles hardware transcoding for any clients that can't direct play (rare with the SQP-1 profile since streaming-quality content is widely compatible).
+
+Plex is also deployed in `media` and claims `gpu.intel.com/xe: 1` (`plex/app/helmrelease.yaml`). Seerr is deployed in `media`.
 
 ---
 
@@ -237,7 +269,7 @@ User adds movie to Radarr
   ├─> Best release sent to SABnzbd with category=movies
   │   └─> Downloaded to /data/downloads/usenet/complete/movies/
   │
-  ├─> SABnzbd post-processes (par2 repair, unrar)
+  ├─> SABnzbd post-processes (par2 repair, unrar; Direct Unpack ON)
   │
   ├─> Radarr imports to /data/nas-media/Movies/
   │   └─> File is copied (not hardlinked) due to CephFS -> NFS boundary
@@ -245,11 +277,12 @@ User adds movie to Radarr
   │
   ├─> Bazarr detects new file, downloads subtitles
   │
-  ├─> Jellyfin library scan picks up the new file
+  ├─> Jellyfin / Plex library scan picks up the new file
   │
-  └─> Tdarr library scan queues for health check
-      └─> If H.264: transcode to HEVC via Intel QSV on one of 3 GPU workers
-      └─> Replaces file in place (/media = /data/nas-media)
+  └─> Tdarr library scan queues for health check / transcode
+      └─> If not already AV1: transcode to AV1 via Intel QSV (B70 on talos-3)
+          and/or the external Windows node
+      └─> Replaces file in place (/media = NAS Media)
 ```
 
 ---
@@ -290,26 +323,27 @@ After direct deletion, trigger a rescan in Radarr so it marks the movies as miss
 kubectl -n media get pods -l app.kubernetes.io/name=tdarr -o wide
 ```
 
-Expect 1 `tdarr-*` server pod + 3 `tdarr-tdarr-node-*` worker pods (one on each node). The Tdarr UI shows worker stats under Nodes Overview.
+Expect 1 `tdarr-*` server pod + 1 `tdarr-tdarr-node-*` worker on talos-3. The Tdarr UI shows worker stats under Nodes Overview.
 
 ### Monitoring GPU usage
 
 ```sh
-kubectl get nodes -o json | jq -r '.items[] | "\(.metadata.name): gpu.intel.com/i915=\(.status.allocatable."gpu.intel.com/i915" // "0")"'
+kubectl get nodes -o json | jq -r '.items[] | "\(.metadata.name): gpu.intel.com/xe=\(.status.allocatable."gpu.intel.com/xe" // "0")"'
 ```
 
-Each Meigao Venus node reports `99` (the Intel device plugin uses shared mode up to 99 concurrent pods).
+Only the B70 node (talos-3) reports `99`. `gpu.intel.com/i915` is 0 on every node
+after the xe migration.
 
 ### Finding which *arr app is failing imports
 
 Check Sonarr/Radarr Activity > History for failed imports. Common causes:
 - File already exists at target path (unmonitored duplicate)
-- Permission issue on NFS (should not happen — fsGroup=2000 across all apps)
+- Permission issue on NFS (should not happen -- fsGroup=2000 across all apps)
 - Quality profile rejection (check custom format score in release details)
 
 ### Backup and recovery
 
-All config PVCs have Volsync with triple backup (Ceph snapshots every 4h, NAS MinIO every 6h, Cloudflare R2 daily). The shared-downloads-pvc is **not** backed up (transient data). The NAS media library is backed up at the NAS level, separately from cluster Volsync.
+All config PVCs have Volsync with triple backup (Ceph snapshots every 4h, NAS MinIO every 6h, Cloudflare R2 daily). The `shared-downloads` PVC is **not** backed up (transient data). `sabnzbd-incomplete` is disposable scratch with no Volsync. The NAS media library is backed up at the NAS level, separately from cluster Volsync.
 
 ---
 
@@ -325,17 +359,21 @@ All config PVCs have Volsync with triple backup (Ceph snapshots every 4h, NAS Mi
 | Prowlarr | `kubernetes/apps/downloads/prowlarr/` |
 | Bazarr | `kubernetes/apps/downloads/bazarr/` |
 | Recyclarr config | `kubernetes/apps/downloads/recyclarr/app/config/recyclarr.yml` |
-| Shared downloads PVC | `kubernetes/apps/downloads/pvc/app/shared-downloads-pvc.yaml` |
+| Shared downloads PVC | `kubernetes/apps/downloads/pvc/app/shared-downloads.yaml` |
+| SAB incomplete PVC | `kubernetes/apps/downloads/pvc/app/sabnzbd-incomplete.yaml` |
+| SAB disk-space runbook | `docs/downloads/sabnzbd-disk-space-runbook.md` |
 | Jellyfin | `kubernetes/apps/media/jellyfin/` |
+| Plex | `kubernetes/apps/media/plex/` |
 | Tdarr | `kubernetes/apps/media/tdarr/` |
+| GPU changelog | `docs/ai-gpu-changelog.md` |
 | Volsync component | `kubernetes/components/volsync/` |
 
 ---
 
 ## References
 
-- [TRaSH Guides](https://trash-guides.info/) — quality profile recommendations, naming schemes, custom formats
-- [Servarr Wiki](https://wiki.servarr.com/) — official *arr documentation
-- [Recyclarr Docs](https://recyclarr.dev/) — declarative *arr config
-- [Tdarr Docs](https://docs.tdarr.io/) — transcoding and distributed setup
-- [bjw-s app-template](https://github.com/bjw-s-labs/helm-charts) — Helm chart used for most deployments
+- [TRaSH Guides](https://trash-guides.info/) - quality profile recommendations, naming schemes, custom formats
+- [Servarr Wiki](https://wiki.servarr.com/) - official *arr documentation
+- [Recyclarr Docs](https://recyclarr.dev/) - declarative *arr config
+- [Tdarr Docs](https://docs.tdarr.io/) - transcoding and distributed setup
+- [bjw-s app-template](https://github.com/bjw-s-labs/helm-charts) - Helm chart used for most deployments

--- a/docs/organisation-services-1password-setup.md
+++ b/docs/organisation-services-1password-setup.md
@@ -2,11 +2,21 @@
 
 This guide covers creating 1Password items for each new organisation service that will be deployed to the Home-Ops Kubernetes cluster. Each item stores secrets that are pulled into the cluster via `ExternalSecret` resources backed by the `onepassword` ClusterSecretStore.
 
+Vaults (case-sensitive):
+
+- ESO ClusterSecretStore `onepassword` uses `Homelab`, `Automation`, and `Services`.
+- Bootstrap/Talos `vals` uses a different vault, `Home-Lab` (`ref+op://Home-Lab/...`). Do not mix them.
+
+PostgreSQL hostname is **not** a 1Password field. App ExternalSecrets pin
+`postgres-17-rw.database.svc.cluster.local` in the template (GitOps hardcode after
+the 2026-05-31 1Password/ESO cutover and later postgres-host pinning). Do not add
+`POSTGRES_DB_HOST` to new items.
+
 ---
 
 ## Prerequisites
 
-1. **1Password vault access** -- You must have write access to the 1Password vault connected to the cluster's `onepassword` ClusterSecretStore.
+1. **1Password vault access** -- You must have write access to the 1Password vault connected to the cluster's `onepassword` ClusterSecretStore (`Homelab` for these org services).
 2. **CloudNative-PG superuser password** -- The `cloudnative-pg` 1Password item must already exist and contain the `POSTGRES_SUPER_PASS` field. This is the superuser password for the `postgres-17` cluster in the `database` namespace. You do not need to duplicate it into each service's item; the ExternalSecret pulls from both the app item and the `cloudnative-pg` item automatically.
 3. **`op` CLI (optional)** -- If you prefer command-line creation, install the [1Password CLI](https://developer.1password.com/docs/cli/get-started/) and sign in.
 
@@ -17,10 +27,10 @@ This guide covers creating 1Password items for each new organisation service tha
 Each service that uses PostgreSQL follows this pattern:
 
 1. The app's **ExternalSecret** extracts fields from _two_ 1Password items:
-    - The app's own item (e.g., `linkwarden`) -- contains DB name, host, user, password, and any app-specific secrets.
+    - The app's own item (e.g., `linkwarden`) -- contains DB name, user, password, and any app-specific secrets.
     - The shared `cloudnative-pg` item -- contains `POSTGRES_SUPER_PASS`.
 
-2. The ExternalSecret templates these into a Kubernetes Secret with both the app's env vars and the **`INIT_POSTGRES_*`** env vars consumed by the `postgres-init` init container.
+2. The ExternalSecret templates these into a Kubernetes Secret with both the app's env vars and the **`INIT_POSTGRES_*`** env vars consumed by the `postgres-init` init container. `INIT_POSTGRES_HOST` is hardcoded to `postgres-17-rw.database.svc.cluster.local` in the template, not mapped from a 1Password field.
 
 3. The `postgres-init` container (`ghcr.io/home-operations/postgres-init`) uses the superuser password to connect to the PostgreSQL cluster, create the database and role if they don't exist, and grant permissions -- all before the main app container starts.
 
@@ -29,7 +39,7 @@ Each service that uses PostgreSQL follows this pattern:
 | Field                      | Purpose                                                                  |
 | -------------------------- | ------------------------------------------------------------------------ |
 | `INIT_POSTGRES_DBNAME`     | Database name to create (mapped from `POSTGRES_DB_NAME`)                 |
-| `INIT_POSTGRES_HOST`       | PostgreSQL host (mapped from `POSTGRES_DB_HOST`)                         |
+| `INIT_POSTGRES_HOST`       | PostgreSQL host (hardcoded `postgres-17-rw.database.svc.cluster.local`)  |
 | `INIT_POSTGRES_USER`       | Database role/user to create (mapped from `POSTGRES_DB_USER_NAME`)       |
 | `INIT_POSTGRES_PASS`       | Password for the database role (mapped from `POSTGRES_DB_USER_PASSWORD`) |
 | `INIT_POSTGRES_SUPER_PASS` | Superuser password for admin operations (from `cloudnative-pg` item)     |
@@ -40,7 +50,8 @@ Each service that uses PostgreSQL follows this pattern:
 
 ### 1. linkwarden
 
-**1Password item name**: `linkwarden`
+**1Password item name**: `linkwarden`  
+**Namespace**: `selfhosted`
 
 **Generate secrets first:**
 
@@ -54,14 +65,14 @@ openssl rand -base64 24
 
 **Create the 1Password item with these fields:**
 
-| Field Name                  | Value                                       |
-| --------------------------- | ------------------------------------------- |
-| `NEXTAUTH_SECRET`           | _(output of `openssl rand -hex 32`)_        |
-| `NEXTAUTH_URL`              | `https://links.{SECRET_DOMAIN}`                   |
-| `POSTGRES_DB_NAME`          | `linkwarden`                                |
-| `POSTGRES_DB_HOST`          | `postgres-17-rw.database.svc.cluster.local` |
-| `POSTGRES_DB_USER_NAME`     | `linkwarden`                                |
-| `POSTGRES_DB_USER_PASSWORD` | _(output of `openssl rand -base64 24`)_     |
+| Field Name                  | Value                                   |
+| --------------------------- | --------------------------------------- |
+| `NEXTAUTH_SECRET`           | _(output of `openssl rand -hex 32`)_    |
+| `POSTGRES_DB_NAME`          | `linkwarden`                            |
+| `POSTGRES_DB_USER_NAME`     | `linkwarden`                            |
+| `POSTGRES_DB_USER_PASSWORD` | _(output of `openssl rand -base64 24`)_ |
+
+`NEXTAUTH_URL` is not a secret. The HelmRelease sets `NEXTAUTH_URL: "https://links.${SECRET_DOMAIN}"`.
 
 > **Note**: `POSTGRES_SUPER_PASS` is NOT stored in this item. It is pulled from the existing `cloudnative-pg` item via a second `dataFrom` extract in the ExternalSecret.
 
@@ -74,11 +85,9 @@ DB_PASS=$(openssl rand -base64 24)
 op item create \
   --category=login \
   --title="linkwarden" \
-  --vault="homelab" \
+  --vault="Homelab" \
   "NEXTAUTH_SECRET=$NEXTAUTH_SECRET" \
-  "NEXTAUTH_URL=https://links.{SECRET_DOMAIN}" \
   "POSTGRES_DB_NAME=linkwarden" \
-  "POSTGRES_DB_HOST=postgres-17-rw.database.svc.cluster.local" \
   "POSTGRES_DB_USER_NAME=linkwarden" \
   "POSTGRES_DB_USER_PASSWORD=$DB_PASS"
 ```
@@ -87,7 +96,8 @@ op item create \
 
 ### 2. immich
 
-**1Password item name**: `immich`
+**1Password item name**: `immich`  
+**Namespace**: `media`
 
 **Generate secrets first:**
 
@@ -95,42 +105,36 @@ op item create \
 # IMMICH_SECRET_KEY -- 32-byte hex string
 openssl rand -hex 32
 
-# DB_PASSWORD -- strong random password
-openssl rand -base64 24
-
-# POSTGRES_DB_USER_PASSWORD -- strong random password (can be same as DB_PASSWORD or separate)
+# POSTGRES_DB_USER_PASSWORD -- strong random password
 openssl rand -base64 24
 ```
 
 **Create the 1Password item with these fields:**
 
-| Field Name                  | Value                                       |
-| --------------------------- | ------------------------------------------- |
-| `DB_PASSWORD`               | _(output of `openssl rand -base64 24`)_     |
-| `POSTGRES_DB_NAME`          | `immich`                                    |
-| `POSTGRES_DB_HOST`          | `postgres-17-rw.database.svc.cluster.local` |
-| `POSTGRES_DB_USER_NAME`     | `immich`                                    |
-| `POSTGRES_DB_USER_PASSWORD` | _(output of `openssl rand -base64 24`)_     |
-| `IMMICH_SECRET_KEY`         | _(output of `openssl rand -hex 32`)_        |
+| Field Name                  | Value                                   |
+| --------------------------- | --------------------------------------- |
+| `POSTGRES_DB_NAME`          | `immich`                                |
+| `POSTGRES_DB_USER_NAME`     | `immich`                                |
+| `POSTGRES_DB_USER_PASSWORD` | _(output of `openssl rand -base64 24`)_ |
+| `IMMICH_SECRET_KEY`         | _(output of `openssl rand -hex 32`)_    |
 
-> **Note**: `DB_PASSWORD` and `POSTGRES_DB_USER_PASSWORD` may be set to the same value if immich uses a single DB credential. Check the ExternalSecret template to confirm how each is mapped. `POSTGRES_SUPER_PASS` comes from the `cloudnative-pg` item.
+The ExternalSecret maps Immich `DB_PASSWORD` from `POSTGRES_DB_USER_PASSWORD`. A separate `DB_PASSWORD` field in 1Password is unused.
+
+> **Note**: `POSTGRES_SUPER_PASS` comes from the `cloudnative-pg` item.
 
 **CLI creation (optional):**
 
 ```bash
 IMMICH_SECRET=$(openssl rand -hex 32)
 DB_PASS=$(openssl rand -base64 24)
-PG_PASS=$(openssl rand -base64 24)
 
 op item create \
   --category=login \
   --title="immich" \
-  --vault="homelab" \
-  "DB_PASSWORD=$DB_PASS" \
+  --vault="Homelab" \
   "POSTGRES_DB_NAME=immich" \
-  "POSTGRES_DB_HOST=postgres-17-rw.database.svc.cluster.local" \
   "POSTGRES_DB_USER_NAME=immich" \
-  "POSTGRES_DB_USER_PASSWORD=$PG_PASS" \
+  "POSTGRES_DB_USER_PASSWORD=$DB_PASS" \
   "IMMICH_SECRET_KEY=$IMMICH_SECRET"
 ```
 
@@ -138,7 +142,8 @@ op item create \
 
 ### 3. paperless-ngx
 
-**1Password item name**: `paperless-ngx`
+**1Password item name**: `paperless-ngx`  
+**Namespace**: `selfhosted`
 
 **Generate secrets first:**
 
@@ -161,7 +166,6 @@ openssl rand -base64 24
 | `PAPERLESS_ADMIN_USER`      | `admin` _(or your preferred admin username)_ |
 | `PAPERLESS_ADMIN_PASSWORD`  | _(output of `openssl rand -base64 18`)_      |
 | `POSTGRES_DB_NAME`          | `paperless`                                  |
-| `POSTGRES_DB_HOST`          | `postgres-17-rw.database.svc.cluster.local`  |
 | `POSTGRES_DB_USER_NAME`     | `paperless`                                  |
 | `POSTGRES_DB_USER_PASSWORD` | _(output of `openssl rand -base64 24`)_      |
 
@@ -177,12 +181,11 @@ DB_PASS=$(openssl rand -base64 24)
 op item create \
   --category=login \
   --title="paperless-ngx" \
-  --vault="homelab" \
+  --vault="Homelab" \
   "PAPERLESS_SECRET_KEY=$SECRET_KEY" \
   "PAPERLESS_ADMIN_USER=admin" \
   "PAPERLESS_ADMIN_PASSWORD=$ADMIN_PASS" \
   "POSTGRES_DB_NAME=paperless" \
-  "POSTGRES_DB_HOST=postgres-17-rw.database.svc.cluster.local" \
   "POSTGRES_DB_USER_NAME=paperless" \
   "POSTGRES_DB_USER_PASSWORD=$DB_PASS"
 ```
@@ -191,7 +194,8 @@ op item create \
 
 ### 4. obsidian-livesync
 
-**1Password item name**: `obsidian-livesync`
+**1Password item name**: `obsidian-livesync`  
+**Namespace**: `selfhosted`
 
 **Generate secrets first:**
 
@@ -222,7 +226,7 @@ COUCH_SECRET=$(uuidgen)
 op item create \
   --category=login \
   --title="obsidian-livesync" \
-  --vault="homelab" \
+  --vault="Homelab" \
   "COUCHDB_USER=admin" \
   "COUCHDB_PASSWORD=$COUCH_PASS" \
   "COUCHDB_SECRET=$COUCH_SECRET"
@@ -230,17 +234,12 @@ op item create \
 
 ---
 
-### 5. ntfy (optional -- may not need secrets initially)
+### 5. ntfy (ConfigMap-only; no 1Password item)
 
-**1Password item name**: `ntfy`
-
-ntfy may not require secrets on initial deployment. If you configure authentication later, create the item with:
-
-| Field Name                 | Value                      |
-| -------------------------- | -------------------------- |
-| `NTFY_AUTH_DEFAULT_ACCESS` | `deny-all` or `read-write` |
-
-This item can be created when auth is actually enabled. No action is needed for the initial deployment.
+ntfy auth is a ConfigMap (`selfhosted/ntfy/app/configmap.yaml`):
+`auth-default-access: read-write`. There is no ntfy ExternalSecret. Creating an
+`NTFY_AUTH_DEFAULT_ACCESS` 1Password item would do nothing unless/until auth is
+wired through ESO.
 
 ---
 
@@ -254,12 +253,12 @@ After creating all 1Password items and deploying the ExternalSecret manifests, v
 # List all ExternalSecrets across all namespaces
 kubectl get externalsecret -A
 
-# Expected output for healthy secrets:
-# NAMESPACE    NAME                  STORE        REFRESH   STATUS         READY
-# selfhosted   linkwarden-secret     onepassword  5m        SecretSynced   True
-# selfhosted   immich-secret         onepassword  5m        SecretSynced   True
-# selfhosted   paperless-ngx-secret  onepassword  5m        SecretSynced   True
-# selfhosted   obsidian-livesync...  onepassword  5m        SecretSynced   True
+# Expected output for healthy secrets (namespaces match GitOps):
+# NAMESPACE    NAME                   STORE        REFRESH   STATUS         READY
+# selfhosted   linkwarden-secret      onepassword  5m        SecretSynced   True
+# media        immich-secret          onepassword  5m        SecretSynced   True
+# selfhosted   paperless-ngx-secret   onepassword  5m        SecretSynced   True
+# selfhosted   obsidian-livesync-...  onepassword  5m        SecretSynced   True
 ```
 
 ### Check individual ExternalSecret details
@@ -306,3 +305,6 @@ dataFrom:
 ```
 
 This pattern ensures the `postgres-init` container receives `INIT_POSTGRES_SUPER_PASS` without duplicating the superuser password across individual service items.
+
+Connect server: `onepassword-connect.security.svc.cluster.local:8080`.
+ClusterSecretStore name: `onepassword`.

--- a/docs/organisation-services-1password-setup.md
+++ b/docs/organisation-services-1password-setup.md
@@ -50,8 +50,8 @@ Each service that uses PostgreSQL follows this pattern:
 
 ### 1. linkwarden
 
-**1Password item name**: `linkwarden`  
-**Namespace**: `selfhosted`
+- **1Password item name**: `linkwarden`
+- **Namespace**: `selfhosted`
 
 **Generate secrets first:**
 
@@ -96,8 +96,8 @@ op item create \
 
 ### 2. immich
 
-**1Password item name**: `immich`  
-**Namespace**: `media`
+- **1Password item name**: `immich`
+- **Namespace**: `media`
 
 **Generate secrets first:**
 
@@ -142,8 +142,8 @@ op item create \
 
 ### 3. paperless-ngx
 
-**1Password item name**: `paperless-ngx`  
-**Namespace**: `selfhosted`
+- **1Password item name**: `paperless-ngx`
+- **Namespace**: `selfhosted`
 
 **Generate secrets first:**
 
@@ -194,8 +194,8 @@ op item create \
 
 ### 4. obsidian-livesync
 
-**1Password item name**: `obsidian-livesync`  
-**Namespace**: `selfhosted`
+- **1Password item name**: `obsidian-livesync`
+- **Namespace**: `selfhosted`
 
 **Generate secrets first:**
 

--- a/docs/pincap/reference.md
+++ b/docs/pincap/reference.md
@@ -1,1 +1,0 @@
-https://github.com/pingcap/docs-tidb-operator/blob/main/en/monitor-a-tidb-cluster.md

--- a/kubernetes/apps/actions-runner-system/TROUBLESHOOTING.md
+++ b/kubernetes/apps/actions-runner-system/TROUBLESHOOTING.md
@@ -2,6 +2,12 @@
 
 This document provides operational guidance for debugging and maintaining the self-hosted GitHub Actions runners deployed via Actions Runner Controller (ARC) on this Kubernetes cluster.
 
+Image tags and chart versions rotate with Renovate. Treat the HelmReleases as
+the source of truth:
+
+- Runner image: `gha-runner-scale-set/app/aviator-coding/{home-ops,ai-k8s-sandbox}/helmrelease.yaml`
+- Controller chart: `gha-runner-scale-set-controller/app/helmrelease.yaml`
+
 ## Architecture Overview
 
 ### Components
@@ -10,20 +16,49 @@ This document provides operational guidance for debugging and maintaining the se
    - Manages the lifecycle of runner scale sets
    - Handles communication with GitHub's API
    - Deployed as a Deployment with 2 replicas
+   - Chart `gha-runner-scale-set-controller` (currently `0.14.2`; no image pin, chart default tracks the chart)
 
-2. **Listener** (`gha-runner-scale-set-aviator-coding-home-ops-*-listener`)
+2. **Listeners** (one per scale set)
    - Long-polling connection to GitHub for job requests
-   - One listener per runner scale set
    - Triggers runner pod creation when jobs are queued
+   - Names: `<scale-set-name>-*-listener`
 
 3. **Runner Pods** (ephemeral)
-   - Created on-demand when jobs are assigned
+   - Created on-demand when jobs are assigned; `minRunners: 1` keeps one warm standby per scale set
    - Deleted after job completion
-   - Use ephemeral storage (Ceph block volumes)
+   - Use ephemeral storage (20Gi `ceph-block` PVCs)
+
+### Scale sets
+
+Both HelmReleases use chart `gha-runner-scale-set` (currently `0.14.2`),
+`minRunners: 1` / `maxRunners: 15`, and image
+`ghcr.io/home-operations/actions-runner` (currently `2.336.0`).
+
+| HelmRelease | GitHub repo | Extra |
+|-------------|-------------|-------|
+| `gha-runner-scale-set-aviator-coding-home-ops` | `aviator-coding/home-ops` | talosctl init container, 20Gi ephemeral `ceph-block` work PVC |
+| `gha-rs-ac-ai-k8s-sandbox` | `aviator-coding/ai-k8s-sandbox` | privileged `docker:29-dind` sidecar, unbounded `emptyDir` dind-storage |
+
+Listener pods:
+
+- `gha-runner-scale-set-aviator-coding-home-ops-*-listener`
+- `gha-rs-ac-ai-k8s-sandbox-*-listener`
+
+`maxRunners: 15` per set is a real ceiling (jobs sit queued once hit). A
+"no runners" diagnosis should check **both** sets.
 
 ### Namespace
 
 All runner components are deployed in: `actions-runner-system`
+
+### Tooling coverage gap
+
+The maintenance CronJob (`REPO_NAME=home-ops`) and Taskfile recipes
+(`.taskfiles/actions-runner/Taskfile.yaml`, `REPO: aviator-coding/home-ops`)
+only cover the **home-ops** scale set. They do not list, clean, or cancel
+`ai-k8s-sandbox` runners. Use `gh api repos/aviator-coding/ai-k8s-sandbox/actions/runners`
+for that repo. Expanding maintenance to the sandbox set is a tooling change,
+not done here.
 
 ## Common Failure Scenarios
 
@@ -35,7 +70,7 @@ All runner components are deployed in: `actions-runner-system`
 
 **Diagnosis:**
 ```bash
-# Check listener pod status
+# Check listener pod status (both scale sets)
 kubectl get pods -n actions-runner-system -l app.kubernetes.io/component=listener
 
 # Check listener logs
@@ -53,11 +88,11 @@ kubectl describe externalsecret aviator-coding-runner-secret -n actions-runner-s
 - GitHub App token expired or misconfigured
 - Listener pod crashed or disconnected
 - Network connectivity issues to GitHub API
-- maxRunners limit reached
+- maxRunners limit reached (15 per scale set)
 
 **Resolution:**
 - Restart listener pod if stuck: `kubectl delete pod -n actions-runner-system -l app.kubernetes.io/component=listener`
-- Verify GitHub App credentials in 1Password are correct
+- Verify GitHub App credentials in 1Password are correct (see Secret Management)
 - Check ExternalSecret sync status
 
 ### 2. Runner Pods Failing to Start
@@ -68,8 +103,8 @@ kubectl describe externalsecret aviator-coding-runner-secret -n actions-runner-s
 
 **Diagnosis:**
 ```bash
-# List all runner pods
-kubectl get pods -n actions-runner-system | grep -v controller -| grep -v listener
+# List runner pods (both scale sets; excludes controller and listeners)
+kubectl get pods -n actions-runner-system -l actions.github.com/scale-set-name
 
 # Describe a failing runner pod
 kubectl describe pod <runner-pod-name> -n actions-runner-system
@@ -82,7 +117,7 @@ kubectl get events -n actions-runner-system --sort-by='.metadata.creationTimesta
 - Insufficient resources (CPU/memory) on nodes
 - Storage provisioning failures (Ceph issues)
 - Image pull failures
-- Talos secret not available
+- Talos secret not available (home-ops scale set)
 
 **Resolution:**
 - Check node resources: `kubectl top nodes`
@@ -94,6 +129,11 @@ kubectl get events -n actions-runner-system --sort-by='.metadata.creationTimesta
 **Symptoms:**
 - PrometheusRule alert: `GithubActionsRunnerControllerDown`
 - No runner scale sets being managed
+
+The scrape `job` label is `actions-runner-system/action-runner-controller`
+(PodMonitor `action-runner-controller`, namespace-prefixed). The rule matches
+that job. `up{job="gha-runner-scale-set-controller"}` is empty and must not be
+used as the health signal.
 
 **Diagnosis:**
 ```bash
@@ -117,6 +157,9 @@ flux get hr -n actions-runner-system gha-runner-scale-set-controller
 **Symptoms:**
 - Jobs that need `talosctl` or `kubectl` access fail
 - Errors about missing config or permissions
+
+Applies to the **home-ops** scale set (talosctl init container). The sandbox
+scale set is DinD, not talosctl.
 
 **Diagnosis:**
 ```bash
@@ -151,18 +194,24 @@ Metrics are exposed via PodMonitor and available in Prometheus/Grafana:
 - `gha_job_startup_duration_seconds` - Time from job assignment to execution start
 - `gha_job_execution_duration_seconds` - Job execution duration
 
+Controller `up` series: `job="actions-runner-system/action-runner-controller"`.
+Listener `up` series are
+`job="actions-runner-system/gha-runner-scale-set-aviator-coding-home-ops"` and
+`job="actions-runner-system/gha-rs-ac-ai-k8s-sandbox"`.
+
 ### Grafana Dashboard
 
-The ARC dashboard is automatically provisioned to Grafana via the `arc-dashboard` ConfigMap.
+The ARC dashboard is automatically provisioned to Grafana via the `arc-dashboard`
+ConfigMap (`grafana_folder: CI`).
 
-Access: Grafana > Dashboards > Search for "Actions Runner Controller"
+Access: Grafana > Dashboards > search **ARC Monitoring** (not "Actions Runner Controller").
 
 ### Alerts
 
 PrometheusRules are configured for:
 - `GithubActionsRunnerJobFailureRateHigh` - >20% failure rate over 1 hour
 - `GithubActionsRunnerZeroIdleRunners` - No idle runners with jobs waiting
-- `GithubActionsRunnerControllerDown` - Controller pod not running
+- `GithubActionsRunnerControllerDown` - No healthy controller scrape
 - `GithubActionsRunnerJobStartupSlow` - P95 startup time >2 minutes
 
 ## Manual Operations
@@ -171,7 +220,7 @@ PrometheusRules are configured for:
 
 To manually trigger runner creation (for testing):
 ```bash
-# Trigger the test workflow from GitHub
+# Trigger the test workflow from GitHub (home-ops synthetic self-test)
 gh workflow run test-runner.yaml --repo aviator-coding/home-ops
 ```
 
@@ -189,24 +238,27 @@ kubectl delete pods -n actions-runner-system -l app.kubernetes.io/component=list
 ### View Runner Registration
 
 ```bash
-# Check registered runners via GitHub CLI
+# home-ops scale set
 gh api repos/aviator-coding/home-ops/actions/runners
+
+# sandbox scale set
+gh api repos/aviator-coding/ai-k8s-sandbox/actions/runners
 ```
 
 ## Secret Management
 
 ### GitHub App Credentials
 
-Managed via ExternalSecret syncing from 1Password:
+Managed via ExternalSecret `aviator-coding-runner-secret` syncing from 1Password
+(`gha-runner-scale-set/app/aviator-coding/externalsecret.yaml`):
 
-```yaml
-# ExternalSecret: aviator-coding-runner-secret
-# Syncs to: Secret/aviator-coding-runner-secret
-# Contains:
-#   - github_app_id
-#   - github_app_installation_id
-#   - github_app_private_key
-```
+| Kubernetes Secret key | 1Password item | Field |
+|-----------------------|----------------|-------|
+| `github_app_id` | `github` | `ACR_AVIATOR_CODING_APP_ID` |
+| `github_app_installation_id` | `github` | `ACR_AVIATOR_CODING_INSTALLATION_ID` |
+| `github_app_private_key` | `github-acr-all-repositories` | `private key` |
+
+Both scale sets share this Secret.
 
 To verify secret sync:
 ```bash
@@ -224,13 +276,19 @@ kubectl get secret actions-runner -n actions-runner-system -o jsonpath='{.data.t
 
 ### Complete Runner System Reset
 
-If the runner system is completely broken:
+If the runner system is completely broken, name **both** scale sets. Do not
+`kubectl delete hr -n actions-runner-system --all` unless you also resume
+`gha-rs-ac-ai-k8s-sandbox` afterwards.
 
-1. Delete the HelmReleases:
+1. Suspend and delete the HelmReleases:
 ```bash
 flux suspend hr -n actions-runner-system gha-runner-scale-set-aviator-coding-home-ops
+flux suspend hr -n actions-runner-system gha-rs-ac-ai-k8s-sandbox
 flux suspend hr -n actions-runner-system gha-runner-scale-set-controller
-kubectl delete hr -n actions-runner-system --all
+kubectl delete hr -n actions-runner-system \
+  gha-runner-scale-set-aviator-coding-home-ops \
+  gha-rs-ac-ai-k8s-sandbox \
+  gha-runner-scale-set-controller
 ```
 
 2. Wait for cleanup:
@@ -238,16 +296,20 @@ kubectl delete hr -n actions-runner-system --all
 kubectl get pods -n actions-runner-system -w
 ```
 
-3. Resume reconciliation:
+3. Resume reconciliation (controller first, then both scale sets):
 ```bash
 flux resume hr -n actions-runner-system gha-runner-scale-set-controller
 flux resume hr -n actions-runner-system gha-runner-scale-set-aviator-coding-home-ops
+flux resume hr -n actions-runner-system gha-rs-ac-ai-k8s-sandbox
 ```
+
+`task actions-runner:reset-scale-set` only recreates the home-ops HelmRelease.
 
 ### Rotate GitHub App Credentials
 
-1. Generate new private key in GitHub App settings
-2. Update the secret in 1Password
+1. Generate a new private key in GitHub App settings
+2. Update 1Password item `github-acr-all-repositories` field `private key`
+   (and `github` / `ACR_AVIATOR_CODING_APP_ID` + `ACR_AVIATOR_CODING_INSTALLATION_ID` if those changed)
 3. Force ExternalSecret refresh:
 ```bash
 kubectl annotate externalsecret -n actions-runner-system aviator-coding-runner-secret force-sync=$(date +%s) --overwrite
@@ -259,11 +321,14 @@ The runner system includes automated maintenance mechanisms to prevent and recov
 
 ### Maintenance CronJob
 
-A CronJob (`runner-maintenance`) runs every 15 minutes to automatically:
+A CronJob (`runner-maintenance`) runs every 15 minutes against **home-ops only**
+(`REPO_NAME=home-ops`) to automatically:
 
 1. **Clean stale runners**: Removes offline runners from GitHub's API that are no longer active
 2. **Cancel stuck runs**: Cancels workflow runs stuck in "queued" state for more than 30 minutes
 3. **Log anomalies**: Reports long-running jobs that may need manual attention
+
+It does not cover `ai-k8s-sandbox`. It has no disk, PVC, or image-cache cleanup.
 
 **View maintenance logs:**
 ```bash
@@ -283,8 +348,8 @@ The following alerts monitor runner health:
 |-------|----------|-------------|
 | `GithubActionsRunnerJobFailureRateHigh` | warning | >20% job failure rate over 1 hour |
 | `GithubActionsRunnerZeroIdleRunners` | warning | No idle runners with jobs waiting |
-| `GithubActionsRunnerControllerDown` | critical | Controller pod not running |
-| `GithubActionsRunnerJobStartupSlow` | warning | P95 startup time >2 minutes |
+| `GithubActionsRunnerControllerDown` | critical | No healthy controller `up` scrape (`job="actions-runner-system/action-runner-controller"`) |
+| `GithubActionsRunnerJobStartupSlow` | warning | P95 job startup time exceeds 2 minutes |
 | `GithubActionsRunnerShortLifetimeDetected` | warning | Multiple runners exiting in <30 seconds (ghost jobs) |
 | `GithubActionsRunnerListenerDisconnected` | critical | Listener pod restarting frequently |
 | `GithubActionsRunnerAssignedJobsStuck` | warning | Jobs assigned but not running |
@@ -302,22 +367,25 @@ Ghost jobs occur when GitHub's Actions service has stale job assignments that no
 
 ### Automated Recovery
 
-The maintenance CronJob automatically:
+The maintenance CronJob automatically (home-ops only):
 - Cleans offline runners from GitHub every 15 minutes
 - Cancels workflow runs stuck for more than 30 minutes
 
 ### Manual Recovery
 
 ```bash
-# Cancel stuck workflow runs
+# Cancel stuck workflow runs (home-ops)
 task actions-runner:cancel-stuck-runs
 
-# Clean up stale runners from GitHub API
+# Clean up stale runners from GitHub API (home-ops)
 task actions-runner:cleanup-stale-runners
 
-# Full reset if above doesn't work
+# Full reset if above doesn't work (home-ops HelmRelease only)
 task actions-runner:reset-scale-set
 ```
+
+For the sandbox repo, use `gh` against `aviator-coding/ai-k8s-sandbox` instead
+of the Taskfile.
 
 ## Broker Connection Issues
 
@@ -343,6 +411,8 @@ task actions-runner:restart-listener
 task actions-runner:logs-listener
 ```
 
+`restart-listener` deletes every listener in the namespace (both scale sets).
+
 ### Investigation Steps
 
 If broker timeouts persist:
@@ -360,7 +430,8 @@ kubectl get ciliumnodes -o yaml | grep -A5 egressGateway
 
 ## Task Commands Reference
 
-All runner maintenance tasks are available via the Taskfile:
+All runner maintenance tasks are available via the Taskfile. Unless noted, they
+target `aviator-coding/home-ops` only.
 
 ```bash
 # Show current system status
@@ -390,15 +461,18 @@ other nodes can fetch it from the peer instead of the upstream registry.
 
 **Spegel Configuration:**
 - Deployed in `kube-system` namespace
-- Mirrors ALL registries by default (including ghcr.io, docker.io)
+- Mirrors ALL registries by default (including ghcr.io, docker.io); the HelmRelease does not set an allow-list
 - Exposes local registry on port 29999
 
 **Container Images Used by ARC:**
 
-| Image | Registry | Size | Cacheable by Spegel |
-|-------|----------|------|---------------------|
-| `ghcr.io/home-operations/actions-runner:2.331.0` | GHCR | ~720MB | Yes |
-| `ghcr.io/actions/gha-runner-scale-set-controller:0.13.1` | GHCR | ~50MB | Yes |
+Current tags live in the HelmReleases (Renovate bumps them). Typical set:
+
+| Image | Registry | Cacheable by Spegel |
+|-------|----------|---------------------|
+| `ghcr.io/home-operations/actions-runner` (scale-set image tag) | GHCR | Yes |
+| `gha-runner-scale-set-controller` chart default image | GHCR | Yes |
+| `docker:29-dind` (sandbox sidecar) | Docker Hub | Yes |
 
 **Verifying Spegel is working:**
 ```bash
@@ -408,8 +482,8 @@ kubectl -n kube-system get pods -l app.kubernetes.io/name=spegel
 # Check containerd registry config
 talosctl -n <node-ip> cat /etc/cri/conf.d/hosts/ghcr.io/hosts.toml
 
-# View Spegel metrics
-kubectl -n kube-system port-forward svc/spegel-metrics 9090:9090
+# View Spegel metrics (Service is `spegel`, port 9090; there is no `spegel-metrics` Service)
+kubectl -n kube-system port-forward svc/spegel 9090:9090
 curl localhost:9090/metrics | grep spegel
 ```
 
@@ -429,7 +503,7 @@ Runner resource requests have been optimized based on actual usage:
 | CPU | 500m | 200m | 8-14m |
 | Memory | 2Gi | 512Mi | 125-142Mi |
 
-This allows more concurrent runners on the same hardware while still providing headroom for burst usage.
+This allows more concurrent runners on the same hardware while still providing headroom for burst usage. Limits remain 2 CPU / 8Gi (plus 2 CPU / 4Gi for the sandbox DinD sidecar).
 
 ## Related Documentation
 

--- a/kubernetes/apps/actions-runner-system/gha-runner-scale-set-controller/Readme.md
+++ b/kubernetes/apps/actions-runner-system/gha-runner-scale-set-controller/Readme.md
@@ -1,3 +1,20 @@
-## Github Runners
+# gha-runner-scale-set-controller
 
-[Setup Github AppID](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners-with-actions-runner-controller/authenticating-to-the-github-api)
+Actions Runner Controller (ARC) scale-set controller for this cluster.
+
+- Chart: `gha-runner-scale-set-controller` in `app/helmrelease.yaml` (currently `0.14.2`)
+- Replicas: 2
+- Namespace: `actions-runner-system`
+
+Scale sets the controller manages (same chart family, currently `0.14.2`):
+
+| HelmRelease | Repo |
+|-------------|------|
+| `gha-runner-scale-set-aviator-coding-home-ops` | `aviator-coding/home-ops` |
+| `gha-rs-ac-ai-k8s-sandbox` | `aviator-coding/ai-k8s-sandbox` |
+
+Operational procedures, recovery, and secret rotation live in
+[`../TROUBLESHOOTING.md`](../TROUBLESHOOTING.md).
+
+GitHub App auth:
+[Authenticating to the GitHub API](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners-with-actions-runner-controller/authenticating-to-the-github-api).

--- a/kubernetes/apps/actions-runner-system/gha-runner-scale-set-controller/app/kustomization.yaml
+++ b/kubernetes/apps/actions-runner-system/gha-runner-scale-set-controller/app/kustomization.yaml
@@ -6,6 +6,7 @@ configMapGenerator:
 generatorOptions:
   annotations:
     kustomize.toolkit.fluxcd.io/substitute: disabled
+    grafana_folder: CI
   disableNameSuffixHash: true
   labels:
     grafana_dashboard: "true"

--- a/kubernetes/apps/actions-runner-system/gha-runner-scale-set-controller/app/prometheusrule.yaml
+++ b/kubernetes/apps/actions-runner-system/gha-runner-scale-set-controller/app/prometheusrule.yaml
@@ -33,13 +33,15 @@ spec:
             description: "All runners are busy with {{ $value }} jobs waiting"
 
         - alert: GithubActionsRunnerControllerDown
-          expr: absent(up{job="gha-runner-scale-set-controller"})
+          # Live scrape job is namespace/PodMonitor name, not the HelmRelease name.
+          # up{job="gha-runner-scale-set-controller"} is empty and would false-fire.
+          expr: count(up{job=~".*action-runner-controller"} == 1) == 0
           for: 5m
           labels:
             severity: critical
           annotations:
             summary: "GitHub Actions Runner Controller is down"
-            description: "The ARC controller pod is not running"
+            description: "No healthy ARC controller scrape (job actions-runner-system/action-runner-controller)"
 
         - alert: GithubActionsRunnerJobStartupSlow
           expr: |

--- a/kubernetes/apps/actions-runner-system/gha-runner-scale-set-controller/app/prometheusrule.yaml
+++ b/kubernetes/apps/actions-runner-system/gha-runner-scale-set-controller/app/prometheusrule.yaml
@@ -35,7 +35,7 @@ spec:
         - alert: GithubActionsRunnerControllerDown
           # Live scrape job is namespace/PodMonitor name, not the HelmRelease name.
           # up{job="gha-runner-scale-set-controller"} is empty and would false-fire.
-          expr: count(up{job=~".*action-runner-controller"} == 1) == 0
+          expr: (count(up{job=~".*action-runner-controller"} == 1) or vector(0)) == 0
           for: 5m
           labels:
             severity: critical

--- a/kubernetes/apps/coder/README.md
+++ b/kubernetes/apps/coder/README.md
@@ -1,7 +1,15 @@
-# Initial Login
+# Coder
 
--  When you first connect you will be presented with interface to create and admin user.
-You can use whatever here because it will be disabled and not used.
-There's just no current way to disable this.
--  After you login your user with oidc you will be a normal user.
-To give your oidc user full admin rights you will need to edit the database record for your user in the users table and set rbac_roles = "{owner}"
+Workspace platform. Sign in with Authentik; do not create a local password user.
+
+Password auth is disabled (`CODER_DISABLE_PASSWORD_AUTH=true`). Authentik group
+`Admins` is mapped to Coder role `owner` via `CODER_OIDC_USER_ROLE_MAPPING`.
+There is no first-boot admin-user form to fill, and you should not `UPDATE`
+`users.rbac_roles` in Postgres to grant admin.
+
+If a first-connect setup wizard still appears, it is leftover Coder chart UI.
+Skip it and use **Sign in with Authentik**. Membership of Authentik `Admins` is
+what grants `owner`.
+
+OIDC issuer: `https://auth.${SECRET_DOMAIN}/application/o/coder/`
+(see `app/helmrelease.yaml`).

--- a/kubernetes/apps/coder/app/rules/coderd.yaml
+++ b/kubernetes/apps/coder/app/rules/coderd.yaml
@@ -15,7 +15,7 @@ spec:
             summary: The Coder instance {{ $labels.pod }} is using high amounts of CPU, which may impact application performance.
           labels:
             severity: critical
-            runbook_url: https://runbooks.${SECRET_DOMAIN}/coder/coder#coderdcpuusage
+            runbook_url: https://github.com/Aviator-Coding/home-ops/blob/main/kubernetes/apps/coder/app/runbooks/coderd.md#coderdcpuusage
         - alert: CoderdCPUUsage
           expr: max by (pod) (rate(container_cpu_usage_seconds_total{pod=~`coder.*`, pod!~`.*provisioner.*`, namespace=`coder`}[10m])) / max by(pod) (kube_pod_container_resource_limits{pod=~`coder.*`, pod!~`.*provisioner.*`, namespace=`coder`, resource="cpu"}) > 0.8
           for: 10m
@@ -23,7 +23,7 @@ spec:
             summary: The Coder instance {{ $labels.pod }} is using high amounts of CPU, which may impact application performance.
           labels:
             severity: warning
-            runbook_url: https://runbooks.${SECRET_DOMAIN}/coder/coder#coderdcpuusage
+            runbook_url: https://github.com/Aviator-Coding/home-ops/blob/main/kubernetes/apps/coder/app/runbooks/coderd.md#coderdcpuusage
     - name: Memory Usage
       rules:
         - alert: CoderdMemoryUsage
@@ -33,7 +33,7 @@ spec:
             summary: The Coder instance {{ $labels.pod }} is using high amounts of memory, which may lead to an Out-Of-Memory (OOM) error.
           labels:
             severity: critical
-            runbook_url: https://runbooks.${SECRET_DOMAIN}/coder/coder#coderdmemoryusage
+            runbook_url: https://github.com/Aviator-Coding/home-ops/blob/main/kubernetes/apps/coder/app/runbooks/coderd.md#coderdmemoryusage
         - alert: CoderdMemoryUsage
           expr: max by (pod) (container_memory_working_set_bytes{pod=~`coder.*`, pod!~`.*provisioner.*`, namespace=`coder`}) / max by (pod) (kube_pod_container_resource_limits{pod=~`coder.*`, pod!~`.*provisioner.*`, namespace=`coder`, resource="memory"})  > 0.8
           for: 10m
@@ -41,7 +41,7 @@ spec:
             summary: The Coder instance {{ $labels.pod }} is using high amounts of memory, which may lead to an Out-Of-Memory (OOM) error.
           labels:
             severity: warning
-            runbook_url: https://runbooks.${SECRET_DOMAIN}/coder/coder#coderdmemoryusage
+            runbook_url: https://github.com/Aviator-Coding/home-ops/blob/main/kubernetes/apps/coder/app/runbooks/coderd.md#coderdmemoryusage
     - name: Pod Restarts
       rules:
         - alert: CoderdRestarts
@@ -51,7 +51,7 @@ spec:
             summary: The Coder instance {{ $labels.pod }} has restarted multiple times in the last 10m, which may indicate a CrashLoop.
           labels:
             severity: critical
-            runbook_url: https://runbooks.${SECRET_DOMAIN}/coder/coder#coderdrestarts
+            runbook_url: https://github.com/Aviator-Coding/home-ops/blob/main/kubernetes/apps/coder/app/runbooks/coderd.md#coderdrestarts
         - alert: CoderdRestarts
           expr: sum by(pod) (increase(kube_pod_container_status_restarts_total{pod=~`coder.*`, pod!~`.*provisioner.*`, namespace=`coder`}[10m])) > 1
           for: 1m
@@ -59,7 +59,7 @@ spec:
             summary: The Coder instance {{ $labels.pod }} has restarted multiple times in the last 10m, which may indicate a CrashLoop.
           labels:
             severity: notify
-            runbook_url: https://runbooks.${SECRET_DOMAIN}/coder/coder#coderdrestarts
+            runbook_url: https://github.com/Aviator-Coding/home-ops/blob/main/kubernetes/apps/coder/app/runbooks/coderd.md#coderdrestarts
         - alert: CoderdRestarts
           expr: sum by(pod) (increase(kube_pod_container_status_restarts_total{pod=~`coder.*`, pod!~`.*provisioner.*`, namespace=`coder`}[10m])) > 2
           for: 1m
@@ -67,7 +67,7 @@ spec:
             summary: The Coder instance {{ $labels.pod }} has restarted multiple times in the last 10m, which may indicate a CrashLoop.
           labels:
             severity: warning
-            runbook_url: https://runbooks.${SECRET_DOMAIN}/coder/coder#coderdrestarts
+            runbook_url: https://github.com/Aviator-Coding/home-ops/blob/main/kubernetes/apps/coder/app/runbooks/coderd.md#coderdrestarts
     - name: Coderd Replicas
       rules:
         - alert: CoderdReplicas
@@ -77,7 +77,7 @@ spec:
             summary: Number of alive coderd replicas is below the threshold = 1.
           labels:
             severity: critical
-            runbook_url: https://runbooks.${SECRET_DOMAIN}/coder/coder#coderdreplicas
+            runbook_url: https://github.com/Aviator-Coding/home-ops/blob/main/kubernetes/apps/coder/app/runbooks/coderd.md#coderdreplicas
     - name: Coderd Workspace Build Failures
       rules:
         - alert: CoderdWorkspaceBuildFailures
@@ -87,7 +87,7 @@ spec:
             summary: Workspace builds have failed multiple times in the last 10m, which may indicate a broken Coder template.
           labels:
             severity: critical
-            runbook_url: https://runbooks.${SECRET_DOMAIN}/coder/coder#coderdworkspacebuildfailures
+            runbook_url: https://github.com/Aviator-Coding/home-ops/blob/main/kubernetes/apps/coder/app/runbooks/coderd.md#coderdworkspacebuildfailures
         - alert: CoderdWorkspaceBuildFailures
           expr: sum(increase(coderd_workspace_builds_total{pod=~`coder.*`, pod!~`.*provisioner.*`, namespace=`coder`, status="failed" }[10m])) > 2
           for: 10m
@@ -95,7 +95,7 @@ spec:
             summary: Workspace builds have failed multiple times in the last 10m, which may indicate a broken Coder template.
           labels:
             severity: notify
-            runbook_url: https://runbooks.${SECRET_DOMAIN}/coder/coder#coderdworkspacebuildfailures
+            runbook_url: https://github.com/Aviator-Coding/home-ops/blob/main/kubernetes/apps/coder/app/runbooks/coderd.md#coderdworkspacebuildfailures
         - alert: CoderdWorkspaceBuildFailures
           expr: sum(increase(coderd_workspace_builds_total{pod=~`coder.*`, pod!~`.*provisioner.*`, namespace=`coder`, status="failed" }[10m])) > 5
           for: 10m
@@ -103,4 +103,4 @@ spec:
             summary: Workspace builds have failed multiple times in the last 10m, which may indicate a broken Coder template.
           labels:
             severity: warning
-            runbook_url: https://runbooks.${SECRET_DOMAIN}/coder/coder#coderdworkspacebuildfailures
+            runbook_url: https://github.com/Aviator-Coding/home-ops/blob/main/kubernetes/apps/coder/app/runbooks/coderd.md#coderdworkspacebuildfailures

--- a/kubernetes/apps/coder/app/rules/provisionerd.yaml
+++ b/kubernetes/apps/coder/app/rules/provisionerd.yaml
@@ -15,7 +15,7 @@ spec:
             summary: Number of alive provisionerd replicas is below the threshold = 1.
           labels:
             severity: critical
-            runbook_url: https://runbooks.${SECRET_DOMAIN}/coder/coder#provisionerdreplicas
+            runbook_url: https://github.com/Aviator-Coding/home-ops/blob/main/kubernetes/apps/coder/app/runbooks/provisionerd.md#provisionerdreplicas
         - alert: ProvisionerdReplicas
           expr: sum(coderd_provisionerd_num_daemons{pod=~`coder.*`, pod!~`.*provisioner.*`, namespace=`coder`}) < 3
           for: 5m
@@ -23,7 +23,7 @@ spec:
             summary: Number of alive provisionerd replicas is below the threshold = 3.
           labels:
             severity: notify
-            runbook_url: https://runbooks.${SECRET_DOMAIN}/coder/coder#provisionerdreplicas
+            runbook_url: https://github.com/Aviator-Coding/home-ops/blob/main/kubernetes/apps/coder/app/runbooks/provisionerd.md#provisionerdreplicas
         - alert: ProvisionerdReplicas
           expr: sum(coderd_provisionerd_num_daemons{pod=~`coder.*`, pod!~`.*provisioner.*`, namespace=`coder`}) < 2
           for: 5m
@@ -31,4 +31,4 @@ spec:
             summary: Number of alive provisionerd replicas is below the threshold = 2.
           labels:
             severity: warning
-            runbook_url: https://runbooks.${SECRET_DOMAIN}/coder/coder#provisionerdreplicas
+            runbook_url: https://github.com/Aviator-Coding/home-ops/blob/main/kubernetes/apps/coder/app/runbooks/provisionerd.md#provisionerdreplicas

--- a/kubernetes/apps/coder/app/runbooks/coderd.md
+++ b/kubernetes/apps/coder/app/runbooks/coderd.md
@@ -1,16 +1,26 @@
 # Coderd Runbooks
 
+These files are mounted as ConfigMap `coder-runbooks` (label `runbook_docs: "true"`).
+There is no `runbooks.${SECRET_DOMAIN}` HTTPRoute. Alert `runbook_url` values
+point at this Git path.
+
 ## CoderdCPUUsage
 
-The CPU usage of one or more Coder pods has been close to the limit defined for
-the deployment. This can cause slowness in the application, workspaces becoming
-unavailable, and may lead to the application failing its liveness probes and
-being restarted.
+The CPU usage of one or more Coder pods has been close to the **limit** defined
+for the deployment. This can cause slowness, workspaces becoming unavailable,
+and liveness-probe restarts.
 
-To resolve this issue, increase the CPU limits of the Coder deployment.
+This cluster's Coder HelmRelease does **not** set a CPU limit. Resources are
+`requests.cpu: 71m` and `limits.memory: 1Gi` only (`app/helmrelease.yaml`).
+The alert divides usage by `kube_pod_container_resource_limits{resource="cpu"}`,
+which is empty here, so this alert will not fire. Do not add a CPU limit as a
+first response: the 2026-06-30 outage comment on the HelmRelease is about
+memory/OOM, not CPU throttling.
 
-If you find this occurring frequently, you may wish to check your Coder
-deployment against [Coder's Reference Architectures](https://coder.com/docs/v2/latest/admin/architectures).
+If CPU is actually high, check request vs usage (`kubectl -n coder top pod`)
+and node pressure. Compare against
+[Coder's Reference Architectures](https://coder.com/docs/v2/latest/admin/architectures)
+only after confirming real saturation.
 
 ## CoderdMemoryUsage
 
@@ -19,11 +29,9 @@ for the deployment. When the memory usage exceeds the limit, the pod(s) will be
 restarted by Kubernetes. This will interrupt all connections to workspaces being
 handled by the affected pod(s).
 
-To resolve this issue, increase the memory limits of the Coder deployment.
-
-If you find this occurring frequently, check the memory usage over a longer
-period of time. If it appears to be increasing monotonically, this is likely a
-memory leak and should be considered a bug.
+The memory limit is `1Gi`. To resolve, increase that limit on the Coder
+HelmRelease if usage is genuinely at the cap. If usage increases monotonically,
+that is likely a memory leak.
 
 ## CoderdRestarts
 
@@ -35,10 +43,13 @@ minutes. This may be due to a number of issues, including:
   similar to the following:
 
   ```console
-  [warn]  ping postgres: retrying  error="dial tcp 10.43.94.60:5432: connect: connection refused"  try=3
+  [warn]  ping postgres: retrying  error="dial tcp postgres-17-rw.database.svc.cluster.local:5432: connect: connection refused"  try=3
   ```
 
-- Out-Of-Memory (OOM) kills due to memory usage (see [above](#codermemoryusage)),
+  The live DSN host is `postgres-17-rw.database.svc.cluster.local:5432`
+  (`app/externalsecret.yaml`), not a ClusterIP.
+
+- Out-Of-Memory (OOM) kills due to memory usage (see [above](#coderdmemoryusage)),
 - An unexpected bug causing the application to exit with an error.
 
 If Coder is not restarting due to excessive memory usage, check the logs:
@@ -46,13 +57,13 @@ If Coder is not restarting due to excessive memory usage, check the logs:
 1. Check the logs of the deployment for any errors,
 
 ```console
-kubectl -n <coder namespace> logs deployment/coder --previous
+kubectl -n coder logs deployment/coder --previous
 ```
 
 2. Check any Kubernetes events related to the deployment,
 
 ```console
-kubectl -n <coder namespace> events --watch
+kubectl -n coder events --watch
 ```
 
 ## CoderdReplicas
@@ -60,8 +71,9 @@ kubectl -n <coder namespace> events --watch
 One or more Coderd replicas are down. This may cause availability problems and elevated
 response times for user and agent API calls.
 
-To resolve this issue, review the Coder deployment for possible `CrashLoopBackOff`
-instances or re-adjust alarm levels based on the actual number of replicas.
+This cluster runs a single coderd replica (`replicas` defaults to 1; there is no
+separate provisioner Deployment). Review `deployment/coder` in namespace `coder`
+for `CrashLoopBackOff`, or re-adjust alarm levels if the replica count changes.
 
 ## CoderdWorkspaceBuildFailures
 
@@ -70,9 +82,3 @@ A few workspace build errors have been recently observed.
 Review Prometheus metrics to identify failed jobs. Check the workspace build logs
 to determine if there is a relationship with a new template version or a buggy
 Terraform plugin.
-
-## CoderdLicenseSeats
-
-Your Enterprise license is approaching or has exceeded the number of seats purchased.
-
-Please contact your Coder sales contact, or visit https://coder.com/contact/sales.

--- a/kubernetes/apps/coder/app/runbooks/provisionerd.md
+++ b/kubernetes/apps/coder/app/runbooks/provisionerd.md
@@ -2,8 +2,15 @@
 
 ## ProvisionerdReplicas
 
-One of more Provisioner replicas is down. Workspace builds may be queued and processed slower.
+One or more provisioner daemons is down. Workspace builds may be queued and
+processed slower.
 
-To resolve this issue, review the Coder deployment (Coder provisioner pods)
-for possible `CrashLoopBackOff` instances or re-adjust alarm levels based on the actual
-number of replicas.
+This cluster does **not** run separate `coder-provisioner-*` pods. coderd uses
+built-in provisioners (Grafana dashboard text: control with
+`CODER_PROVISIONER_DAEMONS` / `--provisioner-daemons`). The HelmRelease does not
+set that env, so the chart default applies. Live `coderd_provisionerd_num_daemons`
+has been 3.
+
+Alerts fire on that metric: notify `< 3`, warning `< 2`, critical `< 1`. If the
+count is wrong, re-adjust those thresholds or set `CODER_PROVISIONER_DAEMONS`
+explicitly. Looking for CrashLoopBackOff on provisioner pods will find nothing.

--- a/kubernetes/apps/monitoring/exporters/graphite-exporter/app/resources/Readme.md
+++ b/kubernetes/apps/monitoring/exporters/graphite-exporter/app/resources/Readme.md
@@ -1,4 +1,28 @@
-## Mapping
+# TrueNAS Graphite exporter mapping
 
-see repo
-`https://github.com/Supporterino/truenas-graphite-to-prometheus/tree/main`
+Vendored mapping for `prom/graphite-exporter` (HelmRelease tag currently
+`v0.17.0`). Upstream project:
+<https://github.com/Supporterino/truenas-graphite-to-prometheus>
+
+## This repo
+
+| What | Path |
+|------|------|
+| Mapping ConfigMap source | `graphite_mapping.conf` (this directory); mounted at `/tmp/graphite_mapping.conf` |
+| Dashboards | `kubernetes/apps/monitoring/exporters/graphite-exporter/dashboard/truenas-scale/` (`truenas-scale.json`, `truenas-scale-disk-insights.json`, `truenas-scale-temperatures.json`; Grafana folder `TrueNas`) |
+| HelmRelease | `../helmrelease.yaml` - LoadBalancer TCP/UDP 2003, metrics 9108 |
+
+Mappings expect Graphite prefix `truenas` (see `match: 'truenas\.(.*)\....'`).
+Point TrueNAS Graphite destination at this exporter's LoadBalancer, port 2003.
+The Cilium IP pin `io.cilium/lb-ipam-ips: 10.10.0.190` is commented; look up the
+live EXTERNAL-IP with `kubectl -n monitoring get svc graphite-exporter`.
+
+## TrueNAS 25.04 / exporter config v2.1
+
+Upstream warns that from exporter config **v2.1** you must also install their
+`netdata.conf` on the TrueNAS host because TrueNAS 25.04 dropped default
+metrics. This cluster vendors the mapping file and three dashboards only. It
+does **not** vendor `netdata.conf`. Do not bump the mapping to v2.1 without
+adding that host file.
+
+Bumping the mapping is a separate change; this Readme only records the gap.


### PR DESCRIPTION
## Intent

Fix CI/runner, coder, and misc documentation findings from data/homeops-docs-audit-ci-misc/report.md (6 high, 14 medium, plus genuine conflicts C1-C3).

Work through that report systematically: actions-runner TROUBLESHOOTING.md and the scale-set controller README against sibling live-measured reports data/homeops-runner-capacity-scout/report.md and data/homeops-ci-rework-scout/report.md; coder README/runbooks; graphite-exporter README; docs/media-stack.md; the sabnzbd disk-space runbook; the 1Password org-services setup doc (against the 2026-05-31 1Password/ESO cutover); the pincap reference.

Constraints from the audit (do not expand into product/tooling work the report left out of scope):
- Do not change the maintenance CronJob or Taskfile to cover ai-k8s-sandbox; document that they currently cover home-ops only.
- Do not add a Coder CPU limit; do not invent a runbooks.${SECRET_DOMAIN} site; point runbook_url at the Git path if the 404 is fixed.
- Do not bump the vendored graphite mapping; record that TrueNAS 25.04 / exporter v2.1 needs netdata.conf which is not in this repo.
- Image tags in TROUBLESHOOTING should not rot on every Renovate bump: point at HelmReleases as source of truth.
- Delete or replace the orphaned docs/pincap/reference.md (no TiDB/PingCAP workload).

C1-C3 required live read-only verification, not guessing:
- C1 Tdarr plugin/encoder (HEVC in media-stack vs AV1 in Helm comment) depends on live Tdarr UI/API.
- C2 SABnzbd Direct Unpack OFF vs direct_unpack=1 depends on live SAB config.
- C3 GithubActionsRunnerControllerDown job label vs PodMonitor name depends on live Prometheus up series.

Accepted live results already recorded in this work (2026-08-21, read-only):
- C1: live flow is Movies AV1 (QSV/B70 xe) with outputCodec av1; classic Boosh HEVC stack is not in use. Document that.
- C2: live SAB API is direct_unpack=true, complete_free=100G, download_free=100G. Align media-stack with the disk-space runbook; note TRaSH still recommends OFF but standing runtime value is ON.
- C3: live up job is actions-runner-system/action-runner-controller; up{job="gha-runner-scale-set-controller"} is empty and the critical alert was false-firing. Make the PrometheusRule, PodMonitor, and TROUBLESHOOTING agree with the live job label.

Also fix the high/medium doc findings: two scale sets (home-ops and ai-k8s-sandbox), current chart/image pointers, Coder Authentik Admins->owner (password auth disabled, no hand-edit of users.rbac_roles), Tdarr xe/B70 single replica not i915 DaemonSet, shared-downloads + sabnzbd-incomplete overlay, 1Password hardcoded postgres-17-rw host and Homelab vault, coder runbook vendor leftovers, broken kubectl pipeline, Recyclarr 3D Radarr-only, GitHub App 1Password item/field names.

## What Changed

- Fixed `GithubActionsRunnerControllerDown` to match the live PodMonitor scrape job (`actions-runner-system/action-runner-controller`) instead of the nonexistent `gha-runner-scale-set-controller` job label that made the critical alert false-fire; added a `grafana_folder: CI` annotation, and updated TROUBLESHOOTING.md and the scale-set controller README to document the two scale sets (home-ops, ai-k8s-sandbox), current chart/image pointers, and the corrected job label.
- Repointed Coder `runbook_url` labels in `coderd.yaml`/`provisionerd.yaml` from the nonexistent `runbooks.${SECRET_DOMAIN}` host to the in-repo runbook paths on GitHub, and updated the Coder README/runbooks to correct the Authentik Admins->owner group mapping, Tdarr single-replica (not i915 DaemonSet) description, and vendor-doc leftovers.
- Corrected `docs/media-stack.md` (live Tdarr AV1/QSV flow, SABnzbd `direct_unpack=true`, shared-downloads + sabnzbd-incomplete overlay), the sabnzbd disk-space runbook, `docs/organisation-services-1password-setup.md` (hardcoded postgres-17-rw host, Homelab vault, GitHub App item/field names, 2026-05-31 ESO cutover), and the graphite-exporter README (documented that TrueNAS 25.04/exporter v2.1 needs a `netdata.conf` not present in this repo, without bumping the vendored mapping); removed the orphaned `docs/pincap/reference.md` (no TiDB/PingCAP workload in the cluster).

## Risk Assessment

✅ Low: The fix round is a single, correctly-targeted PromQL change that resolves the confirmed empty-vector false-negative while preserving the round-1 false-positive fix; the rest of the branch is documentation-only and was already reviewed with no unresolved issues.

## Testing

<code>This change is documentation-only plus two small config tweaks (a kustomization.yaml annotation and a PrometheusRule expr fix), so no unit/integration test suite applies; I instead did targeted read-only verification. All changed YAML files (kustomization.yaml, prometheusrule.yaml) parse cleanly with PyYAML. The PrometheusRule&#39;s GithubActionsRunnerControllerDown expr `(count(up{job=~&#34;.*action-runner-controller&#34;} == 1) or vector(0)) == 0` correctly matches the live PodMonitor named `action-runner-controller` in namespace `actions-runner-system` (verified against kubernetes/apps/actions-runner-system/gha-runner-scale-set-controller/app/pod-monitor.yaml), fixing the prior false-fire/never-fire bug per C3. Cross-checked every doc-report factual claim against source manifests: Coder HelmRelease has no CPU limit and DSN host is postgres-17-rw.database.svc.cluster.local (matches externalsecret.yaml and runbook text); Authentik Admins-&gt;owner via CODER_OIDC_USER_ROLE_MAPPING and CODER_DISABLE_PASSWORD_AUTH=true (matches helmrelease.yaml); Tdarr worker is a Deployment with replicas:1 on gpu.intel.com/xe (matches helmrelease.yaml, not a DaemonSet); shared-downloads/sabnzbd-incomplete PVC names, storage classes and sizes match pvc.yaml manifests; ClusterSecretStore vault name `Homelab` (exact casing) matches the actual ExternalSecrets config; GitHub App 1Password item/field names in TROUBLESHOOTING.md match aviator-coding/externalsecret.yaml exactly; referenced files (docs/ai-gpu-changelog.md, kubernetes/apps/media/plex/) exist. Confirmed forbidden actions were avoided: no diff to the maintenance CronJob or Taskfile (still home-ops only), no diff to Coder&#39;s helmrelease.yaml (no CPU limit added), no runbooks.${SECRET_DOMAIN} references remain (replaced with GitHub path links), the vendored graphite_mapping.conf file is untouched (only its Readme changed), and docs/pincap/reference.md was deleted with no other repo references remaining. Working tree is clean with no leftover artifacts.</code>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"b3a7f0108c234679d34ceb56fa05852a671168eb","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `kubernetes/apps/actions-runner-system/gha-runner-scale-set-controller/app/prometheusrule.yaml:37` - GithubActionsRunnerControllerDown&#39;s new expr `count(up{job=~&#34;.*action-runner-controller&#34;} == 1) == 0` can silently never fire during a real total controller outage: Prometheus/VictoriaMetrics count() over an empty/fully-filtered vector returns no series (not 0), so when all matching `up` series are 0 or absent entirely, the rule produces no alert. It correctly fixes the prior false-positive (old expr always fired since the job label never existed), but introduces a false-negative for the exact &#39;controller down&#39; case it&#39;s meant to detect. Recommended fix: `(count(up{job=~&#34;.*action-runner-controller&#34;} == 1) or vector(0)) == 0`.

🔧 Fix: fix(actions-runner): handle empty-vector case in controller-down alert
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `git diff d72f5b5a9f1be...f1d18772 --stat (full change inventory)`
- `python3 -c "import yaml; yaml.safe_load_all(...)" over every changed .yaml file (kustomization.yaml, prometheusrule.yaml)`
- `manual PromQL review of the GithubActionsRunnerControllerDown expr against the live PodMonitor name/namespace in pod-monitor.yaml`
- `cross-check of docs/media-stack.md Tdarr claims against kubernetes/apps/media/tdarr/app/helmrelease.yaml (replicas, gpu.intel.com/xe)`
- `cross-check of coder README/runbooks claims against kubernetes/apps/coder/app/helmrelease.yaml and app/externalsecret.yaml`
- `cross-check of PVC names/sizes/storageClass in docs against kubernetes/apps/downloads/pvc/app/shared-downloads.yaml and sabnzbd-incomplete.yaml`
- `cross-check of 1Password vault casing (Homelab) in docs against the live ClusterSecretStore manifest`
- `cross-check of GitHub App 1Password item/field names in TROUBLESHOOTING.md against gha-runner-scale-set/app/aviator-coding/externalsecret.yaml`
- `confirmed empty diff for .taskfiles/actions-runner/, kubernetes/apps/actions-runner-system/maintenance/, and kubernetes/apps/coder/app/helmrelease.yaml (forbidden-scope guard)`
- `confirmed docs/pincap/reference.md deleted and no remaining repo references to pincap`
- `confirmed graphite_mapping.conf byte-for-byte unchanged`
- `grep for grafana_folder usage across kubernetes/apps to confirm the new annotation follows an established repo pattern`
- `git status --porcelain (clean tree, no leftover artifacts)`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
