### PR TITLE
fix(ai): bump hermes VOLSYNC_CAPACITY to match actual PVC size

### DIFF
--- a/kubernetes/apps/ai/hermes/ks.yaml
+++ b/kubernetes/apps/ai/hermes/ks.yaml
@@ -29,7 +29,8 @@ spec:
     substitute:
       APP: *app
       CONFIG_TIMEZONE: America/New_York
-      VOLSYNC_CAPACITY: 10Gi
+      VOLSYNC_CAPACITY: 25Gi
+      VOLSYNC_CACHE_CAPACITY: 5Gi
       VOLSYNC_SCHEDULE_CEPH: "35 */4 * * *"
       VOLSYNC_SCHEDULE_MINIO: "35 */6 * * *"
       VOLSYNC_SCHEDULE_R2: "10 2 * * *"


### PR DESCRIPTION
## Intent

Fix Hermes' PVC capacity mismatch that's blocking Flux reconciliation. kubernetes/apps/ai/hermes/ks.yaml declared VOLSYNC_CAPACITY: 10Gi, but the actual bound PVC (kubectl -n ai get pvc hermes) is 25Gi - it grew at some point outside Git. Kubernetes forbids shrinking a bound PVC, so Flux's dry-run apply was failing continuously with: PersistentVolumeClaim "hermes" is invalid: spec.resources.requests.storage: Forbidden: field can not be less than status.capacity. This blocked the hermes Kustomization from ever reaching Ready=True, meaning any future change to this app could not be applied by Flux (the pod itself was running fine, 3/3 Ready, on the last state that did apply). Fix: bump ks.yaml's VOLSYNC_CAPACITY to 25Gi to match current reality. Also checked CLAUDE.md's Volsync cache-sizing guidance (20-50% of PVC size for cache capacity) and set VOLSYNC_CACHE_CAPACITY to 5Gi (20%, previously unset so it defaulted to an undersized 2Gi). Verified by reproducing the exact error against the live cluster (flux get ks -n ai hermes, kubectl -n ai get pvc hermes), then confirming the fix resolves it via flux build ks --kustomization-file against the locally edited ks.yaml plus kubectl apply --dry-run=server against the live cluster - all 14 hermes resources including the PVC applied cleanly with no errors.

## What Changed

- Bumped `VOLSYNC_CAPACITY` for hermes from `10Gi` to `25Gi` in `kubernetes/apps/ai/hermes/ks.yaml` to match the actual bound PVC size, which had grown outside Git and was blocking Flux reconciliation (Kubernetes forbids shrinking a bound PVC's requested storage below its current capacity).
- Set `VOLSYNC_CACHE_CAPACITY` to `5Gi` (20% of the new PVC size, per this repo's cache-sizing guidance), where it was previously unset and defaulting to an undersized `2Gi`.

## Risk Assessment

✅ Low: Single-line config value change (PVC capacity increase to match live cluster reality, plus a related cache-size increase) that only enlarges volumes, never shrinks a bound PVC, matching CLAUDE.md guidance and the stated intent exactly.

## Testing

Ran `flux build kustomization` (local dry-run, no cluster mutation) against both the base and fixed ks.yaml: the fix cleanly renders all 14 hermes resources with the PVC at 25Gi and VolSync cache capacity at 5Gi everywhere, exactly matching the stated intent; live-cluster verification (`kubectl apply --dry-run=server`, `flux get ks`) as performed by the author was not reproducible here since this sandbox has no kubeconfig context, so that portion of the author's evidence is trusted rather than independently re-confirmed.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"08807956fe8ed48232a10793527f18b4243f0de5","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`flux build kustomization hermes --path ./kubernetes/apps/ai/hermes/app --kustomization-file ./kubernetes/apps/ai/hermes/ks.yaml --dry-run --namespace ai` (target commit) - built all 14 resources with no errors; PersistentVolumeClaim renders `storage: 25Gi`; all 4 VolSync cache fields render `cacheCapacity: 5Gi`</code>
- <code>Same command against the base commit&#39;s ks.yaml (bf03fdae) for comparison - renders `storage: 10Gi` with `cacheCapacity: 1Gi`/`2Gi` (unset/defaulted), confirming the before/after delta matches the intended fix</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
