### PR TITLE
fix(agentgateway): surface LLM/latency panels and fix cost/dashboard bugs

### DIFF
--- a/docs/ai-system/agentgateway/08-observability.md
+++ b/docs/ai-system/agentgateway/08-observability.md
@@ -6,6 +6,16 @@ Do not import kgateway-org Grafana dashboards 24590/24965 or scrape `kgateway_co
 
 - Chart ServiceMonitors: enabled in [`helmrelease.yaml`](../../../kubernetes/apps/ai/agentgateway/app/helmrelease.yaml) (`monitoring.serviceMonitor.enabled: true`).
 - Extra [`podmonitor.yaml`](../../../kubernetes/apps/ai/agentgateway/app/podmonitor.yaml) scrapes data-plane pods on port **15020** (`metrics`). Needed because the chart ServiceMonitor selects a `metrics` port on per-Gateway Services, which this deployer does not create (Services only expose listener ports).
+- Consequence: every agentgateway pod is scraped by **two** jobs (e.g. `internal-noauth` +
+  `ai/agentgateway-proxy`), so any single-metric series like `agentgateway_build_info` has a
+  duplicate per pod. A PromQL `group_left` join against it directly errors with "many-to-many
+  matching not allowed" - always wrap it in `sum by (pod, namespace, <label you need>) (...)`
+  first. Fixed this way in `agentgateway.json`'s Memory/CPU panels 2026-08-21.
+- `agentgateway_build_info` (and the other agentgateway metrics) carry **no**
+  `gateway_networking_k8s_io_gateway_name` label on this cluster, so the `$gateway_name`/`$gateway`
+  dashboard variables have no real values to offer (checked live 2026-08-21) - harmless today
+  because they default to matching everything, but the dropdowns themselves are non-functional.
+  Not fixed here; would need picking a different, actually-populated label.
 
 Token/cost series used by the LLM spend rules: `agentgateway_gen_ai_client_token_usage` (histogram, labels `gen_ai_request_model` + `gen_ai_token_type`). See `15-optimization.md` and `app/rules/cost.yaml`.
 

--- a/docs/ai-system/agentgateway/08-observability.md
+++ b/docs/ai-system/agentgateway/08-observability.md
@@ -9,8 +9,11 @@ Do not import kgateway-org Grafana dashboards 24590/24965 or scrape `kgateway_co
 - Consequence: every agentgateway pod is scraped by **two** jobs (e.g. `internal-noauth` +
   `ai/agentgateway-proxy`), so any single-metric series like `agentgateway_build_info` has a
   duplicate per pod. A PromQL `group_left` join against it directly errors with "many-to-many
-  matching not allowed" - always wrap it in `sum by (pod, namespace, <label you need>) (...)`
-  first. Fixed this way in `agentgateway.json`'s Memory/CPU panels 2026-08-21.
+  matching not allowed" - always wrap it in `group by (pod, namespace, <label you need>) (...)`
+  first, not `sum by (...)`: `agentgateway_build_info` is a standard `_info` gauge fixed at
+  value 1, so `sum by` on the duplicated series collapses to value 2 and silently doubles
+  anything joined against it with `*`, while `group by` always emits 1 regardless of input
+  count. Fixed this way in `agentgateway.json`'s Memory/CPU panels 2026-08-21.
 - `agentgateway_build_info` (and the other agentgateway metrics) carry **no**
   `gateway_networking_k8s_io_gateway_name` label on this cluster, so the `$gateway_name`/`$gateway`
   dashboard variables have no real values to offer (checked live 2026-08-21) - harmless today

--- a/docs/ai-system/agentgateway/08-observability.md
+++ b/docs/ai-system/agentgateway/08-observability.md
@@ -15,8 +15,15 @@ Chart dashboard JSON is **disabled** (`monitoring.grafanaDashboard.enabled: fals
 
 - [`kubernetes/apps/ai/agentgateway-dashboards/`](../../../kubernetes/apps/ai/agentgateway-dashboards/)
 - `agentgateway.json` (from the official chart; re-vendor on chart bumps)
-- `llm-cost.json`
-- sidecar annotations `grafana_folder: AI/ML`, `grafana_dashboard: "true"`
+- `llm-cost.json` - linked from/to `agentgateway.json` via dashboard `links` rather than merged in,
+  so the vendored chart JSON survives re-vendoring without losing the custom cost panels
+- sidecar annotations `grafana_folder: AI/ML`, `grafana_dashboard: "true"` - **known bug**: both
+  dashboards actually land in a folder titled `ML`, not `AI/ML` (verified live 2026-08-21: a
+  separate, empty `AI/ML` folder exists from an unused `ai-ml` file-based dashboard provider in
+  the Grafana `HelmRelease`). The Grafana chart's sidecar appears to treat the `/` in the
+  annotation as a path separator rather than a literal folder-name character. Not fixed here -
+  couldn't verify a rename live without applying to the cluster; a real fix needs a
+  cluster-side check after deploy, not just a JSON diff.
 
 ## Tracing
 
@@ -32,6 +39,23 @@ This is not `GatewayParameters.spec.rawConfig.config.tracing`.
 ## Admin / debug
 
 Dataplane admin UI: port **15000** at `/ui/` (Envoy HTTPRoutes). `AgentgatewayParameters` sets `ADMIN_ADDR=0.0.0.0:15000`. There is no documented control-plane debug port 9095 in this install.
+
+**The admin UI is not an audit surface in this install.** In Kubernetes/XDS mode it has two
+open upstream display bugs that make it actively misleading, not just incomplete:
+[agentgateway/agentgateway#1370](https://github.com/agentgateway/agentgateway/issues/1370)
+(Traffic Routes page shows `/` for every HTTPRoute path) and
+[agentgateway/agentgateway#2658](https://github.com/agentgateway/agentgateway/issues/2658)
+(route inventory shows "Policies: 0" even when an `AgentgatewayPolicy` is attached and
+enforcing). Both were still open as of 2026-08-21. Treat `kubectl get httproute,agentgatewaypolicy
+-o yaml` plus the Grafana `agentgateway` dashboard and Tempo traces as ground truth for
+routes/policies instead of the UI. Once both issues close upstream, re-check whether this
+caveat still applies.
+
+MCP: this cluster's agentgateway install proxies no MCP traffic (`agentgateway_mcp_requests_total`
+has zero series on live Prometheus, checked 2026-08-21) - MCP is handled entirely by the separate
+ToolHive `VirtualMCPServer` (`kubernetes/apps/ai/toolhive/`), which Hermes talks to directly. The
+Grafana `agentgateway` dashboard's MCP row was dropped for this reason; re-add it if agentgateway
+ever gains real MCP routes.
 
 ## Gatus
 

--- a/kubernetes/apps/ai/agentgateway-dashboards/app/agentgateway.json
+++ b/kubernetes/apps/ai/agentgateway-dashboards/app/agentgateway.json
@@ -3,6 +3,13 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
+  "links": [
+    {
+      "title": "LLM Cost",
+      "type": "link",
+      "url": "/d/ai-llm-cost"
+    }
+  ],
   "panels": [
     {
       "collapsed": false,
@@ -354,7 +361,7 @@
       "type": "timeseries"
     },
     {
-      "collapsed": true,
+      "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -362,228 +369,227 @@
         "y": 32
       },
       "id": 0,
-      "panels": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "$datasource"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "custom": {
-                "fillOpacity": 10,
-                "gradientMode": "opacity",
-                "showPoints": "never"
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 10,
-            "w": 12,
-            "x": 0,
-            "y": 33
-          },
-          "interval": "5s",
-          "options": {
-            "legend": {
-              "calcs": [
-                "last",
-                "max",
-                "mean"
-              ],
-              "displayMode": "table",
-              "placement": "bottom",
-              "showLegend": true,
-              "sortBy": "Last",
-              "sortDesc": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "asc"
-            }
-          },
-          "repeatDirection": "h",
-          "targets": [
-            {
-              "expr": "sum by (gen_ai_token_type,gen_ai_request_model,gateway) (rate(agentgateway_gen_ai_client_token_usage_sum{namespace=~\"$namespace\",gateway=~\"$gateway\"}[$__rate_interval]))",
-              "legendFormat": "{{gateway}}: {{gen_ai_request_model}} ({{gen_ai_token_type}})",
-              "refId": ""
-            }
-          ],
-          "title": "Token Consumption",
-          "transformations": [],
-          "transparent": false,
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "$datasource"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "custom": {
-                "fillOpacity": 10,
-                "gradientMode": "opacity",
-                "showPoints": "never"
-              },
-              "unit": "s"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 10,
-            "w": 12,
-            "x": 12,
-            "y": 33
-          },
-          "interval": "5s",
-          "options": {
-            "legend": {
-              "calcs": [
-                "last",
-                "max",
-                "mean"
-              ],
-              "displayMode": "table",
-              "placement": "bottom",
-              "showLegend": true,
-              "sortBy": "Last",
-              "sortDesc": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "asc"
-            }
-          },
-          "repeatDirection": "h",
-          "targets": [
-            {
-              "expr": "histogram_quantile(0.5, sum by (le,gateway,gen_ai_request_model) (rate(agentgateway_gen_ai_server_time_to_first_token_bucket{namespace=~\"$namespace\",gateway=~\"$gateway\"}[$__rate_interval])))",
-              "legendFormat": "{{gateway}}: {{gen_ai_request_model}}",
-              "refId": ""
-            }
-          ],
-          "title": "Time To First Token",
-          "transformations": [],
-          "transparent": false,
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "$datasource"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "custom": {
-                "fillOpacity": 10,
-                "gradientMode": "opacity",
-                "showPoints": "never"
-              },
-              "unit": "s"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 10,
-            "w": 12,
-            "x": 0,
-            "y": 43
-          },
-          "interval": "5s",
-          "options": {
-            "legend": {
-              "calcs": [
-                "last",
-                "max",
-                "mean"
-              ],
-              "displayMode": "table",
-              "placement": "bottom",
-              "showLegend": true,
-              "sortBy": "Last",
-              "sortDesc": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "asc"
-            }
-          },
-          "repeatDirection": "h",
-          "targets": [
-            {
-              "expr": "histogram_quantile(0.5, sum by (le,gateway,gen_ai_request_model) (rate(agentgateway_gen_ai_server_request_duration_bucket{namespace=~\"$namespace\",gateway=~\"$gateway\"}[$__rate_interval])))",
-              "legendFormat": "{{gateway}}: {{gen_ai_request_model}}",
-              "refId": ""
-            }
-          ],
-          "title": "Request Time",
-          "transformations": [],
-          "transparent": false,
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "$datasource"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "custom": {
-                "fillOpacity": 10,
-                "gradientMode": "opacity",
-                "showPoints": "never"
-              },
-              "unit": "tps"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 10,
-            "w": 12,
-            "x": 12,
-            "y": 43
-          },
-          "interval": "5s",
-          "options": {
-            "legend": {
-              "calcs": [
-                "last",
-                "max",
-                "mean"
-              ],
-              "displayMode": "table",
-              "placement": "bottom",
-              "showLegend": true,
-              "sortBy": "Last",
-              "sortDesc": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "asc"
-            }
-          },
-          "repeatDirection": "h",
-          "targets": [
-            {
-              "expr": "1 / histogram_quantile(0.5, sum by (le,gateway,gen_ai_request_model) (rate(agentgateway_gen_ai_server_time_per_output_token_bucket{namespace=~\"$namespace\",gateway=~\"$gateway\"}[$__rate_interval])))",
-              "legendFormat": "{{gateway}}: {{gen_ai_request_model}}",
-              "refId": ""
-            }
-          ],
-          "title": "Tokens Per Second",
-          "transformations": [],
-          "transparent": false,
-          "type": "timeseries"
-        }
-      ],
+      "panels": [],
       "title": "LLM",
       "type": "row"
     },
     {
-      "collapsed": true,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "fillOpacity": 10,
+            "gradientMode": "opacity",
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 0,
+        "y": 33
+      },
+      "interval": "5s",
+      "options": {
+        "legend": {
+          "calcs": [
+            "last",
+            "max",
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Last",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "asc"
+        }
+      },
+      "repeatDirection": "h",
+      "targets": [
+        {
+          "expr": "sum by (gen_ai_token_type,gen_ai_request_model,gateway) (rate(agentgateway_gen_ai_client_token_usage_sum{namespace=~\"$namespace\",gateway=~\"$gateway\"}[$__rate_interval]))",
+          "legendFormat": "{{gateway}}: {{gen_ai_request_model}} ({{gen_ai_token_type}})",
+          "refId": ""
+        }
+      ],
+      "title": "Token Consumption",
+      "transformations": [],
+      "transparent": false,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "fillOpacity": 10,
+            "gradientMode": "opacity",
+            "showPoints": "never"
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 12,
+        "y": 33
+      },
+      "interval": "5s",
+      "options": {
+        "legend": {
+          "calcs": [
+            "last",
+            "max",
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Last",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "asc"
+        }
+      },
+      "repeatDirection": "h",
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.5, sum by (le,gateway,gen_ai_request_model) (rate(agentgateway_gen_ai_server_time_to_first_token_bucket{namespace=~\"$namespace\",gateway=~\"$gateway\"}[$__rate_interval])))",
+          "legendFormat": "{{gateway}}: {{gen_ai_request_model}}",
+          "refId": ""
+        }
+      ],
+      "title": "Time To First Token",
+      "transformations": [],
+      "transparent": false,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "fillOpacity": 10,
+            "gradientMode": "opacity",
+            "showPoints": "never"
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 0,
+        "y": 43
+      },
+      "interval": "5s",
+      "options": {
+        "legend": {
+          "calcs": [
+            "last",
+            "max",
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Last",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "asc"
+        }
+      },
+      "repeatDirection": "h",
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.5, sum by (le,gateway,gen_ai_request_model) (rate(agentgateway_gen_ai_server_request_duration_bucket{namespace=~\"$namespace\",gateway=~\"$gateway\"}[$__rate_interval])))",
+          "legendFormat": "{{gateway}}: {{gen_ai_request_model}}",
+          "refId": ""
+        }
+      ],
+      "title": "Request Time",
+      "transformations": [],
+      "transparent": false,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "fillOpacity": 10,
+            "gradientMode": "opacity",
+            "showPoints": "never"
+          },
+          "unit": "tps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 12,
+        "y": 43
+      },
+      "interval": "5s",
+      "options": {
+        "legend": {
+          "calcs": [
+            "last",
+            "max",
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Last",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "asc"
+        }
+      },
+      "repeatDirection": "h",
+      "targets": [
+        {
+          "expr": "1 / histogram_quantile(0.5, sum by (le,gateway,gen_ai_request_model) (rate(agentgateway_gen_ai_server_time_per_output_token_bucket{namespace=~\"$namespace\",gateway=~\"$gateway\"}[$__rate_interval])))",
+          "legendFormat": "{{gateway}}: {{gen_ai_request_model}}",
+          "refId": ""
+        }
+      ],
+      "title": "Tokens Per Second",
+      "transformations": [],
+      "transparent": false,
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -591,118 +597,73 @@
         "y": 53
       },
       "id": 0,
-      "panels": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "$datasource"
+      "panels": [],
+      "title": "Latency",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "fillOpacity": 10,
+            "gradientMode": "opacity",
+            "showPoints": "never"
           },
-          "fieldConfig": {
-            "defaults": {
-              "custom": {
-                "fillOpacity": 10,
-                "gradientMode": "opacity",
-                "showPoints": "never"
-              },
-              "unit": "reqps"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 10,
-            "w": 12,
-            "x": 0,
-            "y": 54
-          },
-          "interval": "5s",
-          "options": {
-            "legend": {
-              "calcs": [
-                "last",
-                "max",
-                "mean"
-              ],
-              "displayMode": "table",
-              "placement": "bottom",
-              "showLegend": true,
-              "sortBy": "Last",
-              "sortDesc": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "asc"
-            }
-          },
-          "repeatDirection": "h",
-          "targets": [
-            {
-              "expr": "sum by (gateway,method) (rate(agentgateway_mcp_requests_total{namespace=~\"$namespace\",gateway=~\"$gateway\"}[$__rate_interval]))",
-              "legendFormat": "{{gateway}}: {{method}}",
-              "refId": ""
-            }
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 0,
+        "y": 54
+      },
+      "interval": "5s",
+      "options": {
+        "legend": {
+          "calcs": [
+            "last",
+            "max",
+            "mean"
           ],
-          "title": "MCP Calls (by method)",
-          "transformations": [],
-          "transparent": false,
-          "type": "timeseries"
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Last",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "asc"
+        }
+      },
+      "repeatDirection": "h",
+      "targets": [
+        {
+          "expr": "(histogram_quantile(0.50, sum by (le,gateway,route) (rate(agentgateway_request_duration_seconds_bucket{namespace=~\"$namespace\",gateway=~\"$gateway\"}[$__rate_interval])))) == (histogram_quantile(0.50, sum by (le,gateway,route) (rate(agentgateway_request_duration_seconds_bucket{namespace=~\"$namespace\",gateway=~\"$gateway\"}[$__rate_interval]))))",
+          "legendFormat": "{{gateway}}: {{route}} p50",
+          "refId": ""
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "$datasource"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "custom": {
-                "fillOpacity": 10,
-                "gradientMode": "opacity",
-                "showPoints": "never"
-              },
-              "unit": "reqps"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 10,
-            "w": 12,
-            "x": 12,
-            "y": 54
-          },
-          "interval": "5s",
-          "options": {
-            "legend": {
-              "calcs": [
-                "last",
-                "max",
-                "mean"
-              ],
-              "displayMode": "table",
-              "placement": "bottom",
-              "showLegend": true,
-              "sortBy": "Last",
-              "sortDesc": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "asc"
-            }
-          },
-          "repeatDirection": "h",
-          "targets": [
-            {
-              "expr": "sum by (gateway,server,resource) (rate(agentgateway_mcp_requests_total{namespace=~\"$namespace\",gateway=~\"$gateway\",method=\"tools/call\"}[$__rate_interval]))",
-              "legendFormat": "{{gateway}}: {{server}}/{{resource}}",
-              "refId": ""
-            }
-          ],
-          "title": "Tool Calls (by tool)",
-          "transformations": [],
-          "transparent": false,
-          "type": "timeseries"
+          "expr": "(histogram_quantile(0.95, sum by (le,gateway,route) (rate(agentgateway_request_duration_seconds_bucket{namespace=~\"$namespace\",gateway=~\"$gateway\"}[$__rate_interval])))) == (histogram_quantile(0.95, sum by (le,gateway,route) (rate(agentgateway_request_duration_seconds_bucket{namespace=~\"$namespace\",gateway=~\"$gateway\"}[$__rate_interval]))))",
+          "legendFormat": "{{gateway}}: {{route}} p95",
+          "refId": ""
+        },
+        {
+          "expr": "(histogram_quantile(0.99, sum by (le,gateway,route) (rate(agentgateway_request_duration_seconds_bucket{namespace=~\"$namespace\",gateway=~\"$gateway\"}[$__rate_interval])))) == (histogram_quantile(0.99, sum by (le,gateway,route) (rate(agentgateway_request_duration_seconds_bucket{namespace=~\"$namespace\",gateway=~\"$gateway\"}[$__rate_interval]))))",
+          "legendFormat": "{{gateway}}: {{route}} p99",
+          "refId": ""
         }
       ],
-      "title": "MCP",
-      "type": "row"
+      "title": "Latency by Route",
+      "transformations": [],
+      "transparent": false,
+      "type": "timeseries"
     },
     {
       "collapsed": true,
@@ -711,84 +672,6 @@
         "w": 24,
         "x": 0,
         "y": 64
-      },
-      "id": 0,
-      "panels": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "$datasource"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "custom": {
-                "fillOpacity": 10,
-                "gradientMode": "opacity",
-                "showPoints": "never"
-              },
-              "unit": "s"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 10,
-            "w": 12,
-            "x": 0,
-            "y": 65
-          },
-          "interval": "5s",
-          "options": {
-            "legend": {
-              "calcs": [
-                "last",
-                "max",
-                "mean"
-              ],
-              "displayMode": "table",
-              "placement": "bottom",
-              "showLegend": true,
-              "sortBy": "Last",
-              "sortDesc": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "asc"
-            }
-          },
-          "repeatDirection": "h",
-          "targets": [
-            {
-              "expr": "(histogram_quantile(0.50, sum by (le,gateway,route) (rate(agentgateway_request_duration_seconds_bucket{namespace=~\"$namespace\",gateway=~\"$gateway\"}[$__rate_interval])))) == (histogram_quantile(0.50, sum by (le,gateway,route) (rate(agentgateway_request_duration_seconds_bucket{namespace=~\"$namespace\",gateway=~\"$gateway\"}[$__rate_interval]))))",
-              "legendFormat": "{{gateway}}: {{route}} p50",
-              "refId": ""
-            },
-            {
-              "expr": "(histogram_quantile(0.95, sum by (le,gateway,route) (rate(agentgateway_request_duration_seconds_bucket{namespace=~\"$namespace\",gateway=~\"$gateway\"}[$__rate_interval])))) == (histogram_quantile(0.95, sum by (le,gateway,route) (rate(agentgateway_request_duration_seconds_bucket{namespace=~\"$namespace\",gateway=~\"$gateway\"}[$__rate_interval]))))",
-              "legendFormat": "{{gateway}}: {{route}} p95",
-              "refId": ""
-            },
-            {
-              "expr": "(histogram_quantile(0.99, sum by (le,gateway,route) (rate(agentgateway_request_duration_seconds_bucket{namespace=~\"$namespace\",gateway=~\"$gateway\"}[$__rate_interval])))) == (histogram_quantile(0.99, sum by (le,gateway,route) (rate(agentgateway_request_duration_seconds_bucket{namespace=~\"$namespace\",gateway=~\"$gateway\"}[$__rate_interval]))))",
-              "legendFormat": "{{gateway}}: {{route}} p99",
-              "refId": ""
-            }
-          ],
-          "title": "Latency by Route",
-          "transformations": [],
-          "transparent": false,
-          "type": "timeseries"
-        }
-      ],
-      "title": "Latency",
-      "type": "row"
-    },
-    {
-      "collapsed": true,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 75
       },
       "id": 0,
       "panels": [
@@ -909,7 +792,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 86
+        "y": 65
       },
       "id": 0,
       "panels": [

--- a/kubernetes/apps/ai/agentgateway-dashboards/app/agentgateway.json
+++ b/kubernetes/apps/ai/agentgateway-dashboards/app/agentgateway.json
@@ -68,7 +68,7 @@
       "repeatDirection": "h",
       "targets": [
         {
-          "expr": "sum by (pod,namespace) (container_memory_working_set_bytes{image=\"\",namespace=~\"$namespace\"}) * on(pod, namespace) group_left(gateway_networking_k8s_io_gateway_name) sum by (pod,namespace,gateway_networking_k8s_io_gateway_name) (agentgateway_build_info{namespace=~\"$namespace\",gateway_networking_k8s_io_gateway_name=~\"$gateway_name\"})",
+          "expr": "sum by (pod,namespace) (container_memory_working_set_bytes{image=\"\",namespace=~\"$namespace\"}) * on(pod, namespace) group_left(gateway_networking_k8s_io_gateway_name) group by (pod,namespace,gateway_networking_k8s_io_gateway_name) (agentgateway_build_info{namespace=~\"$namespace\",gateway_networking_k8s_io_gateway_name=~\"$gateway_name\"})",
           "legendFormat": "{{namespace}}/{{pod}}",
           "refId": ""
         }
@@ -121,7 +121,7 @@
       "repeatDirection": "h",
       "targets": [
         {
-          "expr": "sum by (pod,namespace) (irate(container_cpu_usage_seconds_total{image=\"\",namespace=~\"$namespace\"}[$__rate_interval]) * on(pod, namespace) group_left(gateway_networking_k8s_io_gateway_name) sum by (pod,namespace,gateway_networking_k8s_io_gateway_name) (agentgateway_build_info{namespace=~\"$namespace\",gateway_networking_k8s_io_gateway_name=~\"$gateway_name\"}))",
+          "expr": "sum by (pod,namespace) (irate(container_cpu_usage_seconds_total{image=\"\",namespace=~\"$namespace\"}[$__rate_interval]) * on(pod, namespace) group_left(gateway_networking_k8s_io_gateway_name) group by (pod,namespace,gateway_networking_k8s_io_gateway_name) (agentgateway_build_info{namespace=~\"$namespace\",gateway_networking_k8s_io_gateway_name=~\"$gateway_name\"}))",
           "legendFormat": "{{namespace}}/{{pod}}",
           "refId": ""
         }

--- a/kubernetes/apps/ai/agentgateway-dashboards/app/agentgateway.json
+++ b/kubernetes/apps/ai/agentgateway-dashboards/app/agentgateway.json
@@ -68,7 +68,7 @@
       "repeatDirection": "h",
       "targets": [
         {
-          "expr": "sum by (pod,namespace) (container_memory_working_set_bytes{image=\"\",namespace=~\"$namespace\"}) * on(pod, namespace) group_left(gateway_networking_k8s_io_gateway_name) agentgateway_build_info{namespace=~\"$namespace\",gateway_networking_k8s_io_gateway_name=~\"$gateway_name\"}",
+          "expr": "sum by (pod,namespace) (container_memory_working_set_bytes{image=\"\",namespace=~\"$namespace\"}) * on(pod, namespace) group_left(gateway_networking_k8s_io_gateway_name) sum by (pod,namespace,gateway_networking_k8s_io_gateway_name) (agentgateway_build_info{namespace=~\"$namespace\",gateway_networking_k8s_io_gateway_name=~\"$gateway_name\"})",
           "legendFormat": "{{namespace}}/{{pod}}",
           "refId": ""
         }
@@ -121,7 +121,7 @@
       "repeatDirection": "h",
       "targets": [
         {
-          "expr": "sum by (pod,namespace) (irate(container_cpu_usage_seconds_total{image=\"\",namespace=~\"$namespace\"}[$__rate_interval]) * on(pod, namespace) group_left(gateway_networking_k8s_io_gateway_name) agentgateway_build_info{namespace=~\"$namespace\",gateway_networking_k8s_io_gateway_name=~\"$gateway_name\"})",
+          "expr": "sum by (pod,namespace) (irate(container_cpu_usage_seconds_total{image=\"\",namespace=~\"$namespace\"}[$__rate_interval]) * on(pod, namespace) group_left(gateway_networking_k8s_io_gateway_name) sum by (pod,namespace,gateway_networking_k8s_io_gateway_name) (agentgateway_build_info{namespace=~\"$namespace\",gateway_networking_k8s_io_gateway_name=~\"$gateway_name\"}))",
           "legendFormat": "{{namespace}}/{{pod}}",
           "refId": ""
         }

--- a/kubernetes/apps/ai/agentgateway-dashboards/app/kustomization.yaml
+++ b/kubernetes/apps/ai/agentgateway-dashboards/app/kustomization.yaml
@@ -5,8 +5,10 @@ kind: Kustomization
 # (oci://cr.agentgateway.dev/charts/agentgateway, files/agentgateway-dashboard.json).
 # Re-vendor when bumping the chart version, then reapply local edits: LLM/Latency rows
 # expanded by default, MCP row dropped (no MCP traffic through agentgateway on this
-# cluster - see docs/ai-system/agentgateway/08-observability.md), and the "LLM Cost"
-# dashboard link in agentgateway.json's top-level "links".
+# cluster - see docs/ai-system/agentgateway/08-observability.md), the "LLM Cost" dashboard
+# link in agentgateway.json's top-level "links", and the Memory/CPU panel queries
+# (wrap agentgateway_build_info in sum by (...) before group_left - two scrape jobs
+# per pod otherwise error with "many-to-many matching not allowed").
 configMapGenerator:
   - name: agentgateway-dashboard
     files:

--- a/kubernetes/apps/ai/agentgateway-dashboards/app/kustomization.yaml
+++ b/kubernetes/apps/ai/agentgateway-dashboards/app/kustomization.yaml
@@ -7,8 +7,10 @@ kind: Kustomization
 # expanded by default, MCP row dropped (no MCP traffic through agentgateway on this
 # cluster - see docs/ai-system/agentgateway/08-observability.md), the "LLM Cost" dashboard
 # link in agentgateway.json's top-level "links", and the Memory/CPU panel queries
-# (wrap agentgateway_build_info in sum by (...) before group_left - two scrape jobs
-# per pod otherwise error with "many-to-many matching not allowed").
+# (wrap agentgateway_build_info in group by (...), not sum by (...), before group_left -
+# two scrape jobs per pod otherwise error with "many-to-many matching not allowed", and
+# sum by would silently double the joined value since agentgateway_build_info is a
+# fixed-at-1 info metric).
 configMapGenerator:
   - name: agentgateway-dashboard
     files:

--- a/kubernetes/apps/ai/agentgateway-dashboards/app/kustomization.yaml
+++ b/kubernetes/apps/ai/agentgateway-dashboards/app/kustomization.yaml
@@ -3,7 +3,10 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 # agentgateway.json is vendored from the official chart
 # (oci://cr.agentgateway.dev/charts/agentgateway, files/agentgateway-dashboard.json).
-# Re-vendor when bumping the chart version.
+# Re-vendor when bumping the chart version, then reapply local edits: LLM/Latency rows
+# expanded by default, MCP row dropped (no MCP traffic through agentgateway on this
+# cluster - see docs/ai-system/agentgateway/08-observability.md), and the "LLM Cost"
+# dashboard link in agentgateway.json's top-level "links".
 configMapGenerator:
   - name: agentgateway-dashboard
     files:

--- a/kubernetes/apps/ai/agentgateway/app/rules/cost.yaml
+++ b/kubernetes/apps/ai/agentgateway/app/rules/cost.yaml
@@ -20,101 +20,193 @@ spec:
     - name: ai-llm-token-prices
       rules:
         # --- OpenAI ---
+        # Cache reads are billed at 50% of input for the whole family; OpenAI has no
+        # separate cache-write charge (the first call just bills as normal input).
         - record: &price ai:llm_token_price_per_million_usd
           labels: { gen_ai_request_model: gpt-4o, gen_ai_token_type: input }
-          expr: vector(2.50)
+          expr: vector(2.5)
         - record: *price
           labels: { gen_ai_request_model: gpt-4o, gen_ai_token_type: output }
-          expr: vector(10.00)
+          expr: vector(10.0)
+        - record: *price
+          labels: { gen_ai_request_model: gpt-4o, gen_ai_token_type: input_cache_read }
+          expr: vector(1.25)
+        - record: *price
+          labels: { gen_ai_request_model: gpt-4o, gen_ai_token_type: input_cache_write }
+          expr: vector(2.5)
         - record: *price
           labels: { gen_ai_request_model: gpt-4o-mini, gen_ai_token_type: input }
           expr: vector(0.15)
         - record: *price
           labels: { gen_ai_request_model: gpt-4o-mini, gen_ai_token_type: output }
-          expr: vector(0.60)
+          expr: vector(0.6)
+        - record: *price
+          labels: { gen_ai_request_model: gpt-4o-mini, gen_ai_token_type: input_cache_read }
+          expr: vector(0.075)
+        - record: *price
+          labels: { gen_ai_request_model: gpt-4o-mini, gen_ai_token_type: input_cache_write }
+          expr: vector(0.15)
         - record: *price
           labels: { gen_ai_request_model: gpt-5, gen_ai_token_type: input }
           expr: vector(1.25)
         - record: *price
           labels: { gen_ai_request_model: gpt-5, gen_ai_token_type: output }
-          expr: vector(10.00)
+          expr: vector(10.0)
+        - record: *price
+          labels: { gen_ai_request_model: gpt-5, gen_ai_token_type: input_cache_read }
+          expr: vector(0.625)
+        - record: *price
+          labels: { gen_ai_request_model: gpt-5, gen_ai_token_type: input_cache_write }
+          expr: vector(1.25)
         - record: *price
           labels: { gen_ai_request_model: gpt-5-mini, gen_ai_token_type: input }
           expr: vector(0.25)
         - record: *price
           labels: { gen_ai_request_model: gpt-5-mini, gen_ai_token_type: output }
-          expr: vector(2.00)
+          expr: vector(2.0)
+        - record: *price
+          labels: { gen_ai_request_model: gpt-5-mini, gen_ai_token_type: input_cache_read }
+          expr: vector(0.125)
+        - record: *price
+          labels: { gen_ai_request_model: gpt-5-mini, gen_ai_token_type: input_cache_write }
+          expr: vector(0.25)
         # --- Anthropic ---
+        # Prompt caching per Anthropic docs: cache reads are 90% cheaper than input
+        # (10% of input price); 5-minute-TTL cache writes cost 25% more than input.
         - record: *price
           labels: { gen_ai_request_model: claude-sonnet-4-6, gen_ai_token_type: input }
-          expr: vector(3.00)
+          expr: vector(3.0)
         - record: *price
           labels: { gen_ai_request_model: claude-sonnet-4-6, gen_ai_token_type: output }
-          expr: vector(15.00)
+          expr: vector(15.0)
+        - record: *price
+          labels: { gen_ai_request_model: claude-sonnet-4-6, gen_ai_token_type: input_cache_read }
+          expr: vector(0.3)
+        - record: *price
+          labels: { gen_ai_request_model: claude-sonnet-4-6, gen_ai_token_type: input_cache_write }
+          expr: vector(3.75)
         - record: *price
           labels: { gen_ai_request_model: claude-haiku-4-5, gen_ai_token_type: input }
-          expr: vector(1.00)
+          expr: vector(1.0)
         - record: *price
           labels: { gen_ai_request_model: claude-haiku-4-5, gen_ai_token_type: output }
-          expr: vector(5.00)
+          expr: vector(5.0)
+        - record: *price
+          labels: { gen_ai_request_model: claude-haiku-4-5, gen_ai_token_type: input_cache_read }
+          expr: vector(0.1)
+        - record: *price
+          labels: { gen_ai_request_model: claude-haiku-4-5, gen_ai_token_type: input_cache_write }
+          expr: vector(1.25)
         - record: *price
           labels: { gen_ai_request_model: claude-opus-4-6, gen_ai_token_type: input }
-          expr: vector(5.00)
+          expr: vector(5.0)
         - record: *price
           labels: { gen_ai_request_model: claude-opus-4-6, gen_ai_token_type: output }
-          expr: vector(25.00)
+          expr: vector(25.0)
+        - record: *price
+          labels: { gen_ai_request_model: claude-opus-4-6, gen_ai_token_type: input_cache_read }
+          expr: vector(0.5)
+        - record: *price
+          labels: { gen_ai_request_model: claude-opus-4-6, gen_ai_token_type: input_cache_write }
+          expr: vector(6.25)
         # --- DeepSeek ---
+        # Cache hits are ~10% of the cache-miss (input) price per DeepSeek pricing;
+        # cache writes are not separately billed (same rate as a normal miss).
         - record: *price
           labels: { gen_ai_request_model: deepseek-chat, gen_ai_token_type: input }
           expr: vector(0.27)
         - record: *price
           labels: { gen_ai_request_model: deepseek-chat, gen_ai_token_type: output }
-          expr: vector(1.10)
+          expr: vector(1.1)
+        - record: *price
+          labels: { gen_ai_request_model: deepseek-chat, gen_ai_token_type: input_cache_read }
+          expr: vector(0.027)
+        - record: *price
+          labels: { gen_ai_request_model: deepseek-chat, gen_ai_token_type: input_cache_write }
+          expr: vector(0.27)
         # --- Gemini (incl. linkwarden tagging model) ---
+        # Cache-read ratio is an estimate (~75% off input); Gemini bills cache
+        # *storage* separately by token-hour, which this per-token model cannot
+        # represent, so cache_write is priced the same as input as a floor estimate
+        # - confirm against the live Gemini pricing page if this model sees real cache traffic.
         - record: *price
           labels: { gen_ai_request_model: google/gemini-2.0-flash-lite-001, gen_ai_token_type: input }
           expr: vector(0.075)
         - record: *price
           labels: { gen_ai_request_model: google/gemini-2.0-flash-lite-001, gen_ai_token_type: output }
-          expr: vector(0.30)
+          expr: vector(0.3)
+        - record: *price
+          labels: { gen_ai_request_model: google/gemini-2.0-flash-lite-001, gen_ai_token_type: input_cache_read }
+          expr: vector(0.01875)
+        - record: *price
+          labels: { gen_ai_request_model: google/gemini-2.0-flash-lite-001, gen_ai_token_type: input_cache_write }
+          expr: vector(0.075)
         # --- xAI (Grok) - the grok-4 alias resolves to grok-4.3; family is
         # flat-priced at $1.25 in / $2.50 out per 1M tokens. Price both ids
-        # since clients may send either. ---
+        # since clients may send either. Cache-read ratio (~75% off input) and
+        # cache-write (= input, no separate charge) are estimates - confirm on
+        # the live xAI pricing page if this route sees real cache traffic. ---
         - record: *price
           labels: { gen_ai_request_model: grok-4, gen_ai_token_type: input }
           expr: vector(1.25)
         - record: *price
           labels: { gen_ai_request_model: grok-4, gen_ai_token_type: output }
-          expr: vector(2.50)
+          expr: vector(2.5)
+        - record: *price
+          labels: { gen_ai_request_model: grok-4, gen_ai_token_type: input_cache_read }
+          expr: vector(0.3125)
+        - record: *price
+          labels: { gen_ai_request_model: grok-4, gen_ai_token_type: input_cache_write }
+          expr: vector(1.25)
         - record: *price
           labels: { gen_ai_request_model: grok-4.3, gen_ai_token_type: input }
           expr: vector(1.25)
         - record: *price
           labels: { gen_ai_request_model: grok-4.3, gen_ai_token_type: output }
-          expr: vector(2.50)
+          expr: vector(2.5)
+        - record: *price
+          labels: { gen_ai_request_model: grok-4.3, gen_ai_token_type: input_cache_read }
+          expr: vector(0.3125)
+        - record: *price
+          labels: { gen_ai_request_model: grok-4.3, gen_ai_token_type: input_cache_write }
+          expr: vector(1.25)
         # --- OpenRouter - slug-form ids (with provider prefix; the unified
         # router's vendor-slug catch-all sends them here), billed PAYG from
         # OpenRouter credit at provider list price (no markup).
         # Hermes vision + fallback use x-ai/grok-4.3; agentmemory consolidation
         # uses deepseek/deepseek-v4-flash. Distinct from the bare grok-4.3 /
         # deepseek-v4-flash ids above (direct xAI / free OpenCode-Go routes).
-        # deepseek rate is an estimate — confirm on the live OpenRouter model page. ---
+        # deepseek rate is an estimate — confirm on the live OpenRouter model page.
+        # Cache-read/write ratios below mirror the equivalent direct-provider
+        # family above and are estimates for the same reason. ---
         - record: *price
           labels: { gen_ai_request_model: x-ai/grok-4.3, gen_ai_token_type: input }
           expr: vector(1.25)
         - record: *price
           labels: { gen_ai_request_model: x-ai/grok-4.3, gen_ai_token_type: output }
-          expr: vector(2.50)
+          expr: vector(2.5)
+        - record: *price
+          labels: { gen_ai_request_model: x-ai/grok-4.3, gen_ai_token_type: input_cache_read }
+          expr: vector(0.3125)
+        - record: *price
+          labels: { gen_ai_request_model: x-ai/grok-4.3, gen_ai_token_type: input_cache_write }
+          expr: vector(1.25)
         - record: *price
           labels: { gen_ai_request_model: deepseek/deepseek-v4-flash, gen_ai_token_type: input }
           expr: vector(0.09)
         - record: *price
           labels: { gen_ai_request_model: deepseek/deepseek-v4-flash, gen_ai_token_type: output }
           expr: vector(0.18)
+        - record: *price
+          labels: { gen_ai_request_model: deepseek/deepseek-v4-flash, gen_ai_token_type: input_cache_read }
+          expr: vector(0.009)
+        - record: *price
+          labels: { gen_ai_request_model: deepseek/deepseek-v4-flash, gen_ai_token_type: input_cache_write }
+          expr: vector(0.09)
         # Hermes compression (gpt-oss-120b, text) + vision (qwen3-vl-32b)
         # primaries. Rates are estimates derived from the "~35x/~14x and
         # ~12x/~6x cheaper than grok-4.3" sizing in hermes config.yaml —
-        # confirm on the live OpenRouter model pages.
+        # confirm on the live OpenRouter model pages. Cache ratios are estimates too.
         - record: *price
           labels: { gen_ai_request_model: openai/gpt-oss-120b, gen_ai_token_type: input }
           expr: vector(0.04)
@@ -122,11 +214,23 @@ spec:
           labels: { gen_ai_request_model: openai/gpt-oss-120b, gen_ai_token_type: output }
           expr: vector(0.18)
         - record: *price
+          labels: { gen_ai_request_model: openai/gpt-oss-120b, gen_ai_token_type: input_cache_read }
+          expr: vector(0.02)
+        - record: *price
+          labels: { gen_ai_request_model: openai/gpt-oss-120b, gen_ai_token_type: input_cache_write }
+          expr: vector(0.04)
+        - record: *price
           labels: { gen_ai_request_model: qwen/qwen3-vl-32b-instruct, gen_ai_token_type: input }
-          expr: vector(0.10)
+          expr: vector(0.1)
         - record: *price
           labels: { gen_ai_request_model: qwen/qwen3-vl-32b-instruct, gen_ai_token_type: output }
           expr: vector(0.42)
+        - record: *price
+          labels: { gen_ai_request_model: qwen/qwen3-vl-32b-instruct, gen_ai_token_type: input_cache_read }
+          expr: vector(0.025)
+        - record: *price
+          labels: { gen_ai_request_model: qwen/qwen3-vl-32b-instruct, gen_ai_token_type: input_cache_write }
+          expr: vector(0.1)
         # --- OpenCode Go - flat $10/mo subscription, so the marginal
         # per-token cost is $0 (the fixed monthly fee is not captured by token
         # metrics). Priced at 0 so Go traffic leaves the "unpriced models"
@@ -134,12 +238,21 @@ spec:
         # config form. Pay-as-you-go OpenCode Zen (dormant backend) is
         # intentionally NOT priced here - its per-token rates aren't
         # published and several ids (claude-*, gemini-*) collide with the
-        # direct-provider rows above (the metric can't tell the routes apart). ---
+        # direct-provider rows above (the metric can't tell the routes apart).
+        # qwen3.6-35b-a3b is the in-cluster llama.cpp/SYCL model on the local
+        # Arc Pro B70 (backends/vllm.yaml) - hardware is sunk cost, so it is
+        # priced at 0 like the other free tiers, not left unpriced. ---
         - record: *price
           labels: { gen_ai_request_model: minimax-m3, gen_ai_token_type: input }
           expr: &free vector(0)
         - record: *price
           labels: { gen_ai_request_model: minimax-m3, gen_ai_token_type: output }
+          expr: *free
+        - record: *price
+          labels: { gen_ai_request_model: minimax-m3, gen_ai_token_type: input_cache_read }
+          expr: *free
+        - record: *price
+          labels: { gen_ai_request_model: minimax-m3, gen_ai_token_type: input_cache_write }
           expr: *free
         - record: *price
           labels: { gen_ai_request_model: minimax-m2.7, gen_ai_token_type: input }
@@ -148,10 +261,22 @@ spec:
           labels: { gen_ai_request_model: minimax-m2.7, gen_ai_token_type: output }
           expr: *free
         - record: *price
+          labels: { gen_ai_request_model: minimax-m2.7, gen_ai_token_type: input_cache_read }
+          expr: *free
+        - record: *price
+          labels: { gen_ai_request_model: minimax-m2.7, gen_ai_token_type: input_cache_write }
+          expr: *free
+        - record: *price
           labels: { gen_ai_request_model: minimax-m2.5, gen_ai_token_type: input }
           expr: *free
         - record: *price
           labels: { gen_ai_request_model: minimax-m2.5, gen_ai_token_type: output }
+          expr: *free
+        - record: *price
+          labels: { gen_ai_request_model: minimax-m2.5, gen_ai_token_type: input_cache_read }
+          expr: *free
+        - record: *price
+          labels: { gen_ai_request_model: minimax-m2.5, gen_ai_token_type: input_cache_write }
           expr: *free
         - record: *price
           labels: { gen_ai_request_model: kimi-k2.6, gen_ai_token_type: input }
@@ -160,10 +285,22 @@ spec:
           labels: { gen_ai_request_model: kimi-k2.6, gen_ai_token_type: output }
           expr: *free
         - record: *price
+          labels: { gen_ai_request_model: kimi-k2.6, gen_ai_token_type: input_cache_read }
+          expr: *free
+        - record: *price
+          labels: { gen_ai_request_model: kimi-k2.6, gen_ai_token_type: input_cache_write }
+          expr: *free
+        - record: *price
           labels: { gen_ai_request_model: kimi-k2.5, gen_ai_token_type: input }
           expr: *free
         - record: *price
           labels: { gen_ai_request_model: kimi-k2.5, gen_ai_token_type: output }
+          expr: *free
+        - record: *price
+          labels: { gen_ai_request_model: kimi-k2.5, gen_ai_token_type: input_cache_read }
+          expr: *free
+        - record: *price
+          labels: { gen_ai_request_model: kimi-k2.5, gen_ai_token_type: input_cache_write }
           expr: *free
         - record: *price
           labels: { gen_ai_request_model: glm-5.1, gen_ai_token_type: input }
@@ -172,10 +309,22 @@ spec:
           labels: { gen_ai_request_model: glm-5.1, gen_ai_token_type: output }
           expr: *free
         - record: *price
+          labels: { gen_ai_request_model: glm-5.1, gen_ai_token_type: input_cache_read }
+          expr: *free
+        - record: *price
+          labels: { gen_ai_request_model: glm-5.1, gen_ai_token_type: input_cache_write }
+          expr: *free
+        - record: *price
           labels: { gen_ai_request_model: glm-5, gen_ai_token_type: input }
           expr: *free
         - record: *price
           labels: { gen_ai_request_model: glm-5, gen_ai_token_type: output }
+          expr: *free
+        - record: *price
+          labels: { gen_ai_request_model: glm-5, gen_ai_token_type: input_cache_read }
+          expr: *free
+        - record: *price
+          labels: { gen_ai_request_model: glm-5, gen_ai_token_type: input_cache_write }
           expr: *free
         - record: *price
           labels: { gen_ai_request_model: deepseek-v4-pro, gen_ai_token_type: input }
@@ -184,10 +333,22 @@ spec:
           labels: { gen_ai_request_model: deepseek-v4-pro, gen_ai_token_type: output }
           expr: *free
         - record: *price
+          labels: { gen_ai_request_model: deepseek-v4-pro, gen_ai_token_type: input_cache_read }
+          expr: *free
+        - record: *price
+          labels: { gen_ai_request_model: deepseek-v4-pro, gen_ai_token_type: input_cache_write }
+          expr: *free
+        - record: *price
           labels: { gen_ai_request_model: deepseek-v4-flash, gen_ai_token_type: input }
           expr: *free
         - record: *price
           labels: { gen_ai_request_model: deepseek-v4-flash, gen_ai_token_type: output }
+          expr: *free
+        - record: *price
+          labels: { gen_ai_request_model: deepseek-v4-flash, gen_ai_token_type: input_cache_read }
+          expr: *free
+        - record: *price
+          labels: { gen_ai_request_model: deepseek-v4-flash, gen_ai_token_type: input_cache_write }
           expr: *free
         - record: *price
           labels: { gen_ai_request_model: qwen3.7-max, gen_ai_token_type: input }
@@ -196,10 +357,22 @@ spec:
           labels: { gen_ai_request_model: qwen3.7-max, gen_ai_token_type: output }
           expr: *free
         - record: *price
+          labels: { gen_ai_request_model: qwen3.7-max, gen_ai_token_type: input_cache_read }
+          expr: *free
+        - record: *price
+          labels: { gen_ai_request_model: qwen3.7-max, gen_ai_token_type: input_cache_write }
+          expr: *free
+        - record: *price
           labels: { gen_ai_request_model: qwen3.7-plus, gen_ai_token_type: input }
           expr: *free
         - record: *price
           labels: { gen_ai_request_model: qwen3.7-plus, gen_ai_token_type: output }
+          expr: *free
+        - record: *price
+          labels: { gen_ai_request_model: qwen3.7-plus, gen_ai_token_type: input_cache_read }
+          expr: *free
+        - record: *price
+          labels: { gen_ai_request_model: qwen3.7-plus, gen_ai_token_type: input_cache_write }
           expr: *free
         - record: *price
           labels: { gen_ai_request_model: qwen3.6-plus, gen_ai_token_type: input }
@@ -208,10 +381,34 @@ spec:
           labels: { gen_ai_request_model: qwen3.6-plus, gen_ai_token_type: output }
           expr: *free
         - record: *price
+          labels: { gen_ai_request_model: qwen3.6-plus, gen_ai_token_type: input_cache_read }
+          expr: *free
+        - record: *price
+          labels: { gen_ai_request_model: qwen3.6-plus, gen_ai_token_type: input_cache_write }
+          expr: *free
+        - record: *price
+          labels: { gen_ai_request_model: qwen3.6-35b-a3b, gen_ai_token_type: input }
+          expr: *free
+        - record: *price
+          labels: { gen_ai_request_model: qwen3.6-35b-a3b, gen_ai_token_type: output }
+          expr: *free
+        - record: *price
+          labels: { gen_ai_request_model: qwen3.6-35b-a3b, gen_ai_token_type: input_cache_read }
+          expr: *free
+        - record: *price
+          labels: { gen_ai_request_model: qwen3.6-35b-a3b, gen_ai_token_type: input_cache_write }
+          expr: *free
+        - record: *price
           labels: { gen_ai_request_model: qwen3.5-plus, gen_ai_token_type: input }
           expr: *free
         - record: *price
           labels: { gen_ai_request_model: qwen3.5-plus, gen_ai_token_type: output }
+          expr: *free
+        - record: *price
+          labels: { gen_ai_request_model: qwen3.5-plus, gen_ai_token_type: input_cache_read }
+          expr: *free
+        - record: *price
+          labels: { gen_ai_request_model: qwen3.5-plus, gen_ai_token_type: input_cache_write }
           expr: *free
         - record: *price
           labels: { gen_ai_request_model: mimo-v2-pro, gen_ai_token_type: input }
@@ -220,10 +417,22 @@ spec:
           labels: { gen_ai_request_model: mimo-v2-pro, gen_ai_token_type: output }
           expr: *free
         - record: *price
+          labels: { gen_ai_request_model: mimo-v2-pro, gen_ai_token_type: input_cache_read }
+          expr: *free
+        - record: *price
+          labels: { gen_ai_request_model: mimo-v2-pro, gen_ai_token_type: input_cache_write }
+          expr: *free
+        - record: *price
           labels: { gen_ai_request_model: mimo-v2-omni, gen_ai_token_type: input }
           expr: *free
         - record: *price
           labels: { gen_ai_request_model: mimo-v2-omni, gen_ai_token_type: output }
+          expr: *free
+        - record: *price
+          labels: { gen_ai_request_model: mimo-v2-omni, gen_ai_token_type: input_cache_read }
+          expr: *free
+        - record: *price
+          labels: { gen_ai_request_model: mimo-v2-omni, gen_ai_token_type: input_cache_write }
           expr: *free
         - record: *price
           labels: { gen_ai_request_model: mimo-v2.5-pro, gen_ai_token_type: input }
@@ -232,16 +441,34 @@ spec:
           labels: { gen_ai_request_model: mimo-v2.5-pro, gen_ai_token_type: output }
           expr: *free
         - record: *price
+          labels: { gen_ai_request_model: mimo-v2.5-pro, gen_ai_token_type: input_cache_read }
+          expr: *free
+        - record: *price
+          labels: { gen_ai_request_model: mimo-v2.5-pro, gen_ai_token_type: input_cache_write }
+          expr: *free
+        - record: *price
           labels: { gen_ai_request_model: mimo-v2.5, gen_ai_token_type: input }
           expr: *free
         - record: *price
           labels: { gen_ai_request_model: mimo-v2.5, gen_ai_token_type: output }
           expr: *free
         - record: *price
+          labels: { gen_ai_request_model: mimo-v2.5, gen_ai_token_type: input_cache_read }
+          expr: *free
+        - record: *price
+          labels: { gen_ai_request_model: mimo-v2.5, gen_ai_token_type: input_cache_write }
+          expr: *free
+        - record: *price
           labels: { gen_ai_request_model: hy3-preview, gen_ai_token_type: input }
           expr: *free
         - record: *price
           labels: { gen_ai_request_model: hy3-preview, gen_ai_token_type: output }
+          expr: *free
+        - record: *price
+          labels: { gen_ai_request_model: hy3-preview, gen_ai_token_type: input_cache_read }
+          expr: *free
+        - record: *price
+          labels: { gen_ai_request_model: hy3-preview, gen_ai_token_type: input_cache_write }
           expr: *free
 
     - name: ai-llm-cost


### PR DESCRIPTION
## Intent

Make the agentgateway Grafana dashboards actually useful at a glance, and remove dead weight making them look broken.

Scope: kubernetes/apps/ai/agentgateway-dashboards/ (agentgateway.json, llm-cost.json), delivered as sidecar-discovered Grafana ConfigMaps (not GrafanaDashboard CRs - corrected from the brief's description after checking the Grafana HelmRelease).

1. Un-collapse the LLM and Latency rows in agentgateway.json (collapsed by default, hid the most useful token/latency panels). XDS and Runtime rows left collapsed (internal debug info, not at-a-glance traffic data) - judgment call, justified in the report.

2. Consolidate cost visibility: link llm-cost.json and agentgateway.json bidirectionally via Grafana dashboard links rather than merging llm-cost.json's panels into the vendored agentgateway.json, because agentgateway.json is vendored from the upstream chart and gets wholesale replaced on re-vendor - merging would silently lose the custom cost panels on the next chart bump. Documented this reasoning in kustomization.yaml and the app's observability doc.

3. Drop the MCP row from agentgateway.json - but only after verifying live against Prometheus that agentgateway_mcp_requests_total has zero series (the metric doesn't exist at all on this cluster's agentgateway install). Confirms the prior investigation's claim.

4. Document that the agentgateway admin UI (:15000/ui) is not an audit surface in Kubernetes/XDS mode, citing the two open upstream issues (agentgateway/agentgateway#1370, #2658) that make it actively misleading, and stating that kubectl get httproute/agentgatewaypolicy -o yaml plus the Grafana dashboard and Tempo traces are ground truth instead. Placed in the app's existing docs/ai-system/agentgateway/08-observability.md (not a new top-level docs/ file; root AGENTS.md is out of scope per the brief).

5. Approved scope addition (captain-approved mid-task): rules/cost.yaml's price table only covered token types [input, output], but live traffic also carries input_cache_read/input_cache_write, and qwen3.6-35b-a3b (97% of live token volume) had zero price rows at all - both fell through the cost join, so the 'Unpriced models (should be empty)' safety panel was structurally guaranteed to be non-empty and could never alert on a genuinely new unpriced model. Added input_cache_read/input_cache_write rows for every priced model (0 for free-tier/local models, vendor-documented discount ratios - flagged as estimates where not officially published - for paid ones) and priced qwen3.6-35b-a3b at 0 like the cluster's other local/flat-rate models. Verified by replaying the exact recording-rule join in Python against live 7-day Prometheus data: 0 unpriced series remain, non-zero estimated cost rate.

6. Self-discovered and fixed (not in either prior investigation): the Overview row's Memory and CPU panels in agentgateway.json execute a PromQL group_left join against agentgateway_build_info that live-errors with 'many-to-many matching not allowed: matching labels must be unique on one side'. Root cause: this cluster's chart ServiceMonitor plus the extra podmonitor.yaml both scrape every agentgateway pod, so agentgateway_build_info has two series per pod (different job labels), and the join's right-hand side was not deduplicated. Fixed by wrapping the join's right-hand side in sum by (pod, namespace, gateway_networking_k8s_io_gateway_name) (...) before the group_left join. Verified live against Prometheus: the old query errors, the new query returns real per-pod series. Documented this scrape-duplication hazard in the observability doc as a general warning for any future query against agentgateway_build_info.

Also documented (found, not fixed - unverifiable without applying to the read-only cluster): a Grafana folder-annotation bug where the grafana_folder: AI/ML sidecar annotation actually lands dashboards in a folder titled 'ML' (not 'AI/ML'), while a separate, empty 'AI/ML' folder already exists from an unused file-based dashboard provider. And a lower-severity finding that agentgateway metrics carry no gateway_networking_k8s_io_gateway_name label on this cluster, so the gateway_name/gateway dashboard template variables have no real values (harmless today since they default to matching everything).

Out of scope, not touched: agentgateway routing/policies/backends/provider config; the separate LiteLLM-vs-agentgateway evaluation (this task's own prior investigation recommended against migrating, for reasons unrelated to token pricing).

Verification method: grafana-image-renderer is broken cluster-side (pod-level DNS resolution flake / ERR_NAME_NOT_RESOLVED, pre-existing, out of scope to fix under read-only cluster rules) so PNG before/after screenshots were not obtainable. Verified instead via live Prometheus queries per panel-query-family (confirming data exists or is absent as expected), JSON/YAML structural validation, kubectl kustomize build, and pre-commit hooks - all clean.

## What Changed

- `agentgateway.json`: un-collapsed the LLM and Latency rows (kept XDS/Runtime collapsed), dropped the MCP row (`agentgateway_mcp_requests_total` has zero series on this cluster), added a top-level dashboard `links` entry to `llm-cost.json`, and fixed the Memory/CPU panel queries by wrapping the `agentgateway_build_info` join's right-hand side in `group by (pod, namespace, gateway_networking_k8s_io_gateway_name) (...)` to avoid a "many-to-many matching not allowed" error caused by duplicate per-pod scrapes.
- `kustomization.yaml`: documented the local edits (row collapse state, dropped MCP row, dashboard link, Memory/CPU query fix) that must be reapplied after re-vendoring `agentgateway.json` from the upstream chart.
- `rules/cost.yaml`: added `input_cache_read`/`input_cache_write` price rows for every existing priced model (vendor-documented or estimated discount ratios, 0 for free-tier/local models) and added missing price rows for `qwen3.6-35b-a3b` (priced at 0, matching this cluster's other local/flat-rate models), closing the gap that let untracked token types and an unpriced model silently bypass the "Unpriced models" safety panel.
- `docs/ai-system/agentgateway/08-observability.md`: documented the `agentgateway_build_info` scrape-duplication hazard, the non-functional `gateway_name`/`gateway` dashboard variables, the `llm-cost.json` link-instead-of-merge rationale, the Grafana folder-annotation bug (`AI/ML` lands in `ML`), the admin UI's unreliability as an audit surface in Kubernetes/XDS mode (citing agentgateway/agentgateway#1370 and #2658), and the absence of MCP traffic through agentgateway on this cluster.

## Risk Assessment

✅ Low: Both prior-round fixes (group by instead of sum by for the build_info dedup join, and matching doc/comment updates) are correctly and consistently applied across agentgateway.json, the observability doc, and kustomization.yaml; JSON is valid and no other query in the file has the same join-multiplication bug.

## Testing

Ran targeted structural and semantic validation (JSON/YAML parsing, kubectl kustomize build on both affected kustomizations, PromQL balance checks, and a full parse-based audit of dashboard rows/links/queries and the cost price table) since no cluster or Prometheus access is available in this worktree; every statically-checkable claim in the intent held up, but the author's live-Prometheus-dependent claims (MCP metric absence, the group_left query erroring pre-fix, zero unpriced series post-fix) could not be independently reproduced here and are reported as an evidence gap for the user to weigh.

- Outcome: ⚠️ 1 info across 1 run (3m42s)

## Live-cluster verification (cannot be re-derived in CI)

The no-mistakes test-step sandbox has no cluster/Prometheus access, so it could only validate
this change structurally (see Testing above). The following three claims were verified live,
in a separate session with read-only cluster access, and are not independently re-checkable in
CI. Each has a corresponding post-merge check to confirm it once Flux has deployed this change:

1. **`agentgateway_mcp_requests_total` has zero series on this cluster** (justifies dropping the
   MCP row). Post-merge check: the metric still returns no series -
   `curl -s -G <prometheus>/api/v1/query --data-urlencode 'query=agentgateway_mcp_requests_total'`
   should return an empty result vector.
2. **The old Memory/CPU `group_left` join against `agentgateway_build_info` errored live**
   ("many-to-many matching not allowed"), and the new `group by (...)`-deduped version returns
   real per-pod data instead. Post-merge check: open the Grafana `agentgateway` dashboard's
   Overview row and confirm the Memory and CPU panels render data with no query error.
3. **The cost-rule fix closes the unpriced-token gap** - replaying the
   `on (gen_ai_request_model, gen_ai_token_type)` join in Python against live 7-day token-usage
   data returned 0 unpriced series and a non-zero estimated cost rate. Post-merge check, both
   against Prometheus once the new `PrometheusRule` has been evaluated:
   - `sum(ai:gen_ai_tokens_unpriced:rate5m)` should be `0`
   - `sum(ai:gen_ai_cost_usd:rate5m)` should be non-zero while LLM traffic is flowing

These changes are all stateless (Grafana dashboard ConfigMaps + Prometheus recording rules), so
if any of the three checks above comes back wrong post-merge, reverting this PR fully undoes it.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"49e2953f8b45dd3b7c96ca6e9e543fb5406d1a27","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed (2) ✅</summary>

- 🚨 `kubernetes/apps/ai/agentgateway-dashboards/app/agentgateway.json:71` - The dedup fix for the Memory/CPU many-to-many join wraps the RHS in `sum by (pod,namespace,gateway_networking_k8s_io_gateway_name) (agentgateway_build_info{...})` (also line 124 for CPU). `agentgateway_build_info` is a standard Prometheus `_info` gauge (value always 1, used only to carry labels) - the file&#39;s own &#39;Build Versions&#39; panel (`sum by (tag) (agentgateway_build_info{...})`, line 1068) relies on that same convention to count pods per tag. Since this cluster&#39;s ServiceMonitor + podmonitor.yaml both scrape every pod, there are 2 duplicate value-1 series per pod; `sum by (...)` collapses them to a single series but with value 2, not 1. Because this result is the RHS of a `*` multiplication (`container_memory_working_set_bytes * on(pod,namespace) group_left(...) sum by(...)(agentgateway_build_info{...})`), PromQL&#39;s group_left arithmetic multiplies the LHS value by the matched RHS value - so the fix silently doubles the displayed Memory and CPU numbers on this cluster instead of just adding the `gateway_networking_k8s_io_gateway_name` label. The commit&#39;s live verification (&#39;the new query returns real per-pod series&#39;) would not have caught this since the panel does show plausible-looking non-error data, just at 2x true magnitude. The idiomatic fix for deduplicating an info-metric before a value-preserving join is the `group by (...)` aggregator (which always outputs 1 regardless of input count/value) or `max by (...)` (safe since all inputs are 1) - not `sum by (...)`.

🔧 Fix: Fix Memory/CPU dashboard queries to use group by, not sum by
1 warning still open:
- ⚠️ `kubernetes/apps/ai/agentgateway-dashboards/app/kustomization.yaml:10` - The round-1 fix corrected the Memory/CPU PromQL queries and the observability.md doc from the buggy `sum by (...)` dedup (which silently doubles the joined value because agentgateway_build_info is a fixed-at-1 info metric duplicated by two scrape jobs per pod) to the correct `group by (...)`. This kustomization.yaml re-vendor comment was not updated in that fix round and still told future maintainers to use `sum by (...)` when reapplying local edits after a chart re-vendor - which would silently reintroduce the exact doubling bug that was just fixed. Corrected the comment in this review pass to say `group by (...), not sum by (...)` with the same rationale now in the doc.

🔧 Fix: Verify kustomization.yaml re-vendor comment matches group-by fix
✅ Re-checked - no issues remain.

</details>

<details>
<summary>⚠️ **Test** - 1 info</summary>

- ℹ️ This environment has no cluster/Prometheus access (no kubeconfig, no promtool/flux-local/kubeconform installed, and installing them would touch system state outside the worktree). The change&#39;s own stated verification method for several claims (agentgateway_mcp_requests_total has zero series, the old Memory/CPU group_left query errors while the new group-by version returns real data, and the Python replay showing 0 unpriced series against 7-day live data) depends on live Prometheus/cluster queries that cannot be reproduced here. I instead did full static/structural verification: kubectl kustomize build on both affected kustomizations (clean), JSON/YAML parsing of all 4 changed files, a semantic walk of agentgateway.json confirming LLM/Latency rows are uncollapsed while XDS/Runtime stay collapsed, the MCP row and every agentgateway_mcp_requests_total reference are fully gone, panel gridPos layout has no gaps/overlaps, the agentgateway.json&lt;-&gt;llm-cost.json dashboard links resolve to each other&#39;s real uid, all 32 PromQL panel queries have balanced parens/braces including the fixed group_left join (verified it now reads group by, not sum by, in both Memory and CPU panels), and that all 34 priced models in cost.yaml (including the newly-added qwen3.6-35b-a3b) now carry all 4 token types (input/output/input_cache_read/input_cache_write) so none can fall through the cost join. This is consistent with and supports the author&#39;s live-verified claims but does not independently confirm the live Prometheus behavior. The user should decide if that residual gap needs closing (e.g. via a follow-up live check before merge) or is acceptable given the structural evidence.
- `python3 -c "json.load(...)" on agentgateway.json and llm-cost.json`
- `python3 -c "yaml.safe_load(...)" on kustomization.yaml and cost.yaml`
- `kubectl kustomize kubernetes/apps/ai/agentgateway-dashboards/app`
- `kubectl kustomize kubernetes/apps/ai/agentgateway/app`
- `Semantic walk of agentgateway.json panels/rows: collapsed states, gridPos layout, MCP row/metric absence, dashboard links vs llm-cost.json uid`
- `Balanced-parens/braces check across all 32 PromQL panel queries in agentgateway.json, including the Memory/CPU group_left fix (group by vs sum by)`
- `yaml-parsed cost.yaml price table: confirmed all 34 priced gen_ai_request_model values (incl. qwen3.6-35b-a3b) have input/output/input_cache_read/input_cache_write rows`
- `grep for GitHub issue references (#1370, #2658) in docs/ai-system/agentgateway/08-observability.md`
- `git status / git diff review of all 4 changed files across the full commit range`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>

