### PR TITLE
fix(flux): resolve postBuild.substitute collisions freezing 4 kustomizations

### DIFF
--- a/kubernetes/apps/coder/app/kustomization.yaml
+++ b/kubernetes/apps/coder/app/kustomization.yaml
@@ -15,6 +15,7 @@ configMapGenerator:
         grafana_dashboard: "true"
       annotations:
         grafana_folder: "Coder"
+        kustomize.toolkit.fluxcd.io/substitute: disabled
     files:
       - ./dashboards/coderd.json
       - ./dashboards/provisionerd.json

--- a/kubernetes/apps/monitoring/grafana/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/grafana/app/helmrelease.yaml
@@ -154,7 +154,7 @@ spec:
                 {
                   "datasource": {
                     "type": "prometheus",
-                    "uid": "${datasource}"
+                    "uid": "$${datasource}"
                   },
                   "gridPos": {"h": 3, "w": 24, "x": 0, "y": 0},
                   "id": 1,
@@ -170,7 +170,7 @@ spec:
                   "type": "text"
                 },
                 {
-                  "datasource": {"type": "prometheus", "uid": "${datasource}"},
+                  "datasource": {"type": "prometheus", "uid": "$${datasource}"},
                   "gridPos": {"h": 8, "w": 8, "x": 0, "y": 3},
                   "id": 2,
                   "options": {
@@ -182,7 +182,7 @@ spec:
                   "type": "text"
                 },
                 {
-                  "datasource": {"type": "prometheus", "uid": "${datasource}"},
+                  "datasource": {"type": "prometheus", "uid": "$${datasource}"},
                   "gridPos": {"h": 8, "w": 8, "x": 8, "y": 3},
                   "id": 3,
                   "options": {
@@ -194,7 +194,7 @@ spec:
                   "type": "text"
                 },
                 {
-                  "datasource": {"type": "prometheus", "uid": "${datasource}"},
+                  "datasource": {"type": "prometheus", "uid": "$${datasource}"},
                   "gridPos": {"h": 8, "w": 8, "x": 16, "y": 3},
                   "id": 4,
                   "options": {

--- a/kubernetes/apps/selfhosted/rsshub/ks.yaml
+++ b/kubernetes/apps/selfhosted/rsshub/ks.yaml
@@ -63,6 +63,7 @@ spec:
         kind: Secret
     substitute:
       APP: *app
+      CONFIG_TIMEZONE: America/New_York
       VOLSYNC_CAPACITY: 5Gi
       VOLSYNC_SCHEDULE_CEPH: "25 */4 * * *"
       VOLSYNC_SCHEDULE_MINIO: "0 */6 * * *"

--- a/kubernetes/apps/selfhosted/rsshub/playwright/hr.yaml
+++ b/kubernetes/apps/selfhosted/rsshub/playwright/hr.yaml
@@ -27,7 +27,7 @@ spec:
               repository: ghcr.io/browserless/chromium
               tag: v2.55.4
             env:
-              TZ: ${TIMEZONE}
+              TZ: ${CONFIG_TIMEZONE}
               DATA_DIR: /config/
               ALLOW_GET: true
               SCREEN_WIDTH: 1920


### PR DESCRIPTION
## Intent

Four Flux Kustomizations in Aviator-Coding/home-ops (coder, monitoring/grafana, selfhosted/rsshub, selfhosted/rsshub-playwright) have not reconciled since 2026-07-08, frozen at commit 37a2aacc, 44 days and 245 commits behind HEAD. Git no longer describes the cluster for those apps. Goal: make git true again by unsticking reconciliation, without touching anything else.

Root cause (confirmed by live re-verification against the cluster, matching a prior diagnosis exactly): the classic Flux postBuild.substitute collision. Each Kustomization's manifests contain literal ${...} tokens that Flux's strict-mode envsubst tries to resolve as its own substitution variables and fails the whole build on the first one it hits, which can mask further collisions in the same resource tree.

Found and fixed three distinct collisions, one per app, each requiring a different fix chosen on its own merits (not one mechanism applied blindly to all four):

1. coder: ConfigMap/coder-dashboards (a configMapGenerator built purely from Grafana dashboard JSON files, no legitimate Flux variables inside it) fails on ${__url_time_range} (5 occurrences across workspace_detail.json and workspaces.json - these are Grafana's own dashboard-link template variables, not Flux vars). Fix: added the `kustomize.toolkit.fluxcd.io/substitute: disabled` annotation to that configMapGenerator's options.annotations, matching the identical pattern already used successfully today by grafana/app/dashboard, monitoring/alertmanager, monitoring/gatus, downloads/sabnzbd, downloads/recyclarr, downloads/qbittorrent, ai/hermes, database/cloudnative-pg/pgadmin, and others in this repo.

2. grafana: HelmRelease/grafana fails on ${datasource} (4 occurrences, Grafana's own dashboard-panel template variable) inside an inline dashboard JSON block in helmrelease.yaml's values. The same HelmRelease resource also legitimately needs real ${SECRET_DOMAIN} Flux substitution elsewhere in the same file (GF_SERVER_ROOT_URL, HTTPRoute hostnames, gethomepage annotation), so the disable-annotation approach was not usable (it would kill the real substitution too). Fix: escaped the 4 occurrences as $${datasource}, matching the $$ escaping convention already proven working today in rsshub/app/hr.yaml (HOTLINK_TEMPLATE), rook-ceph's backup-system.yaml, and media/immich's helmrelease.yaml.

3. rsshub-playwright: HelmRelease/playwright fails on ${TIMEZONE}. This was NOT a Grafana-token collision - TIMEZONE was never defined anywhere in this repo (no ks.yaml substitute map, no substituteFrom secret key). It looks like a typo/omission bug: the repo has an established convention (selfhosted/homepage, ai/agentmemory, ai/hermes, media/calibre-web) of defining CONFIG_TIMEZONE: America/New_York in postBuild.substitute and referencing ${CONFIG_TIMEZONE} in the HelmRelease. Fix: renamed TZ: ${TIMEZONE} to TZ: ${CONFIG_TIMEZONE} in playwright/hr.yaml and added CONFIG_TIMEZONE: America/New_York to rsshub-playwright's ks.yaml substitute map, following that exact existing convention rather than inventing a new one.

4. rsshub: was not failing on its own envsubst - its Kustomization was blocked purely because its dependency rsshub-playwright was not ready. No direct change needed; fixing #3 should let it cascade to ready once playwright reconciles.

Swept every resource under all four apps' Kustomization paths for other ${...} tokens (not just the first-reported failure per app) to make sure fixing the reported token wouldn't just reveal another one underneath - found nothing else.

Verification performed (evidence, not guesswork):
- Re-verified live cluster state first via the configured read-only kubeconfig before changing anything: `flux get ks -A --status-selector ready=false` showed the exact same 4 Kustomizations, same error messages, same revision 37a2aacc as the prior diagnosis. Confirmed drift: coder's HelmRelease chart pinned at 2.36.0 in git vs 2.34.3 running live.
- Important finding: `flux-local test`/`flux-local build` (the exact tool and invocation this repo's own CI workflow .github/workflows/flux-local.yaml uses) does NOT reproduce this failure class at all. I proved this empirically by running the identical flux-local test command against a separate worktree checked out at the original unfixed commit (a77c09ee, current main HEAD) - it reported all 4 Kustomizations PASSED even without any fix applied. So flux-local cannot be relied on to prove this specific fix pre-merge, and would not have caught this regression in the first place; this is worth the pipeline knowing so it does not misread a clean flux-local run as proof.
- Given that gap, I instead validated with `kustomize build` (the lower-level tool flux-local itself wraps) against each fixed app directory - all four built cleanly (exit 0), confirming the YAML/JSON edits are structurally valid and the disable-annotation attaches to the correct resource, the escaped $${datasource} tokens survive kustomize build unmodified (as they must, since kustomize build does not run envsubst - only Flux's controller does), and the renamed ${CONFIG_TIMEZONE} appears correctly in the rendered playwright manifest.
- Cross-checked that all three fix mechanisms used (disable-annotation, $$ escaping, CONFIG_TIMEZONE convention) are already in live, successfully-reconciling use elsewhere in this exact cluster today (confirmed via `flux get ks` showing True/Applied at current HEAD for alertmanager, gatus, sabnzbd, recyclarr, hermes, calibre-web-automated, homepage, agentmemory, and others) - this is the actual pre-merge evidence for correctness, not flux-local.
- The real acceptance test - flux get ks -A --status-selector ready=false returning no rows for these four, kubectl -n coder get hr coder reporting chart version 2.36.0, and all four reporting a revision at or near current HEAD instead of 37a2aacc - can only be proven after merge, once Flux reconciles the merged commit live. This needs to be watched after merge, not assumed from local proof.

Also confirmed as part of this investigation but explicitly out of scope and NOT touched: downloads/bazarr (pre-existing Helm upgrade timeout, matches a prior rollback) and selfhosted/linkwarden (pre-existing rollback to v48) remain in their same pre-existing unhealthy states - these are unrelated, known issues and this change must not disturb them.

Diffed the full 44-day/245-commit drift for the three apps that actually had merged-but-unapplied commits (13 total: coder 6, rsshub 6, grafana 1) to assess whether unsticking this is a quiet catch-up or something risky landing all at once:
- coder (6 commits): four incremental Helm chart version bumps 2.34.3 -> 2.35.1 -> 2.35.2 -> 2.35.3 -> 2.36.0, one postgres-init image patch bump (18.4 -> 18.6), and one commit touching only README/runbook/PrometheusRule alert-threshold docs (no application behavior change).
- grafana (1 commit): a single-line Renovate-authored dashboard revision bump (community SMARTctl Exporter Dashboard gnetId 22604, revision 2 -> 3) - flagged with a Renovate breaking-change `!` marker but is in substance a trivial community-dashboard version bump, not a real breaking change to the running cluster.
- rsshub (6 commits): browserless/chromium image bumps (v2.54.2 -> v2.55.4) and rsshub image digest bumps - routine patch/minor container updates.
None of this drift looks risky to apply in one go; this is a quiet catch-up, not a risky batch, and that assessment should be relayed to the captain in the outcome.

Scope constraint: keep the diff to exactly what unsticks reconciliation for these four Kustomizations. Do not touch anything else in the broader reference-refactor program that this task's diagnosis was originally part of (e.g. do not delete archived files, do not migrate HelmRepository sources to OCI, do not restructure docs, do not touch task runners) - those are separate, unrelated efforts.

## What Changed

- `coder`: added `kustomize.toolkit.fluxcd.io/substitute: disabled` to the `coder-dashboards` configMapGenerator options so Flux's strict-mode envsubst stops trying to resolve Grafana's own `${__url_time_range}` dashboard-link template tokens.
- `monitoring/grafana`: escaped the 4 occurrences of `${datasource}` in the inline dashboard JSON (grafana `helmrelease.yaml`) as `$${datasource}`, preserving the real `${SECRET_DOMAIN}` Flux substitution used elsewhere in the same HelmRelease.
- `selfhosted/rsshub-playwright`: renamed `TZ: ${TIMEZONE}` to `TZ: ${CONFIG_TIMEZONE}` in `playwright/hr.yaml` and added `CONFIG_TIMEZONE: America/New_York` to the rsshub `ks.yaml` `postBuild.substitute` map, since `TIMEZONE` was never defined anywhere in the repo.
- `selfhosted/rsshub` itself required no direct change; its Kustomization was only blocked on the `rsshub-playwright` dependency above.

## Risk Assessment

✅ Low: The diff is exactly 4 files matching the stated scope, each fix (disable-annotation, $$ escaping, CONFIG_TIMEZONE rename) mirrors a pattern independently verified to already exist and work elsewhere in the repo (alertmanager/gatus/sabnzbd for disabled substitution, rsshub/rook-ceph/immich for $$ escaping, homepage/agentmemory/hermes/calibre-web for the CONFIG_TIMEZONE convention), and a full grep sweep of all four apps' Kustomization paths for stray ${...} tokens confirms no remaining collision - the only two collisions targeted (${__url_time_range}, ${datasource}) are correctly neutralized and the one omission bug (${TIMEZONE}) is fixed at its defining ks.yaml (rsshub-playwright's substitute map, verified by reading the full two-document ks.yaml) as well as its use site.

## Testing

Reproduced the exact reported failure mode end-to-end: running flux build kustomization --dry-run --strict-substitute (Flux's actual substitution code, not just kustomize build) against the base-commit (a77c09ee) app trees fails with the precise reported errors — variable not set (strict mode): "__url_time_range" for coder, "datasource" for grafana, "TIMEZONE" for playwright — and the identical command against the fixed target commit (c7d5c665) succeeds (exit 0) for all three, with the resolved output correct in each case (coder's Grafana-native tokens preserved via the disable annotation, grafana's $${datasource} correctly unescaping to a literal ${datasource} for Grafana's own template resolution, and playwright's TZ resolving to America/New_York). Also confirmed rsshub/app itself builds cleanly at both commits (it was never independently broken, matching the stated cascade-only root cause), kustomize build succeeds structurally for all four app paths, and the diff touches exactly the four files described with no changes to the explicitly out-of-scope bazarr/linkwarden apps or any broader refactor. No cluster access was available to observe live Flux reconciliation, which the change author already notes can only be confirmed post-merge; local reproduction with the real substitution engine is the strongest evidence obtainable pre-merge and it fully corroborates the fix.

<details>
<summary>Evidence: flux build --strict-substitute reproduction (base fails, target passes)</summary>

<code>coder-BASE: exit=1, envsubst strict-mode error on &#34;__url_time_range&#34; | coder-TARGET: exit=0&#10;grafana-BASE: exit=1, envsubst strict-mode error on &#34;datasource&#34; | grafana-TARGET: exit=0&#10;playwright-BASE: exit=1, envsubst strict-mode error on &#34;TIMEZONE&#34; | playwright-TARGET: exit=0, TZ resolves to America/New_York&#10;rsshub-app-BASE: exit=0 | rsshub-app-TARGET: exit=0 (never had its own substitution failure, confirming it was only blocked by the playwright dependency)</code>

```text
Reproduction: Flux's real postBuild.substitute (strict mode) run locally via 'flux build kustomization --dry-run --strict-substitute'
against the app tree BEFORE the fix (base commit a77c09ee) and AFTER the fix (target commit c7d5c665).
SECRET_DOMAIN is injected as a stand-in for the cluster-secrets substituteFrom value that dry-run mode cannot fetch (unrelated to the bug).

=== coder-BASE ===
$ flux build kustomization coder -n coder --path ./kubernetes/apps/coder/app --kustomization-file <ks.yaml> --dry-run --strict-substitute
exit=1
✗ var substitution failed for 'coder-dashboards': envsubst error: variable substitution failed: variable not set (strict mode): "__url_time_range"

=== coder-TARGET ===
$ flux build kustomization coder -n coder --path ./kubernetes/apps/coder/app --kustomization-file <ks.yaml> --dry-run --strict-substitute
exit=0

=== grafana-BASE ===
$ flux build kustomization grafana -n monitoring --path ./kubernetes/apps/monitoring/grafana/app --kustomization-file <ks.yaml> --dry-run --strict-substitute
exit=1
✗ var substitution failed for 'grafana': envsubst error: variable substitution failed: variable not set (strict mode): "datasource"

=== grafana-TARGET ===
$ flux build kustomization grafana -n monitoring --path ./kubernetes/apps/monitoring/grafana/app --kustomization-file <ks.yaml> --dry-run --strict-substitute
exit=0

=== playwright-BASE ===
$ flux build kustomization rsshub-playwright -n selfhosted --path ./kubernetes/apps/selfhosted/rsshub/playwright --kustomization-file <ks.yaml> --dry-run --strict-substitute
exit=1
✗ var substitution failed for 'playwright': envsubst error: variable substitution failed: variable not set (strict mode): "TIMEZONE"

=== playwright-TARGET ===
$ flux build kustomization rsshub-playwright -n selfhosted --path ./kubernetes/apps/selfhosted/rsshub/playwright --kustomization-file <ks.yaml> --dry-run --strict-substitute
exit=0

=== rsshub-app-BASE ===
$ flux build kustomization rsshub -n selfhosted --path ./kubernetes/apps/selfhosted/rsshub/app --kustomization-file <ks.yaml> --dry-run --strict-substitute
exit=0

=== rsshub-app-TARGET ===
$ flux build kustomization rsshub -n selfhosted --path ./kubernetes/apps/selfhosted/rsshub/app --kustomization-file <ks.yaml> --dry-run --strict-substitute
exit=0

--- confirm resolved TZ value in fixed playwright manifest ---
              TZ: America/New_York
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"c7d5c6650596db2e6036c41161c71bc87f5c505b","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"skipped"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `git diff --stat a77c09ee c7d5c665 (confirms exactly the 4 described files changed, nothing in bazarr/linkwarden or elsewhere touched)`
- `kustomize build against kubernetes/apps/{coder/app,monitoring/grafana/app,selfhosted/rsshub/app,selfhosted/rsshub/playwright} — all exit 0`
- `flux build kustomization <app> -n <ns> --path <app-path> --kustomization-file <ks.yaml> --dry-run --strict-substitute run against both the base-commit (a77c09ee) and target-commit (c7d5c665) app trees for coder, grafana, rsshub-playwright, and rsshub/app — this is Flux's real production postBuild.substitute code, run locally with SECRET_DOMAIN injected as a stand-in for the cluster-secrets value dry-run mode can't fetch`
- `Inspected rendered output: coder-dashboards ConfigMap retains its literal ${__url_time_range} Grafana tokens untouched (substitute-disabled annotation applied to the correct resource); grafana's $${datasource} unescapes to literal ${datasource} in the final manifest for Grafana's own template-variable resolution; playwright's TZ resolves to America/New_York`

</details>

<details>
<summary>⏭️ **Document** - skipped</summary>

- ℹ️ This is the second Flux Kustomization freeze from the same postBuild.substitute/envsubst collision class (literal ${...} tokens in Grafana dashboard JSON or unresolved app vars). Three distinct fix mechanisms now exist in the repo (kustomize.toolkit.fluxcd.io/substitute: disabled annotation, $$ escaping, and the CONFIG_TIMEZONE convention) but none are documented as a named failure mode anywhere - not in AGENTS.md&#39;s &#39;Flux variable substitution&#39; bullet, not elsewhere. Given this has now caused a real 44-day/4-app outage, a follow-up documenting the collision pattern and its three fixes in AGENTS.md&#39;s UNIQUE STYLES section (next to the existing substitution bullet) would be high-value for future sessions. Left undone here since it&#39;s a pre-existing gap, not something this change&#39;s diff made stale, and out of this pass&#39;s narrow scope.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
