### PR TITLE
fix(container): roll back bazarr to 1.5.6 (1.6.0 hangs under Python 3.14)

### DIFF
--- a/.renovate/overrides.json5
+++ b/.renovate/overrides.json5
@@ -61,5 +61,16 @@
       ],
       allowedVersions: "<2.0.0",
     },
+    {
+      // 1.6.0 moved to python:3.14-alpine (home-operations/containers#1255), which
+      // upstream Bazarr has never tested and explicitly does not support
+      // (morpheus65535/bazarr maintainer, quoted in home-operations/containers#1386).
+      // The app hangs right after "Bazarr starting child process" and never binds
+      // its HTTP port, so kubelet liveness-kills it in an infinite crash loop.
+      // Stay on 1.5.6 (built on Python 3.13) until upstream confirms 3.14 support.
+      description: "Pin Bazarr to 1.5.6 (1.6.0 hangs on startup under Python 3.14, see home-operations/containers#1386)",
+      matchPackageNames: ["ghcr.io/home-operations/bazarr"],
+      allowedVersions: "<1.6.0",
+    },
   ],
 }

--- a/kubernetes/apps/downloads/bazarr/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/bazarr/app/helmrelease.yaml
@@ -33,7 +33,7 @@ spec:
           app:
             image:
               repository: ghcr.io/home-operations/bazarr
-              tag: 1.6.0
+              tag: 1.5.6
             envFrom:
               - secretRef:
                   name: bazarr-secret


### PR DESCRIPTION
## Intent

Fix Bazarr's continuous crash loop (~1825+ restarts over 4 days). Root cause investigation was required, not a guess: check whether a recent Renovate image bump introduced this or whether it predates the crash-looping; check for OOM-kill patterns via kubectl describe pod / previous container state before assuming an application bug; check Bazarr's own GitHub issues for startup-crash reports matching the currently-pinned version. The fix should be whichever of (a) roll back to last known-good image tag, (b) fix a resource limit for OOMKilling, or (c) address config/PVC corruption is supported by the evidence - not a guess.

Investigation findings: kubectl describe pod showed CrashLoopBackOff with exit code 143 (SIGTERM from a failed kubelet liveness probe against http://:6767/health), not OOMKilled - no OOM events in kubectl events, ruling out (b). Container logs on every restart show an identical hang: it prints "Python version greater than 3.13.x is unsupported. Current version is 3.14.6" plus "Bazarr starting child process..." then goes silent and never binds port 6767, so the liveness probe kills it ~30s later, every time - ruling out (c) config/PVC corruption (a corrupted DB would not produce this exact same hang point on every single restart with no variation, and the config PVC is 320 days old with no other symptoms). git log showed the current pinned tag 1.6.0 was bumped from 1.5.6 via Renovate PR #1137 (home-operations/bazarr image). Confirmed via research: home-operations/containers PR #1255 moved the bazarr image to python:3.14-alpine, and PR #1574 (merged 2026-07-04) shipped that base bump in the 1.6.0 tag. home-operations/containers issue #1386 reports the exact same "Python version greater than 3.13.x is unsupported" log signature with no fix, and quotes the Bazarr maintainer saying Python 3.14 has never been tested and is not supported. 1.5.6 (merged 2026-02-26) predates the Python 3.14 base bump and is the last known-good tag. This matches (a).

Fix applied: rolled kubernetes/apps/downloads/bazarr/app/helmrelease.yaml image tag back from 1.6.0 to 1.5.6. Added a Renovate pin in .renovate/overrides.json5 (allowedVersions: "<1.6.0" for ghcr.io/home-operations/bazarr) so Renovate does not immediately re-propose the broken 1.6.0 bump, following this repo's existing established pattern for holding back known-broken bumps (see the EMQX, Talos, and agentgateway pins already in that same file), each including a comment explaining why. Validated with flux-local: bazarr::downloads/bazarr PASSED under task flux:test:ns NAMESPACE=downloads. Live re-verification (force a Flux reconcile after merge and confirm the pod stays Running with 0 new restarts for an observation window) is a separate post-merge step, not part of this validation run.

## What Changed

- Rolled `ghcr.io/home-operations/bazarr` image tag back from `1.6.0` to `1.5.6` in `kubernetes/apps/downloads/bazarr/app/helmrelease.yaml`, fixing a continuous CrashLoopBackOff caused by `1.6.0`'s Python 3.14 base image hanging before it binds its HTTP port, which triggers repeated liveness-probe kills.
- Added an `allowedVersions: "<1.6.0"` Renovate pin for `ghcr.io/home-operations/bazarr` in `.renovate/overrides.json5`, with a comment explaining the Python 3.14 incompatibility and referencing `home-operations/containers#1386`, so Renovate does not re-propose the broken `1.6.0` bump.

## Risk Assessment

✅ Low: The diff is a minimal, well-scoped two-file revert (image tag 1.6.0->1.5.6 plus a matching Renovate pin) that exactly matches the documented investigation: git history confirms PR #1137 was the 1.5.6->1.6.0 bump now being reverted, and the pin follows the repo's established EMQX/Talos/agentgateway containment pattern with a clear rationale comment.

## Testing

Ran the project's own flux-local Kustomization/HelmRelease test suite scoped to bazarr (matching the author's claimed validation) and it passed; additionally rendered the full cluster manifest tree to directly confirm the actual Deployment spec that Flux would apply now uses image tag 1.5.6 instead of the crash-looping 1.6.0, and validated the new Renovate override entry parses correctly as JSON5. No issues found; this is a minimal config-only rollback with no application logic to unit test, so the rendered-manifest check is the strongest available end-to-end evidence.

<details>
<summary>Evidence: flux-local test result for bazarr</summary>

```text
kubernetes/flux/cluster::bazarr::kustomization PASSED
kubernetes/flux/cluster::bazarr::downloads/bazarr PASSED
```
</details>
<details>
<summary>Evidence: Rendered Deployment image after fix (from flux-local build all)</summary>

```text
image:
repository: ghcr.io/home-operations/bazarr
tag: 1.5.6
...
containers:
- image: ghcr.io/home-operations/bazarr:1.5.6
```
</details>
<details>
<summary>Evidence: Parsed Renovate override rule for bazarr</summary>

```text
{
"description": "Pin Bazarr to 1.5.6 (1.6.0 hangs on startup under Python 3.14, see home-operations/containers#1386)",
"matchPackageNames": ["ghcr.io/home-operations/bazarr"],
"allowedVersions": "<1.6.0"
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"c080cf537f654c5372c1f7019ebd2d3c958d670a","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`flux-local test --all-namespaces --enable-helm --path kubernetes/flux/cluster --verbose` (grepped for bazarr) -&gt; `bazarr::downloads/bazarr PASSED`</code>
- <code>`flux-local build all kubernetes/flux/cluster --enable-helm --output-file ...` then grepped rendered output for `ghcr.io/home-operations/bazarr` -&gt; confirmed rendered Deployment/HelmRelease both pin `1.5.6`</code>
- <code>Parsed `.renovate/overrides.json5` (strip JSON5 comments/trailing commas, `JSON.parse` via node) -&gt; new bazarr `packageRules` entry (`allowedVersions: &#34;&lt;1.6.0&#34;`) is syntactically valid and structurally matches the file&#39;s other pins</code>
- <code>`git diff e108b4c5..c080cf53 -- .` reviewed to confirm the only changes are the two files described in the intent</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
