### PR TITLE
fix(hermes): remove crashlooping webui sidecar

### DIFF
--- a/kubernetes/apps/ai/hermes/README.md
+++ b/kubernetes/apps/ai/hermes/README.md
@@ -139,7 +139,7 @@ scrubs) and the gateway for per-repo summaries. Register its daily run in-agent 
 the pod is up:
 
 ```bash
-# in the dashboard/webui terminal, or: kubectl -n ai exec -it deploy/hermes -c app -- hermes ...
+# in the dashboard terminal, or: kubectl -n ai exec -it deploy/hermes -c app -- hermes ...
 # create the `homelab-peers-commit-watcher` cron (see the skill's SKILL.md).
 ```
 

--- a/kubernetes/apps/ai/hermes/README.md
+++ b/kubernetes/apps/ai/hermes/README.md
@@ -5,21 +5,29 @@ self-improving conversational AI agent (learning loop, persistent memory, skills
 deployed here as a homelab operator. Self-contained Python image; no upstream Helm
 chart, so this is a hand-authored `app-template` deploy.
 
-The pod runs three containers (one controller, one PVC):
+The pod runs two containers (one controller, one PVC):
 
 | Container | Purpose | URL |
 | --------- | ------- | --- |
 | `app` | Hermes gateway + built-in dashboard (basic auth) | `https://hermes.${SECRET_DOMAIN}` |
-| `webui` | Richer standalone chat UI ([nesquena/hermes-webui](https://github.com/nesquena/hermes-webui)) | `https://hermes-webui.${SECRET_DOMAIN}` (LAN) |
 | `codeserver` | Browser VS Code over `/opt/data` (skills/config/sessions) | `https://hermes-code.${SECRET_DOMAIN}` (LAN) |
 
 Plus an OpenAI-compatible API on `:8642` and a companion **agentmemory** service
 (`../agentmemory/`) for long-term cross-session memory.
 
 > The `app` container exposes a terminal + cluster RBAC + git, so the dashboard is
-> gated by basic auth. `webui` and `codeserver` have **no auth of their own** — they
-> are only on the **internal** gateway (`envoy-internal`, LAN). Front them with
-> Authentik if you ever need more than network isolation.
+> gated by basic auth. `codeserver` has **no auth of its own** — it is only on the
+> **internal** gateway (`envoy-internal`, LAN). Front it with Authentik if you ever
+> need more than network isolation.
+
+> **`webui` (removed 2026-08-21).** A third sidecar ran
+> [nesquena/hermes-webui](https://github.com/nesquena/hermes-webui) as a richer
+> standalone chat UI. Renovate's 0.52.157 → 0.52.158 bump made the image pip-install
+> `hermes-agent` at container start, which upstream refuses to build ("Building
+> wheels or sdists for hermes-agent is not supported") — permanent CrashLoopBackOff,
+> the third such incident for this component. Removed rather than pinned back: the
+> route sat at probe-floor traffic (~1 req/min, 100% 5xx, no human usage) with no
+> real users to justify carrying the risk of a fourth incident.
 
 ## Configuration is GitOps (read this first)
 
@@ -176,21 +184,15 @@ PAT or account SSH key would expose every repo; don't use those.)
 
 - **Single-writer state.** `/opt/data` (sessions/memories/skills, incl. SQLite) is not
   concurrency-safe → `replicas: 1` + `strategy: Recreate` + RWO `ceph-block` PVC. The
-  `codeserver` and `webui` sidecars share the PVC **in the same pod** (no
-  multi-attach). Do not scale up.
+  `codeserver` sidecar shares the PVC **in the same pod** (no multi-attach). Do not
+  scale up.
 - **Gateway runs via the profile service, not the CMD.** The image auto-starts a
   `gateway-default` s6 service (the gateway: cron + messaging). The container CMD is
   idled (`args: ["sleep","infinity"]`) — passing `gateway run` started a *second*
   gateway that collided and CrashLooped. **Don't set `args` back to `gateway run`.**
-- **webui is the fiddly one.** It imports a staged copy of the image's `/opt/hermes`
-  (the `copy-agent-source` init → `agent-source` emptyDir) and reads agent state from
-  the PVC at `/home/hermeswebui/.hermes`. The `app` container's `/opt/hermes` is left
-  pristine on purpose (don't disturb the gateway). If webui misbehaves, it can be
-  removed without touching the rest — see the disable note in `helmrelease.yaml`.
 - **Runs as root then drops** to UID 10000 (s6-overlay), so no `runAsNonRoot` on the
   `app` container — `fsGroup: 10000` makes the PVC writable for the dropped user.
 - **Cost tracking:** every model goes through the agentgateway unified `/v1`, so
   ALL Hermes LLM traffic is in gateway cost metering (`rules/cost.yaml`) and Tempo
   tracing — there is no untracked direct-provider path anymore.
-- **Ports:** `9119` dashboard, `8642` OpenAI-compatible API, `8787` webui, `12321`
-  code-server.
+- **Ports:** `9119` dashboard, `8642` OpenAI-compatible API, `12321` code-server.

--- a/kubernetes/apps/ai/hermes/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/hermes/app/helmrelease.yaml
@@ -73,23 +73,6 @@ spec:
             securityContext:
               runAsUser: 0
               runAsGroup: 0
-          # Stage a copy of the image's hermes-agent source into an emptyDir for
-          # the webui sidecar to import. `command:` overrides the image's s6
-          # entrypoint so this is a plain copy. The app container keeps the image's
-          # pristine /opt/hermes (we don't overlay it — don't disturb the gateway).
-          copy-agent-source:
-            image:
-              repository: docker.io/nousresearch/hermes-agent
-              tag: v2026.8.18
-            command:
-              - /bin/sh
-              - -c
-              - |
-                set -e
-                cp -r /opt/hermes/. /agent-src/
-            securityContext:
-              runAsUser: 0
-              runAsGroup: 0
         containers:
           app:
             image:
@@ -246,43 +229,6 @@ spec:
                 cpu: 10m
               limits:
                 memory: 1Gi
-          # Richer standalone chat UI (separate from the built-in :9119 dashboard).
-          # Imports the hermes-agent source staged by copy-agent-source and reads
-          # the agent's state from the data PVC at /home/hermeswebui/.hermes. Starts
-          # as root (chowns HOME to WANTED_UID) then drops to 10000. LAN-only via
-          # envoy-internal, no auth of its own.
-          # NOTE: most likely of these additions to need post-deploy tuning. To
-          # disable: remove this container, the copy-agent-source init, the
-          # agent-source volume, the webui service port and the hermes-webui route.
-          webui:
-            image:
-              repository: ghcr.io/nesquena/hermes-webui
-              tag: 0.52.158@sha256:28783c1ec13cda2f65ec1249a8537d3b9353fcfe5f97f4d24865ab524d26815d
-            env:
-              # upstream entrypoint uses `su -c`, HOME stays /root → .env missed
-              HERMES_HOME: /home/hermeswebui/.hermes
-              HERMES_WEBUI_HOST: 0.0.0.0
-              HERMES_WEBUI_PORT: "8787"
-              HERMES_WEBUI_STATE_DIR: /home/hermeswebui/.hermes/webui
-              HOME: /home/hermeswebui
-              TZ: ${CONFIG_TIMEZONE}
-              # Match the agent's uid/gid so webui owns the shared /opt/data state.
-              WANTED_UID: "10000"
-              WANTED_GID: "10000"
-            securityContext:
-              allowPrivilegeEscalation: false
-              capabilities:
-                add: [CHOWN, DAC_OVERRIDE, FOWNER, FSETID, SETGID, SETUID]
-                drop: [ALL]
-              runAsUser: 0
-              runAsGroup: 0
-              runAsNonRoot: false
-            resources:
-              requests:
-                cpu: 50m
-                memory: 256Mi
-              limits:
-                memory: 2Gi
     defaultPodOptions:
       # Hermes operates the cluster via kubectl, so its SA token must be mounted.
       # app-template v5 defaults automountServiceAccountToken to false.
@@ -303,9 +249,6 @@ spec:
           # code-server IDE sidecar.
           codeserver:
             port: 12321
-          # hermes-webui chat UI sidecar.
-          webui:
-            port: 8787
     route:
       app:
         annotations:
@@ -339,21 +282,8 @@ spec:
           - backendRefs:
               - name: *app
                 port: 12321
-      # hermes-webui chat UI — LAN-only, no auth gate beyond the network.
-      webui:
-        hostnames:
-          - "hermes-webui.${SECRET_DOMAIN}"
-        parentRefs:
-          - name: envoy-internal
-            namespace: network
-            sectionName: https
-        rules:
-          - backendRefs:
-              - name: *app
-                port: 8787
     persistence:
-      # Agent state PVC. advancedMounts (not globalMounts) so the webui sidecar can
-      # mount it at /home/hermeswebui/.hermes while everything else gets /opt/data.
+      # Agent state PVC, mounted at /opt/data by every container that needs it.
       data:
         existingClaim: *app
         advancedMounts:
@@ -366,18 +296,6 @@ spec:
               - path: /opt/data
             codeserver:
               - path: /opt/data
-            webui:
-              - path: /home/hermeswebui/.hermes
-      # Staged copy of the image's /opt/hermes (from copy-agent-source) for webui
-      # to import as the hermes-agent package.
-      agent-source:
-        type: emptyDir
-        advancedMounts:
-          hermes:
-            copy-agent-source:
-              - path: /agent-src
-            webui:
-              - path: /home/hermeswebui/.hermes/hermes-agent
       # Single private-repo git token, rendered as `.git-credentials` by the
       # hermes-git ExternalSecret and read by the git `store` helper (see
       # GIT_CONFIG_* env above). reloader restarts the pod on token rotation.

--- a/kubernetes/apps/ai/hermes/ks.yaml
+++ b/kubernetes/apps/ai/hermes/ks.yaml
@@ -11,6 +11,11 @@ spec:
       app.kubernetes.io/name: *app
   components:
     - ../../../../components/volsync
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: *app
+      namespace: *namespace
   dependsOn:
     - name: onepassword-store
       namespace: security


### PR DESCRIPTION
## Intent

Remove the hermes webui sidecar from kubernetes/apps/ai/hermes. It has been in CrashLoopBackOff since 2026-08-05: Renovate bumped ghcr.io/nesquena/hermes-webui 0.52.157 -> 0.52.158, and that image now pip-installs hermes-agent at container start, which upstream refuses to build ("RuntimeError: Building wheels or sdists for hermes-agent is not supported"). This is the third incident for this component. The captain decided on 2026-08-21 to remove webui rather than pin it back to the last working image, on the evidence that the hermes-webui.sklab.dev route sits at the probe floor with no real human traffic and that pinning back just queues a fourth incident.

Scope of the change:
1. Remove the webui sidecar cleanly, following the removal recipe already documented in kubernetes/apps/ai/hermes/app/helmrelease.yaml: the webui container, its copy-agent-source init container, the agent-source emptyDir volume, the webui Service port, and the hermes-webui HTTPRoute. Swept the rest of the repo for anything that existed only to serve webui (ServiceMonitor, Gatus endpoint annotation, DNS record, homepage/dashboard entry, 1Password item reference, Renovate custom manager) and found none - the externalsecret.yaml secret fields, the Renovate config, and the rest of the manifests are all shared by app/codeserver or otherwise unrelated. The app and codeserver containers were untouched and were already healthy (0 restarts) before and after. Also updated kubernetes/apps/ai/hermes/README.md to drop the webui documentation and add a note on why/when it was removed, and fixed one stale comment in helmrelease.yaml that referenced the webui sidecar after removal.
2. Added healthChecks (a HelmRelease health check) to kubernetes/apps/ai/hermes/ks.yaml, since none of the 14 Kustomizations in the ai namespace defined healthChecks, which is why this 16-day crashloop went unseen while `flux get ks -n ai` printed everything green. This was added in a separate commit after the removal was already correct, so a still-broken app wouldn't wedge the Kustomization.

I do not own any other app in the ai namespace - a sibling task is adding healthChecks to every other ai/*/ks.yaml, and another task owns kubernetes/apps/ai/agentgateway/app/rules/cost.yaml and agentgateway-dashboards/, so I left those untouched even though I didn't find anything wrong in them.

Before changing anything I re-verified the CrashLoopBackOff live via kubectl (webui at 40 restarts with the exact same RuntimeError, app/codeserver at 0 restarts) and verified the "no real traffic" claim against Prometheus (14-day retention): hermes-webui's envoy route received a constant ~1 request/minute over the full window, with 100% of those requests returning 5xx (i.e. zero successful requests ever, consistent with automated probing rather than human usage) - this confirmed the captain's basis for removing rather than pinning.

Validated locally: `flux-local test --all-namespaces --enable-helm --path ./kubernetes/flux/cluster` passes (225/225, including the hermes kustomization/helmrelease), and `flux-local build helmreleases -A hermes` renders cleanly with no webui/nesquena/8787/agent-source remnants, only the app and codeserver containers, routes, and service ports remain. Pre-commit passed on all touched files.

## What Changed

- Removed the `webui` sidecar from the hermes HelmRelease: the `webui` container, its `copy-agent-source` init container, the `agent-source` emptyDir volume, the `webui` Service port, and the `hermes-webui` HTTPRoute, along with their advanced volume mounts.
- Updated `kubernetes/apps/ai/hermes/README.md` to drop webui from the container table, ports list, and single-writer/auth notes, and added a note documenting why and when webui was removed.
- Added a `healthChecks` entry (HelmRelease health check) to `kubernetes/apps/ai/hermes/ks.yaml` so Flux Kustomization status reflects HelmRelease health.

## Risk Assessment

✅ Low: Clean, well-scoped removal of a crashlooping sidecar (container, init container, emptyDir volume, service port, HTTPRoute all removed together with no orphaned references anywhere in the repo) plus an isolated healthChecks addition that matches the existing repo pattern; both commits are verified against the stated intent and leave the app/codeserver containers untouched.

## Testing

Ran flux-local's full cluster test suite (225/225 passing, matching the PR's own claim) and rendered the hermes HelmRelease through the real kustomize+helm pipeline; the generated manifest that would actually reach the cluster contains only the app/codeserver containers, ports, and routes, with zero trace of the webui sidecar, its init container, its emptyDir, or its Service/HTTPRoute — confirming the removal is complete and correctly scoped, and the new ks.yaml healthCheck correctly targets the hermes HelmRelease. No findings.

<details>
<summary>Evidence: flux-local test --all-namespaces (targeted at hermes)</summary>

```text
kubernetes/flux/cluster::hermes::kustomization PASSED
kubernetes/flux/cluster::hermes::ai/hermes PASSED
...
= 225 passed in 54.73s =
```
</details>
<details>
<summary>Evidence: flux-local build helmreleases hermes -A -- rendered Deployment/Service/HTTPRoute summary</summary>

```text
Deployment containers: app, codeserver
Deployment initContainers: copy-config, seed-skills
Deployment volumes: config, data, git-credentials, plugin-agentmemory, skill-commit-watcher
Service ports: agent:8642, codeserver:12321, http:9119
HTTPRoutes: hermes-app (hermes., hermes-code.), hermes-codeserver (hermes., hermes-code.)

grep -in 'webui|nesquena|8787|agent-source' rendered.yaml -> no matches
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"6869795afd1f6cef6862c837f76e1dbdd2165ad8","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`flux-local test --all-namespaces --enable-helm --path kubernetes/flux/cluster --verbose` (225/225 passed, including kubernetes/flux/cluster::hermes::kustomization and kubernetes/flux/cluster::hermes::ai/hermes)</code>
- <code>`flux-local build helmreleases hermes -A --path kubernetes/flux/cluster` rendered the live Deployment/Service/HTTPRoute manifests; verified via yq that containers/initContainers/volumes/service-ports/routes contain no webui/copy-agent-source/agent-source/8787 remnants</code>
- <code>`grep -in &#39;webui|nesquena|8787|agent-source&#39; /tmp/hermes_rendered.yaml` on the generated manifest returned no matches</code>
- `manual diff review of the 3 changed files (helmrelease.yaml, ks.yaml, README.md) against the stated removal recipe and healthCheck addition`
- `repo-wide grep sweep for hermes-webui/nesquena/copy-agent-source/agent-source/8787 outside kubernetes/apps/ai/hermes/ to confirm no other component referenced the removed sidecar (only unrelated readarr port-8787 coincidence and a historical dated incident doc)`
- <code>`git status --short` before/after to confirm no test artifacts were left in the worktree</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
