### PR TITLE
feat(github-action): migrate cache-independent workflows to local ARC runner

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,7 +22,7 @@ permissions:
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
-    runs-on: ubuntu-latest
+    runs-on: gha-runner-scale-set-aviator-coding-home-ops
     timeout-minutes: 15
 
     permissions:

--- a/.github/workflows/flux-local.yaml
+++ b/.github/workflows/flux-local.yaml
@@ -35,7 +35,12 @@ jobs:
     if: ${{ needs.filter.outputs.changed-files != '[]' }}
     needs: filter
     name: Flux Local - Test
-    runs-on: gha-runner-scale-set-aviator-coding-home-ops
+    # Not migrated to the local runner: this job uses `docker://...` container actions
+    # (flux-local), which need a Docker daemon. The local ARC runner pod has none (no
+    # docker.sock, no DinD sidecar) - confirmed by a live PR run failing with "failed to
+    # connect to the docker API at unix:///var/run/docker.sock". See
+    # kubernetes/apps/actions-runner-system/TROUBLESHOOTING.md.
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
       - name: Generate Token
@@ -68,7 +73,8 @@ jobs:
     if: ${{ needs.filter.outputs.changed-files != '[]' }}
     needs: filter
     name: Flux Local - Diff
-    runs-on: gha-runner-scale-set-aviator-coding-home-ops
+    # Not migrated: same docker:// container-action / no-Docker-daemon gap as the Test job above.
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
       contents: read

--- a/.github/workflows/flux-local.yaml
+++ b/.github/workflows/flux-local.yaml
@@ -20,7 +20,7 @@ permissions:
 jobs:
   filter:
     name: Flux Local - Filter
-    runs-on: ubuntu-latest
+    runs-on: gha-runner-scale-set-aviator-coding-home-ops
     timeout-minutes: 5
     outputs:
       changed-files: ${{ steps.changed-files.outputs.changed_files }}
@@ -35,7 +35,7 @@ jobs:
     if: ${{ needs.filter.outputs.changed-files != '[]' }}
     needs: filter
     name: Flux Local - Test
-    runs-on: ubuntu-latest
+    runs-on: gha-runner-scale-set-aviator-coding-home-ops
     timeout-minutes: 15
     steps:
       - name: Generate Token
@@ -68,7 +68,7 @@ jobs:
     if: ${{ needs.filter.outputs.changed-files != '[]' }}
     needs: filter
     name: Flux Local - Diff
-    runs-on: ubuntu-latest
+    runs-on: gha-runner-scale-set-aviator-coding-home-ops
     timeout-minutes: 15
     permissions:
       contents: read
@@ -143,7 +143,7 @@ jobs:
       - test
       - diff
     name: Flux Local - Success
-    runs-on: ubuntu-latest
+    runs-on: gha-runner-scale-set-aviator-coding-home-ops
     timeout-minutes: 5
     steps:
       - name: Any jobs failed?

--- a/.github/workflows/image-pull.yaml
+++ b/.github/workflows/image-pull.yaml
@@ -20,7 +20,7 @@ permissions:
 jobs:
   filter:
     name: Image Pull - Filter
-    runs-on: ubuntu-latest
+    runs-on: gha-runner-scale-set-aviator-coding-home-ops
     timeout-minutes: 5
     outputs:
       changed-files: ${{ steps.changed-files.outputs.changed_files }}
@@ -35,7 +35,7 @@ jobs:
     if: ${{ needs.filter.outputs.changed-files != '[]' }}
     needs: filter
     name: Image Pull - Extract Images
-    runs-on: ubuntu-latest
+    runs-on: gha-runner-scale-set-aviator-coding-home-ops
     timeout-minutes: 10
     strategy:
       matrix:
@@ -110,7 +110,7 @@ jobs:
     if: ${{ needs.extract.outputs.default != needs.extract.outputs.pull }}
     needs: extract
     name: Image Pull - Diff Images
-    runs-on: ubuntu-latest
+    runs-on: gha-runner-scale-set-aviator-coding-home-ops
     timeout-minutes: 5
     outputs:
       images: ${{ steps.diff.outputs.images }}
@@ -163,7 +163,7 @@ jobs:
     if: ${{ !cancelled() }}
     needs: pull
     name: Image Pull - Success
-    runs-on: ubuntu-latest
+    runs-on: gha-runner-scale-set-aviator-coding-home-ops
     timeout-minutes: 5
     steps:
       - name: Any jobs failed?

--- a/.github/workflows/image-pull.yaml
+++ b/.github/workflows/image-pull.yaml
@@ -35,7 +35,11 @@ jobs:
     if: ${{ needs.filter.outputs.changed-files != '[]' }}
     needs: filter
     name: Image Pull - Extract Images
-    runs-on: gha-runner-scale-set-aviator-coding-home-ops
+    # Not migrated: this job runs `docker run ... ghcr.io/allenporter/flux-local`, which needs
+    # a Docker daemon. The local ARC runner pod has none - confirmed by a live PR run failing
+    # with "failed to connect to the docker API at unix:///var/run/docker.sock". See
+    # kubernetes/apps/actions-runner-system/TROUBLESHOOTING.md.
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     strategy:
       matrix:

--- a/.github/workflows/label-sync.yaml
+++ b/.github/workflows/label-sync.yaml
@@ -20,7 +20,7 @@ permissions:
 jobs:
   label-sync:
     name: Label Sync
-    runs-on: ubuntu-latest
+    runs-on: gha-runner-scale-set-aviator-coding-home-ops
     timeout-minutes: 5
     permissions:
       contents: read

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   main:
     name: Labeler - Labeler
-    runs-on: ubuntu-latest
+    runs-on: gha-runner-scale-set-aviator-coding-home-ops
     timeout-minutes: 5
     if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
     permissions:

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -41,7 +41,11 @@ permissions:
 jobs:
   main:
     name: Renovate
-    runs-on: gha-runner-scale-set-aviator-coding-home-ops
+    # Not migrated: renovatebot/github-action always launches Renovate via `docker run`
+    # (there is no non-Docker execution mode), and the local ARC runner pod has no Docker
+    # daemon. Confirmed by a live run failing with "failed to connect to the docker API at
+    # unix:///var/run/docker.sock". See kubernetes/apps/actions-runner-system/TROUBLESHOOTING.md.
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
       packages: read

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -41,7 +41,7 @@ permissions:
 jobs:
   main:
     name: Renovate
-    runs-on: ubuntu-latest
+    runs-on: gha-runner-scale-set-aviator-coding-home-ops
     timeout-minutes: 30
     permissions:
       packages: read

--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   main:
     name: Tag
-    runs-on: ubuntu-latest
+    runs-on: gha-runner-scale-set-aviator-coding-home-ops
     timeout-minutes: 5
     permissions:
       contents: write

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,6 +95,7 @@ Talos nodes are `talos-1|talos-2|talos-3` mapping to `10.10.10.11/12/13`. Do not
 - `.private/` directory for local-only files (gitignored)
 - Renovate ignores `**/*.sops.*` and `**/resources/**` paths
 - Ceph metadata CronJob (`rook-ceph-backup` / `ceph-backup-pvc`) is in-cluster `openebs-hostpath`, **not** last-resort DR; complete cluster/host wipe destroys it. Emergency steps: `kubernetes/apps/rook-ceph/rook-ceph/backup/RECOVERY-PROCEDURES.md`. Never restart all OSDs; see `docs/ceph/osd-device-path-recovery.md`.
+- The home-ops local ARC runner (`gha-runner-scale-set-aviator-coding-home-ops`) has no Docker daemon (no socket, no DinD sidecar) - `docker://` container actions, `docker run`, and anything that shells out to Docker (e.g. `renovatebot/github-action`) fail there. Details and the exact `runs-on:` label: `kubernetes/apps/actions-runner-system/TROUBLESHOOTING.md`.
 
 ## Maintaining this file
 

--- a/kubernetes/apps/actions-runner-system/TROUBLESHOOTING.md
+++ b/kubernetes/apps/actions-runner-system/TROUBLESHOOTING.md
@@ -532,6 +532,24 @@ the tradeoff as of 2026-08-21, so the custom runner image ships `buildx`
 only (already present in the upstream base image) and does not install
 `podman`/`uidmap`/`netavark`/`aardvark-dns`.
 
+### No Docker daemon in home-ops runner pods - blocks `docker://` actions and `docker run`
+
+The home-ops scale set's runner container has no Docker daemon: no
+`/var/run/docker.sock`, no privileged mode, no DinD sidecar (unlike
+`ai-k8s-sandbox`, which has a `docker:29-dind` sidecar). `docker buildx
+version` works because it's just the CLI plugin binary reporting its version -
+it does not need a daemon connection. Confirmed live (2026-08-21, PR #1361):
+migrating `flux-local.yaml`'s `test`/`diff` jobs (`uses: docker://...`
+container actions), `image-pull.yaml`'s `extract` job (`docker run ...`),
+and `renovate.yaml` (the `renovatebot/github-action` always shells out to
+`docker run ghcr.io/renovatebot/renovate`, with no non-Docker execution mode)
+to this runner failed every job with `failed to connect to the docker API at
+unix:///var/run/docker.sock: ... no such file or directory`. Those jobs, and
+`build-talosctl-busybox.yaml` (a real `docker buildx build --push`), stay on
+`ubuntu-latest` until a Docker daemon is actually provisioned for this scale
+set (a DinD sidecar like `ai-k8s-sandbox`'s, or a privileged/rootful Docker
+setup) - a separate infra decision, not a `runs-on:` line change.
+
 ## Related Documentation
 
 - [Actions Runner Controller GitHub](https://github.com/actions/actions-runner-controller)

--- a/kubernetes/flux/cluster/ks.yaml
+++ b/kubernetes/flux/cluster/ks.yaml
@@ -4,6 +4,7 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: cluster-meta
+  # temp: trigger kubernetes/** path filter to validate local-runner CI (reverted before merge)
   namespace: &namespace flux-system
 spec:
   interval: 1h

--- a/kubernetes/flux/cluster/ks.yaml
+++ b/kubernetes/flux/cluster/ks.yaml
@@ -4,7 +4,6 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: cluster-meta
-  # temp: trigger kubernetes/** path filter to validate local-runner CI (reverted before merge)
   namespace: &namespace flux-system
 spec:
   interval: 1h


### PR DESCRIPTION
## Intent

Migrate home-ops workflows that don't depend on actions/cache onto the local ARC runner
(gha-runner-scale-set-aviator-coding-home-ops), now that the custom actions-runner-buildx
image (#1351) is live. Candidate list per captain decision H2 / runner-capacity-scout report.

Prior migration attempt (Aug 2025, commits 091a1563/329450e8) used a runner label
(`aviator-coding-home-ops-runner`) that never matched any actual runner group - the
gha-runner-scale-set architecture didn't land until the next day - so those jobs would have
hung forever; that's why it was reverted. This migration uses the real, currently-live label
confirmed from test-runner.yaml / image-pull.yaml's already-local job:
`gha-runner-scale-set-aviator-coding-home-ops`.

## What Changed

Migrated to the local runner (all verified passing via live PR/workflow_dispatch runs):
- `codeql.yml`, `labeler.yaml`, `label-sync.yaml`, `tag.yaml`
- `flux-local.yaml`'s `filter` and `success` jobs
- `image-pull.yaml`'s `filter`, `diff`, and `success` jobs (its `pull` job was already local)

`tag.yaml` was migrated (same no-Docker action pattern as label-sync/codeql, already proven
safe) but not manually triggered for testing, since a real run creates a live git tag +
GitHub release on this repo - a side effect not worth causing just to validate a runner
migration. Its next monthly scheduled run will exercise it for real.

**Not migrated** - genuine blockers found via live testing, not left on ubuntu-latest by
assumption:
- `renovate.yaml`, `flux-local.yaml`'s `test`/`diff` jobs, and `image-pull.yaml`'s `extract`
  job all depend on a working Docker daemon (`docker://` container actions, `docker run`, or
  `renovatebot/github-action`'s internal `docker run`). The local ARC runner pod has none - no
  `/var/run/docker.sock`, no DinD sidecar. Confirmed live: migrating these failed every job
  with `failed to connect to the docker API at unix:///var/run/docker.sock`. Reverted back to
  `ubuntu-latest`, each annotated with why.
- `build-talosctl-busybox.yaml` was never migrated: it hits the same missing-Docker-daemon
  wall (it's a real `docker buildx build --push`), and separately uses
  `cache-from`/`cache-to: type=gha` - a GitHub Actions cache dependency the prior
  capacity-scout report's literal `actions/cache` grep missed, so it wouldn't have cleanly
  fit the "cache-independent" bucket even if Docker worked.

Documented the Docker-daemon gap in `kubernetes/apps/actions-runner-system/TROUBLESHOOTING.md`
and `AGENTS.md` as durable project knowledge for whoever picks up provisioning Docker (DinD
sidecar or privileged/rootful setup) for this runner group next.

## Testing

Live-verified on PR #1361 itself and via `gh workflow run` (not just inspected):
- `Labeler - Labeler`: pass (PR trigger)
- `Flux Local - Filter` / `Flux Local - Success`: pass (PR trigger)
- `Flux Local - Test` / `Flux Local - Diff` (both matrix legs): pass, correctly still on
  ubuntu-latest
- `Image Pull - Filter` / `Image Pull - Success`: pass (PR trigger)
- `Image Pull - Extract Images` (both legs): pass, correctly still on ubuntu-latest
- `Image Pull - Diff` / `Pull Images`: skipped (no image diff between branches - expected,
  not a failure)
- `codeql.yml`: pass (`gh workflow run`)
- `label-sync.yaml`: pass (`gh workflow run`)
- `renovate.yaml` (dryRun=true): failed with the Docker-daemon error above, confirming it
  needed reverting

`build-talosctl-busybox.yaml` last 2 runs on `main` are green (unrelated fix, PR #1342).