### PR TITLE
docs(ai): record Qwen3.6→3.8 upgrade evaluation, stay on 3.6

### DIFF
--- a/docs/ai-gpu-changelog.md
+++ b/docs/ai-gpu-changelog.md
@@ -55,6 +55,38 @@ Change · Why · Evidence · Risk/rollback · Verify
 
 ---
 
+## [2026-08-21] Qwen3.6 → 3.8 upgrade evaluated, staying on 3.6
+
+**Change:** None. HelmRelease, agentgateway config, and hermes config are unchanged -
+chat stays on `Qwen3.6-35B-A3B UD-Q4_K_M`. Docs updated with the investigation
+(`docs/ai/b70-llm-serving-tuning.md` §2/§5) so this isn't re-litigated from scratch.
+
+**Why considered:** Routine check for a Qwen3.6 → 3.8 model bump on the local chat
+model, prompted by the general Qwen3.8 release wave (`Qwen3.8-27B` dense, 2026-08-05).
+
+**Why rejected - two independent blockers:**
+- **No comparable model exists.** As of 2026-08-21, Alibaba has shipped only
+  `Qwen3.8-27B` (dense) and `Qwen3.8-2.4T-A95B` (2.4T total / 95B active MoE, far too
+  large for one 32 GiB card). No `35B-A3B`-class MoE successor to the currently-running
+  model exists; a GitHub sighting of one was confirmed a typo, not a real release
+  (`Qwen/Qwen3.8-27B` discussion #120).
+- **The dense alternative can't run on this backend.** `Qwen3.8-27B` GGUF quants do
+  exist (unsloth/bartowski, `UD-Q4_K_M` at 16.5 GiB) and would in principle fit VRAM,
+  but the architecture is a hybrid: 48/64 layers Gated DeltaNet (linear attention/SSM),
+  16/64 full attention. `ggml-sycl` (this cluster's backend) has no SSM_SCAN/SSM_CONV/
+  GATED_DELTA_NET kernels - open upstream gap, ggml-org/llama.cpp#19957 - and there's a
+  live report of exactly this shape SIGSEGV-crashing on Intel SYCL for hybrid archs
+  (ollama#15966: `qwen3.5moe`, `qwen3next`). This is independent of the llama.cpp image
+  tag; bumping past `b9592` does not add the missing kernels.
+
+**Risk/rollback:** n/a, no config changed.
+
+**Verify:** n/a. Revisit when either (a) Alibaba ships a `35B-A3B`-class Qwen3.8 MoE, or
+(b) `ggml-sycl` gains SSM/DeltaNet kernel support upstream - check
+`ggml-org/llama.cpp#19957` for status before re-attempting the dense 27B path.
+
+---
+
 ## [2026-08-21] flash-attn + q8_0 KV accepted on `server-intel-b9592`
 
 **Change:** Docs only. Rewrote the current baseline to match live GitOps and **lifted

--- a/docs/ai/b70-llm-serving-tuning.md
+++ b/docs/ai/b70-llm-serving-tuning.md
@@ -95,6 +95,7 @@ kubectl -n ai exec deploy/vllm -c app -- sh -lc 'curl -s localhost:8000/metrics 
 | `q8_0` KV cost (~6% tg) | **Accepted** | required for VRAM fit; see §3 |
 | vLLM hosts 35B MoE on 1 card (`intel/llm-scaler#382`) | **Still blocked** | #382 OPEN; OOMs even on 2 cards. Keep llama.cpp |
 | `GGML_SYCL_DISABLE_OPT=1` for MoE stability | **Not needed for us** | single-source claim; our pod ran 7d, 4 slots, no SEGV |
+| SYCL Gated DeltaNet / SSM kernels (needed for hybrid archs, e.g. Qwen3.8-27B) | **Missing** | `ggml-sycl` has no SSM_SCAN/SSM_CONV/GATED_DELTA_NET kernels; ollama#15966 reports SIGSEGV on hybrid archs (`qwen3.5moe`, `qwen3next`) on Intel SYCL. Blocks any hybrid `qwen35`/`qwen35moe`-family model on this backend until upstream adds support - independent of image tag |
 
 ## 3. Tuning A/B matrix
 
@@ -247,3 +248,4 @@ is a **second B70** (one model per card, no time-slicing) — currently **deferr
 | --- | --- | --- |
 | 2026-06-26 | Baseline + SYCL-vs-Vulkan A/B + tuning matrix | SYCL kept (61 vs 36 t/s); config validated; isolation identified as the win |
 | 2026-07-08 | `--ctx-size` 131072 → 262144 (native max, no yarn) | Live-tested with `vllm-embed`/`comfyui` both at `replicas: 0`: loads clean (0 restarts), decode 68.4 t/s (no regression). KV grows ~2.6→~5.2 GiB. Motivated by 115 "failed to find free space in the KV cache" warnings observed in prod at 131072 — 4 concurrent slots were oversubscribing the shared unified pool, not one long chat. Only fits because the card is otherwise empty; re-enabling embeddings or ComfyUI needs re-validation and possibly stepping back down. |
+| 2026-08-21 | Evaluated Qwen3.6 → 3.8 upgrade | **No change - staying on Qwen3.6-35B-A3B.** No Qwen3.8 MoE (35B-A3B class) release exists; Alibaba has only shipped dense `Qwen3.8-27B` and `Qwen3.8-2.4T-A95B` (too large for one B70). `Qwen3.8-27B` GGUF quants exist (unsloth, bartowski) but the architecture is 48/64 Gated DeltaNet + 16/64 full-attention layers, requiring SSM kernels `ggml-sycl` doesn't implement (see §2) - would crash on load regardless of image tag. Revisit when either a comparable MoE 3.8 ships or SYCL SSM support lands upstream. |


### PR DESCRIPTION
## Intent

Update the local Qwen model from 3.6 to 3.8 on the Intel Arc B70 and adjust every downstream reference to match, per docs/ai/b70-llm-serving-tuning.md and the vllm helmrelease. Required precondition before touching any live config: verify a Qwen3.8-35B-A3B (or equivalent) GGUF quant actually exists at a comparable quant level, and if the architecture changed, redo the VRAM/KV-cache math for the new model rather than copying the 3.6 numbers forward. Also check for other pending model updates (embedding model Qwen/Qwen3-VL-Embedding-2B, vision model qwen/qwen3-vl-32b-instruct) while in this area, without upgrading them without asking.

Investigation outcome, confirmed with the user/captain: no live config change is being made. No Qwen3.8 MoE (35B-A3B class) model exists as of 2026-08-21 - Alibaba has only shipped Qwen3.8-27B (dense) and Qwen3.8-2.4T-A95B (too large for one 32GB card); a GitHub sighting of a 35B-A3B variant was confirmed a typo, not real. The dense Qwen3.8-27B alternative does have GGUF quants (unsloth/bartowski, UD-Q4_K_M at 16.5 GiB), and the user's first instinct was to try it anyway since it could be reverted - but further research showed llama.cpp's SYCL backend (this cluster's backend) has no SSM_SCAN/SSM_CONV/GATED_DELTA_NET kernel implementations that Qwen3.8-27B's hybrid architecture (48/64 Gated DeltaNet layers, 16/64 full-attention layers) requires - an open upstream gap (ggml-org/llama.cpp#19957), with a live report of exactly this failure mode SIGSEGV-crashing on Intel SYCL for hybrid architectures (ollama#15966). This is independent of the llama.cpp image tag, so it is not a revertible experiment - it would be a near-certain crash of the cluster's only local chat model for the ~30-minute startup-probe window. Given that, the user/captain decided to stay on Qwen3.6-35B-A3B rather than deploy a combination known to fail architecturally.

The embedding and vision models were checked and found not stale (no newer versions worth flagging).

The completed deliverable is documentation only: a dated entry in docs/ai-gpu-changelog.md and two additions to docs/ai/b70-llm-serving-tuning.md (an upstream-applicability-verdicts table row on the missing SYCL SSM kernels, and a change-log table row) recording this investigation, its two independent blockers, and the revisit trigger (a real MoE-class Qwen3.8 ships, or SYCL SSM support lands upstream), so this isn't re-investigated from scratch later. No kubernetes/apps/ai manifests were touched.

## What Changed

- Added a dated entry to `docs/ai-gpu-changelog.md` documenting the evaluation of a Qwen3.6 → 3.8 upgrade for the local chat model on the Intel Arc B70, recording that no config change was made and the two independent blockers found (no comparable `35B-A3B`-class MoE model exists; the dense `Qwen3.8-27B` alternative's hybrid Gated DeltaNet/SSM architecture has no `ggml-sycl` kernel support), plus the revisit trigger.
- Added a row to the upstream-applicability-verdicts table in `docs/ai/b70-llm-serving-tuning.md` §2 marking SYCL Gated DeltaNet/SSM kernels as "Missing," citing the upstream gap (`ggml-org/llama.cpp#19957`) and a live SIGSEGV report on Intel SYCL for hybrid architectures (`ollama#15966`).
- Added a row to the change-log table in `docs/ai/b70-llm-serving-tuning.md` §5 summarizing the same evaluation outcome and revisit conditions.

## Risk Assessment

✅ Low: Documentation-only change (2 files, +34 lines) recording an investigation with no config, manifest, or code touched; content matches the authorized-containment intent exactly.

## Testing

This is a documentation-only change (no code, no live config); verified via diff stat that only the two intended markdown files changed and that kubernetes/apps/ai manifests are untouched, matching the intent's explicit 'no live config change' outcome, then rendered both files to HTML to confirm the new table rows and changelog entry are well-formed and display correctly - no broken markdown, no stray edits, worktree left clean.

<details>
<summary>Evidence: docs/ai-gpu-changelog.md rendered as HTML</summary>

```text
<html><head><meta charset='utf-8'><style>
body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Helvetica,Arial,sans-serif;max-width:980px;margin:20px auto;padding:0 20px;color:#1f2328;line-height:1.5;}
table{border-collapse:collapse;width:100%;margin:16px 0;}
th,td{border:1px solid #d1d9e0;padding:6px 13px;text-align:left;}
th{background:#f6f8fa;font-weight:600;}
tr:nth-child(2n){background:#f6f8fa;}
code{background:#f6f8fa;padding:.2em .4em;border-radius:6px;font-size:85%;}
h1,h2,h3{border-bottom:1px solid #d1d9e0;padding-bottom:.3em;}
</style></head><body><h1>AI / B70 GPU Stack Change Log</h1>
<p>Track record of <strong>deliberate configuration changes</strong> to the <code>ai</code> namespace and the Intel
Arc Pro B70 GPU it runs on - what changed, why, the evidence behind it, and how to roll it
back. Mirrors <a href="./ceph-cluster-changelog.md"><code>ceph-cluster-changelog.md</code></a> (deliberate Ceph
changes) and <a href="./hardware-incidents.md"><code>hardware-incidents.md</code></a> (hardware failures), but for
the GPU / LLM-serving stack. Goal: when something breaks, answer &quot;what did we change
recently, and why?&quot; without spelunking git.</p>
<ul>
<li><strong>Hardware failures</strong> → <a href="./hardware-incidents.md"><code>hardware-incidents.md</code></a></li>
<li><strong>Ceph config changes</strong> → <a href="./ceph-cluster-changelog.md"><code>ceph-cluster-changelog.md</code></a></li>
<li><strong>This file</strong> → chronological log of applied AI / GPU changes</li>
</ul>
<blockquote>
<p>⚠️ All AI config is GitOps under <code>kubernetes/apps/ai/</code>. Changes go through the relevant
HelmRelease (e.g. <code>kubernetes/apps/ai/vllm/app/helmrelease.yaml</code>); Flux reconciles.
Record every deliberate change here when you merge it.</p>
</blockquote>
<hr>
<h2>Current baseline (2026-08-21)</h2>
<table>
<thead>
<tr>
<th>Layer</th>
<th>Value</th>
</tr>
</thead>
<tbody><tr>
<td><strong>GPU</strong></td>
<td>1× Intel Arc Pro B70 (Battlemage G31, 32 GiB / 32656 MiB reported), on talos-3 via OCuLink</td>
</tr>
<tr>
<td><strong>Device plugin</strong></td>
<td><code>gpu.intel.com/xe: 99</code> shared units - a <strong>scheduling token only, no VRAM fencing</strong></td>
</tr>
<tr>
<td><strong>On the card</strong></td>
<td>chat (<code>vllm</code>) only. <code>vllm-embed</code> and <code>comfyui</code> are pinned <code>replicas: 0</code></td>
</tr>
<tr>
<td><strong>Chat image</strong></td>
<td><code>ghcr.io/ggml-org/llama.cpp:server-intel-b9592</code> (pin is load-bearing; do not float to <code>server-intel</code>)</td>
</tr>
<tr>
<td><strong>Chat window</strong></td>
<td><code>--ctx-size 262144</code> (native max, no yarn), auto <code>n_parallel=4</code> + <code>kv_unified=true</code></td>
</tr>
<tr>
<td><strong>Chat KV / FA</strong></td>
<td><code>--flash-attn on</code>, <code>--cache-type-k/-v q8_0</code> (accepted on this pin; see 2026-08-21)</td>
</tr>
</tbody></table>
<h3>Workloads on the B70</h3>
<table>
<thead>
<tr>
<th>Pod</th>
<th>Image</th>
<th>Role</th>
<th>VRAM</th>
</tr>
</thead>
<tbody><tr>
<td><code>vllm</code></td>
<td><code>ghcr.io/ggml-org/llama.cpp:server-intel-b9592</code></td>
<td>Chat - <strong>llama.cpp SYCL</strong>, <code>Qwen3.6-35B-A3B UD-Q4_K_M</code>. Keeps the <code>vllm</code> name so the service + gateway backend stay stable; real vLLM OOMs the MoE warmup (intel/llm-scaler#382).</td>
<td>~21.4 GiB weights + ~5.2 GiB KV @262k q8_0</td>
</tr>
<tr>
<td><code>vllm-embed</code></td>
<td><code>intel/llm-scaler-vllm</code></td>
<td>Embeddings - <code>Qwen3-VL-Embedding-2B</code>. <strong>Default off</strong> (<code>replicas: 0</code>); agentmemory moved to OpenRouter 2026-06-28.</td>
<td>(not resident)</td>
</tr>
<tr>
<td><code>comfyui</code></td>
<td><code>intel/llm-scaler-omni</code></td>
<td>Image generation. <strong>Default off</strong> (<code>replicas: 0</code>).</td>
<td>(not resident)</td>
</tr>
</tbody></table>
<h3>SYCL / Battlemage constraints</h3>
<ul>
<li>✅ <strong><code>--flash-attn on</code> + <code>--cache-type-k/-v q8_0</code></strong> are the live, measured baseline on <code>server-intel-b9592</code> (enabled 2026-06-17, verified 2026-08-21). The 2026-06-14 prohibition citing ggml-org/llama.cpp#19276 does <strong>not</strong> apply to this official SYCL build on the B70.</li>
<li>⚠️ <strong>Do not bump the llama.cpp tag without re-measuring.</strong> Later SYCL FA/XMX and Q4_K MoE-reorder work landed after b9592; quality and hang reports on newer builds are a different stack (see 2026-08-21).</li>
<li>✅ For heavy ComfyUI work, scale <code>vllm</code>→0 first - the card is shared with no memory fencing. Flux will return ComfyUI to <code>replicas: 0</code>.</li>
</ul>
<hr>
<h2>How to add an entry</h2>
<p>When you merge an AI / GPU config change, prepend an entry (newest first):</p>
<pre><code class="language-markdown">## [YYYY-MM-DD] Short title  (PR #NNN)
Change · Why · Evidence · Risk/rollback · Verify
</code></pre>
<hr>
<h2>[2026-08-21] Qwen3.6 → 3.8 upgrade evaluated, staying on 3.6</h2>
<p><strong>Change:</strong> None. HelmRelease, agentgateway config, and hermes config are unchanged -
chat stays on <code>Qwen3.6-35B-A3B UD-Q4_K_M</code>. Docs updated with the investigation
(<code>docs/ai/b70-llm-serving-tuning.md</code> §2/§5) so this isn&#39;t re-litigated from scratch.</p>
<p><strong>Why considered:</strong> Routine check for a Qwen3.6 → 3.8 model bump on the local chat
model, prompted by the general Qwen3.8 release wave (<code>Qwen3.8-27B</code> dense, 2026-08-05).</p>
<p><strong>Why rejected - two independent blockers:</strong></p>
<ul>
<li><strong>No comparable model exists.</strong> As of 2026-08-21, Alibaba has shipped only
<code>Qwen3.8-27B</code> (dense) and <code>Qwen3.8-2.4T-A95B</code> (2.4T total / 95B active MoE, far too
large for one 32 GiB card). No <code>35B-A3B</code>-class MoE successor to the currently-running
model exists; a GitHub sighting of one was confirmed a typo, not a real release
(<code>Qwen/Qwen3.8-27B</code> discussion #120).</li>
<li><strong>The dense alternative can&#39;t run on this backend.</strong> <code>Qwen3.8-27B</code> GGUF quants do
exist (unsloth/bartowski, <code>UD-Q4_K_M</code> at 16.5 GiB) and would in principle fit VRAM,
but the architecture is a hybrid: 48/64 layers Gated DeltaNet (linear attention/SSM),
16/64 full attention. <code>ggml-sycl</code> (this cluster&#39;s backend) has no SSM_SCAN/SSM_CONV/
GATED_DELTA_NET kernels - open upstream gap, ggml-org/llama.cpp#19957 - and there&#39;s a
live report of exactly this shape SIGSEGV-crashing on Intel SYCL for hybrid archs
(ollama#15966: <code>qwen3.5moe</code>, <code>qwen3next</code>). This is independent of the llama.cpp image
tag; bumping past <code>b9592</code> does not add the missing kernels.</li>
</ul>
<p><strong>Risk/rollback:</strong> n/a, no config changed.</p>
<p><strong>Verify:</strong> n/a. Revisit when either (a) Alibaba ships a <code>35B-A3B</code>-class Qwen3.8 MoE, or
(b) <code>ggml-sycl</code> gains SSM/DeltaNet kernel support upstream - check
<code>ggml-org/llama.cpp#19957</code> for status before re-attempting the dense 27B path.</p>
<hr>
<h2>[2026-08-21] flash-attn + q8_0 KV accepted on <code>server-intel-b9592</code></h2>
<p><strong>Change:</strong> Docs only. Rewrote the current baseline to match live GitOps and <strong>lifted
the 2026-06-14 &quot;do not enable flash-attn / q8_0 KV&quot; prohibition.</strong> HelmRelease args are
unchanged (<code>kubernetes/apps/ai/vllm/app/helmrelease.yaml</code>: <code>--flash-attn on</code>,
<code>--cache-type-k/-v q8_0</code>).</p>
<p><strong>Why the 2026-06-14 prohibition was wrong for this stack:</strong></p>
<ul>
<li>ggml-org/llama.cpp#19276 (the cited bug) was filed 2026-02-02 against the <strong>IPEX-LLM
XPU container</strong>, whose llama.cpp is a closed-source fork. intel/ipex-llm was archived
2026-01-28. Hardware in that report is an <strong>Arrow Lake-H iGPU</strong>, not this Arc Pro B70.
Maintainer NeoZhangJianyu: IPEX-LLM is unsupported. Closed 2026-03-14 as <code>not_planned</code>
(stale) - never confirmed, never fixed on official SYCL.</li>
<li>Official ggml-org SYCL al

... [722 bytes truncated] ...

> / <code>2eabcc67</code>) and still live 2026-08-21 - <strong>two months</strong>
of production. No home-ops issue, commit, alert, or AI-doc note of output corruption,
FA segfaults, or a revert of these flags. The 2026-06-26 tuning runbook
(<code>docs/ai/b70-llm-serving-tuning.md</code>) measured SYCL decode <strong>~61 t/s</strong> with
<code>q8_0/q8_0</code> + <code>--flash-attn on</code> and recorded <strong>7 days, 4 slots, no SEGV</strong>.</li>
<li>2026-07-08 (<code>07fe6828</code>): <code>--ctx-size 262144</code> live-tested on the same flags, <strong>0
restarts, 68.4 t/s decode</strong>. q8_0 is required for that KV to fit (~5.2 GiB at 262k).</li>
<li>Completions used for those timings returned coherent <code>predicted_per_second</code> samples;
Hermes has used this server as the local chat backend throughout.</li>
</ul>
<p><strong>Not a reason to revert live config, but a reason not to float the tag:</strong></p>
<ul>
<li>ggml-org/llama.cpp#25692 (open): FA + q8_0/q8_0 GPU hang (xe CCS engine reset) on a
B70 under concurrent load, on <strong>newer master</strong>, original host kernel 6.17.0-1028-oem.
Reporter could not reproduce after moving the same card to a newer xe kernel +
OCuLink; maintainer suspected that OEM kernel. This cluster is Talos + OCuLink on
b9592, and has not logged that hang.</li>
<li>ggml-org/llama.cpp#25761 (closed duplicate): Qwen3.6-35B-A3B thinking-mode gibberish
on a B70 in the <strong>b9802 → b10034</strong> window (after this pin). XMX FA (PR #25222,
2026-07-15) also landed after b9592.</li>
<li>ggml-org/llama.cpp#24168 (open): hybrid-model empty/gibberish on <strong>B60</strong> around
b9128-b9479. Does not match measured B70 / b9592 production.</li>
</ul>
<p><strong>Risk / rollback:</strong> leave HelmRelease as-is. If a future image bump regresses quality
or hangs, revert the tag to <code>server-intel-b9592</code> before touching FA/q8_0; those flags
are required for 262k to fit.</p>
<p><strong>Verify:</strong> <code>kubectl -n ai exec deploy/vllm -c app -- sh -lc &#39;curl -s localhost:8000/props&#39;</code>
shows flash-attn on + q8_0 K/V; a short <code>/completion</code> returns coherent text and a
non-zero <code>predicted_per_second</code> (see the tuning runbook reproduce block).</p>
<hr>
<h2>[2026-07-08] vllm chat context 128k → 262144  (<code>07fe6828</code>)</h2>
<p><strong>Change:</strong> <code>--ctx-size 131072</code> → <code>262144</code> in <code>kubernetes/apps/ai/vllm/app/helmrelease.yaml</code>.
Native window, no yarn. Fits only because <code>vllm-embed</code> and <code>comfyui</code> are both <code>replicas: 0</code>.</p>
<p><strong>Why:</strong> 115 &quot;failed to find free space in the KV cache&quot; warnings at 131072 - four
concurrent slots oversubscribing the shared unified pool, not one long chat.</p>
<p><strong>Evidence:</strong> live-tested on the empty card: clean load, 0 restarts, <strong>68.4 t/s decode</strong>.
KV grows ~2.6 → ~5.2 GiB at q8_0. Recorded in <code>docs/ai/b70-llm-serving-tuning.md</code> §5.</p>
<p><strong>Risk / rollback:</strong> re-enabling embeddings or ComfyUI needs re-validation; step back
toward 131072 on VRAM OOM.</p>
<hr>
<h2>[2026-06-28] scale vllm-embed to 0  (PR #1098)</h2>
<p><strong>Change:</strong> <code>vllm-embed</code> <code>replicas: 0</code>. Controller + PVC kept. agentmemory moved to
OpenRouter embeddings (<code>text-embedding-3-small</code>).</p>
<p><strong>Why:</strong> free the B70 <code>gpu.intel.com/xe</code> slot and ~5-6.5 GiB VRAM so chat can own the
card. Restoring local embeddings is a one-line revert (<code>replicas: 0</code> → <code>1</code>).</p>
<hr>
<h2>[2026-06-26] B70 serving validated; ComfyUI default-off  (PR #1092)</h2>
<p><strong>Change:</strong> Measured SYCL vs Vulkan and the live llama.cpp args on <code>server-intel-b9592</code>.
Pinned ComfyUI <code>replicas: 0</code> in git. Full write-up: <code>docs/ai/b70-llm-serving-tuning.md</code>.</p>
<p><strong>Evidence:</strong> SYCL decode <strong>~61 t/s</strong> vs Vulkan ~36 t/s on the MoE chat model. <code>q8_0</code> KV</p>
<ul>
<li><code>--flash-attn on</code> kept (VRAM-bound, not a speed trade). Explicit <code>--parallel</code> /
<code>--kv-unified</code> pin was tried and <strong>reverted the next day</strong> (PR #1093) - on b9592 the
explicit flags overcommit KV and collapse decode to ~0.5 t/s; leave auto.</li>
</ul>
<p><strong>Isolation:</strong> chat decode collapses ~38× (61 → 1.6 t/s) under an embeddings flood.
The B70 has no hardware compute partition. Run ComfyUI only after scaling <code>vllm</code> to 0.</p>
<hr>
<h2>[2026-06-17] enable flash-attn, q8_0 KV, cache-reuse, no-mmap  (<code>5d99d64f</code>)</h2>
<p><strong>Change:</strong> in <code>kubernetes/apps/ai/vllm/app/helmrelease.yaml</code>:</p>
<ul>
<li><code>--flash-attn</code> (follow-up <code>2eabcc67</code> passes explicit <code>on</code>; the flag requires on|off|auto)</li>
<li><code>--cache-type-k/-v q8_0</code></li>
<li><code>--cache-reuse 256</code></li>
<li><code>--no-mmap</code></li>
<li><code>UR_L0_ENABLE_RELAXED_ALLOCATION_LIMITS=1</code>, <code>SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1</code></li>
</ul>
<p><strong>Why (commit rationale):</strong> unlock KV quantization + better attention memory access;
halve KV VRAM at 131k; prefix reuse for Hermes system prompts; avoid Ceph RBD
page-fault jitter on load; Intel L0 alloc + dispatch opts.</p>
<p><strong>Evidence at the time:</strong> none recorded in this changelog (gap closed 2026-08-21).
Subsequent production measurements are in the 2026-06-26 and 2026-08-21 entries.</p>
<hr>
<h2>[2026-06-14] vllm chat context 32k → 128k  (PR #982)</h2>
<p><strong>Change:</strong> <code>--ctx-size 32768</code> → <code>131072</code> in <code>kubernetes/apps/ai/vllm/app/helmrelease.yaml</code>
(the llama.cpp chat server). Raises the per-request context window from 32k to <strong>128k</strong>.</p>
<p><strong>Why it fits the 32 GiB card:</strong></p>
<ul>
<li><code>Qwen3.6-35B-A3B</code> native window is <strong>262144</strong> (<code>max_position_embeddings</code>, <code>rope_type: default</code>,
no yarn) → 128k needs <strong>no rope/yarn scaling</strong>.</li>
<li>Hybrid arch: 40 layers, <code>full_attention_interval: 4</code> → only <strong>10 layers</strong> keep a growing KV
cache; the other 30 are Gated DeltaNet (fixed-size state). With <code>num_key_value_heads: 2</code>,
<code>head_dim: 256</code>, KV ≈ <strong>20 KiB/token → ~2.6 GiB at 128k</strong>.</li>
<li>Live server runs <code>n_parallel = 4, kv_unified = true</code>, so the KV cache is one shared pool sized
to <code>--ctx-size</code>; a single request can use the whole pool. Raising <code>--ctx-size</code> raises the
per-request ceiling directly (no <code>-np</code> change needed).</li>
</ul>
<p><strong>Evidence (live pod, 2026-06-14):</strong>
<code>SYCL0 : Intel(R) Arc(TM) Pro B70 Graphics (32656 MiB, 32574 MiB free)</code>;
<code>n_parallel is set to auto, using n_parallel = 4 and kv_unified = true</code>; warning
<code>n_ctx_seq (32768) &lt; n_ctx_train (262144)</code> confirmed 32k was the prior ceiling.</p>
<p><strong>Deliberately NOT changed at this commit:</strong> no <code>-fa</code>, no <code>q8_0</code> KV. That choice was
the 2026-06-14 belief (citing ggml-org/llama.cpp#19276). <strong>Superseded 2026-06-17</strong> when
those flags were enabled on the same <code>server-intel-b9592</code> image; see 2026-08-21 for why
#19276 does not apply here. KV at 128k was small enough without them (~2.6 GiB).</p>
<p><strong>Risk / rollback:</strong> a bigger KV pool narrows the VRAM headroom for ComfyUI + chat + embed running
at peak together. On a VRAM OOM (<code>out of device memory</code> in the <code>vllm</code> pod, especially with ComfyUI
active), step <code>--ctx-size</code> down to <code>98304</code> then <code>65536</code>.</p>
<p><strong>Verify:</strong> <code>kubectl -n ai logs deploy/vllm -c app | grep -E &quot;n_ctx|kv_unified|out of device memory&quot;</code>
→ slots show <code>n_ctx = 131072</code>, no OOM; then a ~70k-token request through the <code>/vllm</code> gateway returns
a coherent, non-truncated response.</p>
</body></html>
```
</details>
- Evidence: docs/ai/b70-llm-serving-tuning.md rendered as HTML (local file: <code>/var/folders/yr/h20mxtv56yj1c1pt9tr1_kbc0000gn/T/no-mistakes-evidence/01M0K6N50RMMWA283TRVMAF5TM/b70-llm-serving-tuning.full.html</code>)
<details>
<summary>Evidence: Diff stat confirming docs-only change scope</summary>

```text
git diff d94c7ab0..13beac1e --stat
docs/ai-gpu-changelog.md | 32 ++++++++++++++++++++++++++++++++
docs/ai/b70-llm-serving-tuning.md | 2 ++
2 files changed, 34 insertions(+)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"13beac1ef018477891c32ee0cf45448c045007bb","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`git diff d94c7ab0..13beac1e --stat` - confirmed only docs/ai-gpu-changelog.md and docs/ai/b70-llm-serving-tuning.md changed (34 insertions, 0 deletions)</code>
- <code>`git diff d94c7ab0..13beac1e -- kubernetes/apps/ai` - confirmed zero lines changed, verifying the intent&#39;s &#39;no manifests touched&#39; claim</code>
- `Manually verified both new markdown table rows have the correct pipe-delimited column count matching their table headers (3 columns each)`
- <code>Rendered both changed markdown files to HTML via `npx marked` to confirm the new tables and changelog entry parse and display without markup breakage</code>
- <code>`git status --porcelain` before and after testing - confirmed clean worktree, no stray files introduced</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
