### PR TITLE
docs(taskfiles): update stale 10.10.3.x IPs to current 10.10.10.x addressing

### DIFF
--- a/.taskfiles/network/README.md
+++ b/.taskfiles/network/README.md
@@ -96,9 +96,9 @@ The test suite is configured with the following parameters:
 
 ```yaml
 vars:
-  TALOS_NODE_1: "10.10.3.11"  # talos-1
-  TALOS_NODE_2: "10.10.3.12"  # talos-2
-  TALOS_NODE_3: "10.10.3.13"  # talos-3
+  TALOS_NODE_1: "10.10.10.11"  # talos-1
+  TALOS_NODE_2: "10.10.10.12"  # talos-2
+  TALOS_NODE_3: "10.10.10.13"  # talos-3
   IPERF3_IMAGE: "networkstatic/iperf3:latest"
   TEST_DURATION: "30"          # seconds
   TEST_PARALLEL: "4"           # parallel streams
@@ -204,27 +204,27 @@ Slave queue ID: 0
 🚀 Running comprehensive network speed tests...
 Test parameters: Duration=30s, Parallel=4 streams
 
-Testing talos-1 (10.10.3.11) -> talos-2 (10.10.3.12)
+Testing talos-1 (10.10.10.11) -> talos-2 (10.10.10.12)
 [SUM]   0.00-30.00  sec  8.24 GBytes  2.31 Gbits/sec  4             sender
 [SUM]   0.00-30.00  sec  8.24 GBytes  2.31 Gbits/sec                  receiver
 
-Testing talos-1 (10.10.3.11) -> talos-3 (10.10.3.13)
+Testing talos-1 (10.10.10.11) -> talos-3 (10.10.10.13)
 [SUM]   0.00-30.00  sec  8.43 GBytes  2.36 Gbits/sec  4             sender
 [SUM]   0.00-30.00  sec  8.43 GBytes  2.36 Gbits/sec                  receiver
 
-Testing talos-2 (10.10.3.12) -> talos-1 (10.10.3.11)
+Testing talos-2 (10.10.10.12) -> talos-1 (10.10.10.11)
 [SUM]   0.00-30.00  sec  8.31 GBytes  2.33 Gbits/sec  4             sender
 [SUM]   0.00-30.00  sec  8.31 GBytes  2.33 Gbits/sec                  receiver
 
-Testing talos-2 (10.10.3.12) -> talos-3 (10.10.3.13)
+Testing talos-2 (10.10.10.12) -> talos-3 (10.10.10.13)
 [SUM]   0.00-30.00  sec  8.36 GBytes  2.34 Gbits/sec  4             sender
 [SUM]   0.00-30.00  sec  8.36 GBytes  2.34 Gbits/sec                  receiver
 
-Testing talos-3 (10.10.3.13) -> talos-1 (10.10.3.11)
+Testing talos-3 (10.10.10.13) -> talos-1 (10.10.10.11)
 [SUM]   0.00-30.00  sec  8.28 GBytes  2.32 Gbits/sec  4             sender
 [SUM]   0.00-30.00  sec  8.28 GBytes  2.32 Gbits/sec                  receiver
 
-Testing talos-3 (10.10.3.13) -> talos-2 (10.10.3.12)
+Testing talos-3 (10.10.10.13) -> talos-2 (10.10.10.12)
 [SUM]   0.00-30.00  sec  8.39 GBytes  2.35 Gbits/sec  4             sender
 [SUM]   0.00-30.00  sec  8.39 GBytes  2.35 Gbits/sec                  receiver
 ```
@@ -286,8 +286,8 @@ All OSDs are up and in:
 - osd.8 (talos-3): up, in
 
 📊 Network configuration:
-public_network = 10.10.3.0/24
-cluster_network = 10.10.3.0/24
+public_network = 10.10.10.0/24
+cluster_network = 10.10.10.0/24
 ```
 
 **Ceph Performance Analysis:**
@@ -411,7 +411,7 @@ Create a cron job for regular network validation:
            miimon: 100
            hashPolicy: layer2+3
          addresses:
-           - 10.10.3.x/24
+           - 10.10.10.x/24
    ```
 
 2. **TCP Tuning for High Bandwidth**
@@ -524,7 +524,7 @@ pipeline {
    task network:check-routes
 
    # Check talosctl connectivity
-   talosctl -n 10.10.3.11 version
+   talosctl -n 10.10.10.11 version
 
    # Test basic ping
    task network:ping-test

--- a/.taskfiles/rook/README.md
+++ b/.taskfiles/rook/README.md
@@ -278,7 +278,7 @@ The Taskfile uses different node references for different operations:
   - Kubernetes identifies nodes by their registered node names
 
 - **Talos CLI Operations** (e.g., `talosctl -n`, direct API calls): Use **IP addresses**
-  - `TALOS_NODE_IPS`: `[10.10.3.11, 10.10.3.12, 10.10.3.13]`
+  - `TALOS_NODE_IPS`: `[10.10.10.11, 10.10.10.12, 10.10.10.13]`
   - Talos CLI connects directly to node IP addresses
 
 This dual reference system ensures:
@@ -406,7 +406,7 @@ If disk checking fails with missing commands:
 task rook:check-node-disks node=talos-1
 
 # Alternative: Check disks directly via Talos
-talosctl -n 10.10.3.11 list /dev/disk/by-id/
+talosctl -n 10.10.10.11 list /dev/disk/by-id/
 ```
 
 ## ⚠️ Important Warnings
@@ -435,7 +435,7 @@ task rook:health-check
 
 # Manual node health check
 kubectl get nodes -o wide
-talosctl health --nodes 10.10.3.11,10.10.3.12,10.10.3.13
+talosctl health --nodes 10.10.10.11,10.10.10.12,10.10.10.13
 ```
 
 ## 🔄 Recommended Workflow
@@ -494,7 +494,7 @@ If you encounter connectivity issues:
 
 - **Talos CLI operations failing**: Check that IP addresses are correct and accessible
   ```bash
-  talosctl -n 10.10.3.11 version
+  talosctl -n 10.10.10.11 version
   ```
 
 - **Updating node references**: Edit the `TALOS_NODE_NAMES` and `TALOS_NODE_IPS` variables in the Taskfile if your cluster configuration changes


### PR DESCRIPTION
## Intent

Fix stale 10.10.3.x IP references in .taskfiles/network/README.md and .taskfiles/rook/README.md. These files still reference stale 10.10.3.x IPs, predating the 2025-08-16 subnet cutover documented in data/homeops-docs-audit-networking/report.md (found by a sibling documentation-fix task). Update to current addressing (10.10.10.x per that report), or snapshot-label the section explicitly if the historical IPs are intentionally preserved as a worked example rather than current state - checked which reading fits each reference before assuming.

Verified against the actual .taskfiles/network/Taskfile.yaml (TALOS_NODE_1/2/3) and .taskfiles/rook/Taskfile.yaml (TALOS_NODE_IPS), which already use 10.10.10.x for the three Talos nodes (talos-1/2/3 = .11/.12/.13). Every 10.10.3.x reference in both READMEs is current-state usage documentation - Taskfile variable examples, sample command output, and troubleshooting snippets meant to mirror those Taskfile vars - not a labeled historical snapshot or intentional worked example. So all occurrences were updated to 10.10.10.x (same last octet) rather than snapshot-labeled.

## What Changed

- Updated `.taskfiles/network/README.md`: replaced stale `10.10.3.x` Talos node IP examples, iperf3 test output samples, Ceph network config, bonding config snippet, and `talosctl` command examples with current `10.10.10.x` addressing (same last octets).
- Updated `.taskfiles/rook/README.md`: replaced stale `10.10.3.x` references in `TALOS_NODE_IPS` documentation, disk-check and health-check command examples, and troubleshooting snippets with current `10.10.10.x` addressing.
- Verified the underlying `.taskfiles/network/Taskfile.yaml` and `.taskfiles/rook/Taskfile.yaml` already use `10.10.10.x` for the three Talos nodes, so all doc references were brought in line with current usage rather than snapshot-labeled as historical.

## Risk Assessment

✅ Low: Documentation-only change (two README.md files) that replaces stale 10.10.3.x IPs with the current 10.10.10.x addressing, verified to match the actual Taskfile.yaml variable values and to leave no remaining stale references.

## Testing

`This is a documentation-only change (no executable code), so validation was done by direct content verification: confirmed no 10.10.3.x references remain in either target README, confirmed all replaced IPs (10.10.10.11/.12/.13) exactly match the live TALOS_NODE_1/2/3 and TALOS_NODE_IPS variables in the corresponding Taskfile.yaml files, and manually reviewed all 20 changed occurrences for consistency (no broken markdown formatting). No findings.</testing_summary>`

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"4866006e037a3e1425e33fc05a0d5d6a7c90a448","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `grep -n "10\\.10\\.3\\." .taskfiles/network/README.md .taskfiles/rook/README.md (confirms zero remaining stale references)`
- `grep -n "TALOS_NODE" .taskfiles/network/Taskfile.yaml .taskfiles/rook/Taskfile.yaml (confirms updated README IPs 10.10.10.11/.12/.13 match the actual Taskfile variables)`
- `grep -n "10\\.10\\.10\\." .taskfiles/network/README.md .taskfiles/rook/README.md (manual review of all 20 updated occurrences for consistency and no formatting breakage)`
- `git status (confirms no stray/uncommitted changes in the worktree)`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
