### PR TITLE
feat(volsync): back up second volumes for syncthing, paperless-ngx, and perplexica

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,6 +70,7 @@ Gatus is an app under `kubernetes/apps/monitoring/gatus`, not a component. Endpo
   - Define the variable properly when it's a genuinely missing Flux var, not a false-positive match - `kubernetes/apps/selfhosted/rsshub/playwright/hr.yaml` renamed `${TIMEZONE}` to `${CONFIG_TIMEZONE}`, defined in `kubernetes/apps/selfhosted/rsshub/ks.yaml`'s `substitute` map.
 - **Component composition**: Namespace `kustomization.yaml` includes `../../components/common` + `../../components/alerts` as components
 - **Volsync triple-backup**: Apps get 3 ReplicationSources (ceph/minio/r2) + 1 ReplicationDestination via a single component include on the Flux `ks.yaml` (`../../../../components/volsync`). Defaults: Ceph every 4h, MinIO every 6h, R2 daily at 02:00. Per-app cron offsets live on `ks.yaml` `VOLSYNC_SCHEDULE_*` (not unique across every app). Live app list and retain settings: `kubernetes/components/volsync/Readme.md`
+- **One component include covers ONE volume.** Every volsync object is named from `${APP}` and Flux allows one `postBuild.substitute` map per Kustomization, so an app with a second PVC needs a second Flux Kustomization in its `ks.yaml` with `path: ./kubernetes/components/volsync/backup` and `APP` set to the claim name. Pattern and examples: `kubernetes/components/volsync/Readme.md` "Apps with more than one volume"
 - **VOLSYNC_CACHE_CAPACITY**: Must be sized 20-50% of PVC size - small PVCs need 50-100%
 - **dependsOn chains**: Many apps use `dependsOn` in ks.yaml - typically `onepassword-store` in `security` namespace
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -267,6 +267,8 @@ spec:
 
 Example: `kubernetes/apps/media/immich/ks.yaml`. This creates three ReplicationSources (automated backups) and one ReplicationDestination (manual restore).
 
+**An app with more than one volume needs one Flux Kustomization per volume.** The component is single-claim by construction - every object is named from `${APP}` and Flux allows one `postBuild.substitute` map per Kustomization. Add a second document to the app's `ks.yaml` with `path: ./kubernetes/components/volsync/backup` (the backup-only bundle, which does not create the PVC) and `APP` set to the claim name. See `kubernetes/components/volsync/Readme.md` "Apps with more than one volume"; live examples are `selfhosted/syncthing`, `selfhosted/paperless-ngx` and `ai/perplexica`.
+
 **Cache sizing**: Set `VOLSYNC_CACHE_CAPACITY` to 20-50% of PVC size for optimal performance. Small PVCs need 50-100%.
 
 ### Network Architecture

--- a/docs/backups/volsync-coverage-2026-08-22.md
+++ b/docs/backups/volsync-coverage-2026-08-22.md
@@ -1,0 +1,278 @@
+# VolSync coverage audit - 2026-08-22
+
+> **Historical snapshot.** Every number below was measured live against the cluster on
+> 2026-08-22 at repo HEAD `d4399e37`. The authoritative description of the backup
+> component and its multi-volume pattern lives in
+> [`kubernetes/components/volsync/Readme.md`](../../kubernetes/components/volsync/Readme.md);
+> re-measure before relying on any figure here.
+
+## 1. What was wrong
+
+`kubernetes/components/volsync/` names every resource from `${APP}` and backs up exactly
+one PVC, `${VOLSYNC_CLAIM:-${APP}}`. Flux allows one `postBuild.substitute` map per
+Kustomization, so an app cannot include the component twice. Any app with more than one
+volume therefore had its extra volumes silently unprotected, and every StorageClass in
+the cluster is `reclaimPolicy: Delete`, so a deleted PVC takes the data with it.
+
+## 2. Complete unbacked-volume inventory
+
+75 PVCs exist cluster-wide once VolSync's own cache/temp PVCs are excluded. **34 were
+backed, 41 were not.** Usage is `rbd du` allocated bytes (RBD volumes) or in-pod `df`
+(CephFS / hostpath), not provisioned capacity.
+
+### 2.1 Covered by this change (4)
+
+The multi-claim defect, on volumes holding non-reconstructible state:
+
+| Volume | Provisioned | Actually used | Why it matters |
+|---|---|---|---|
+| `selfhosted/syncthing-data` | 100Gi | 28 KiB (empty) | the synced-file target |
+| `selfhosted/paperless-ngx-media` | 50Gi | 32 KiB (empty) | scanned-document originals + archived PDFs |
+| `ai/perplexica-dbstore` | 1Gi | 64 KiB | `db.sqlite` - chat history and settings |
+| `ai/perplexica-uploads` | 5Gi | 20 KiB | user-uploaded documents |
+
+### 2.2 Deliberately not covered (37)
+
+| Volume(s) | Prov. | Used | Why not |
+|---|---|---|---|
+| `monitoring/*` (7) | 170Gi | ~132Gi | **out of scope** - separate decision, see the cleanliness scout report |
+| `database/postgres-17-{1,5,6}` | 300Gi | 62Gi | already protected by CloudNativePG `barmanObjectStore`; `ScheduledBackup postgres-17` completed 10 min before this audit, 6 consecutive daily backups `completed` |
+| `downloads/sabnzbd-incomplete` | 1500Gi | 939Gi | in-flight downloads; transient by definition |
+| `downloads/shared-downloads` | 2Ti | (CephFS) | completed media, re-acquirable |
+| `media/tdarr-temp` | 200Gi | 0 | transcode scratch |
+| `ai/comfyui-models` | 100Gi | 0.26Gi | model cache, re-downloadable; the `comfyui` Deployment is scaled to 0 |
+| `ai/vllm-models` | 50Gi | 46.7Gi | model cache, re-downloadable from HuggingFace |
+| `media/jellyfin-metadata` | 50Gi | 17.3Gi | artwork/metadata cache Jellyfin regenerates from the library. **The one judgement call here** - regenerating 17Gi is hours of API calls, so it is defensible to cover it later; it is a cache, not data. |
+| `rook-ceph/ceph-backup-pvc`, `rook-ceph-mon-{h,i,m}` | 80Gi | hostpath | Ceph's own mon store / config backup; backing Ceph up onto Ceph is circular |
+| `selfhosted/paperless-ngx-consume` | 10Gi | 20 KiB | watched inbox - paperless **deletes** files from it once ingested into `media`, so it only ever holds transient state |
+| `ai/vllm-embed-models` | 20Gi | 4.1Gi | model cache |
+| `ai/comfyui-{custom-nodes,input,output,user}` | 42Gi | 0.16Gi | re-installable / scratch; app is scaled to 0 |
+| `database/nats-js-nats-{0,1,2}` | 30Gi | 0.74Gi | JetStream, 3-way replicated across the same StatefulSet |
+| `database/emqx-core-data-*` (4) | 20Gi | 1.0Gi | MQTT session state, regenerated on reconnect. **2 of the 4 are orphans** from an old ReplicaSet (`597bbb9c7c`) with no pod - worth a separate cleanup. |
+| `database/surrealdb` | 20Gi | 0.44Gi | **flagged, not fixed** - a live database with no backup and no CNPG-style equivalent. Not part of the multi-claim defect and not in this task's scope; recommend covering it. |
+| `flux-system/headlamp` | 1Gi | 0.12Gi | plugin dir, re-installed by the chart |
+| `actions-runner-system/*-work` (2) | 40Gi | 0.18Gi | ephemeral runner workdirs |
+
+### 2.3 Correction to the premise
+
+The task was framed as "two volumes holding real data have no backup". **Both volumes are
+empty.** `syncthing-data` holds 28 KiB (a `lost+found` directory and nothing else) and
+`paperless-ngx-media` holds 32 KiB (an empty `documents/` and a zero-byte `media.lock`);
+`select count(*) from documents_document` in the `paperless` database returns **0**. The
+"160 GiB unbacked" figure in the cleanliness scout report is *provisioned* capacity, not
+stored data.
+
+That makes the exposure a future one rather than a live one - and makes now the cheapest
+possible moment to close it, since the first document scanned into paperless is protected
+from its first backup window onward instead of after the next audit.
+
+It also means VolSync will log `== Directory is empty skipping backup ===` and create **no
+snapshot** for `syncthing-data`, `paperless-ngx-media` and `perplexica-uploads` until real
+data arrives. That is correct mover behaviour, not a failure - `selfhosted/rsshub` and
+`rsshub-playwright` already sit in exactly that state today (`Successful`, zero snapshot
+objects in their restic repos). Only `perplexica-dbstore` has content, so it is the only
+one of the four that will produce a snapshot immediately.
+
+### 2.4 Separate finding - perplexica's existing coverage points at the wrong volume
+
+`ai/perplexica` sets no `VOLSYNC_CLAIM`, so the component defaults to `${APP}` and creates
+and backs up a PVC named `perplexica`. The HelmRelease never mounts it - it mounts
+`perplexica-dbstore` and `perplexica-uploads`. So perplexica has had three
+ReplicationSources faithfully backing up an empty, unmounted volume (`rbd du`: 0.00Gi)
+while its real data was unprotected. The two Kustomizations added here cover the real
+volumes; **the redundant `perplexica` source and its unused PVC are left alone** because
+removing them means pruning a live PVC, which is the captain's call.
+
+### 2.5 Separate finding - orphaned restic repositories
+
+Roughly 41% of the local Ceph backup bucket belongs to apps that no longer exist:
+
+| Repo | Bytes | Live app? |
+|---|---|---|
+| `my-claw` | 17.6 GB | no |
+| `openclaw` | 4.0 GB | no |
+| `homeops-claw` | 0.41 GB | no |
+| `qbittorrent` | 0.21 GB | no |
+| `cross-seed` | 8.0 MB | no |
+| `open-notebook` | 4.1 MB | no |
+
+~22.2 GB of 53.9 GB. Not touched here; reclaiming it is a deletion and needs a decision.
+
+## 3. How coverage was extended
+
+Three shapes were possible:
+
+1. **A second instance of the component in the same Kustomization** - impossible. Flux
+   permits one `postBuild.substitute` map per Kustomization and every object name derives
+   from `${APP}`.
+2. **A parameterised claim list inside the component** (`VOLSYNC_CLAIM_2`, ...) - rejected.
+   Kustomize has no conditionals, so an unset second claim would still emit a broken
+   ReplicationSource for all 34 apps already using the component.
+3. **A dedicated Flux Kustomization per extra volume** - chosen.
+
+The component was split so that the reusable half exists on its own:
+
+```
+kubernetes/components/volsync/
+├── backup/            # NEW - ceph + minio + r2, no PVC. Also a valid Flux `path`.
+├── pvc.yaml
+└── kustomization.yaml # Component: ./backup + ./pvc.yaml
+```
+
+`backup/` is now the single definition of "back this PVC up to all three destinations".
+The parent Component layers `pvc.yaml` on top for the normal single-claim case, and
+`kustomize build` output for the 34 existing apps is **byte-identical to HEAD** (verified
+by diffing a build of the component before and after).
+
+An extra volume is then ~20 lines appended to the app's own `ks.yaml`, with `APP` set to
+the claim name so it gets its own restic repository, ExternalSecrets and
+ReplicationDestination:
+
+```yaml
+path: "./kubernetes/components/volsync/backup"
+postBuild:
+  substitute:
+    APP: &app paperless-ngx-media
+    VOLSYNC_CLAIM: *app
+```
+
+Multi-document `ks.yaml` is already an established pattern here (14 apps use it), so this
+introduces no new convention. All three targets (`ceph`, `minio`, `r2`) are used, matching
+existing coverage.
+
+## 4. Capacity
+
+Measured before committing to schedules and retention.
+
+| Target | Currently stored | Headroom | Verdict |
+|---|---|---|---|
+| **Local Ceph S3** (`volsync` bucket, RGW) | 53.9 GB across 11,092 objects, **no bucket quota** | pool `ceph-objectstore.rgw.buckets.data` `MAX AVAIL` **3.6 TiB**; raw 17 TiB with 12 TiB free at 30.31% used | safe |
+| **Cloudflare R2** | `paperless-ngx` repo alone: 1.577 GiB raw over 43 snapshots | usage-billed, no fixed ceiling | safe; the constraint is cost, not capacity |
+| **NAS MinIO** | `paperless-ngx` repo: 5.472 MiB raw over 24 snapshots (13.93x compression) | **not measurable** - `https://nas.sklab.dev:9000/minio/v2/metrics/cluster` returns HTTP 403 and the VolSync credential is not a MinIO admin key | see below |
+
+**What is actually being added today: ~144 KiB.** All four volumes are empty or near-empty,
+so the first backups add essentially nothing.
+
+**Worst case, if all four volumes fill to their provisioned size:** 156 GiB of source data.
+On Ceph that is ~156 GiB stored / ~468 GiB raw at 3x replication - about 4% of the 3.6 TiB
+usable headroom, and 2.7% of raw. Safe with a very wide margin.
+
+**The MinIO gap is a real one and is stated rather than papered over.** NAS free space could
+not be read without admin credentials that are deliberately not in the cluster. The bound is
+the same +156 GiB worst case; if the NAS has less than ~200 GiB free, the `minio`
+ReplicationSources for `syncthing-data` and `paperless-ngx-media` should be reconsidered
+before those volumes are filled. **Recommend checking NAS free space manually before
+syncthing is pointed at a large dataset.** No schedule or retention was tightened on the
+strength of an unmeasured number.
+
+Retention is the component default (ceph 6h/14d/10w/6m, minio 14d/8w/6m, r2 30d/12w/12m).
+Schedule minutes were picked to avoid collisions with every existing ReplicationSource in
+the same namespace, so no two movers snapshot the same Ceph pool in the same minute.
+
+Cache sizing: 5Gi for `syncthing-data` and `paperless-ngx-media` (restic cache scales with
+file count, not volume size, and both start empty), component default 2Gi for the two
+perplexica claims.
+
+## 5. Restore evidence
+
+**A restore was performed and verified, with zero writes to the cluster and zero writes to
+the backup repositories.**
+
+The new ReplicationSources ship through Git and cannot exist until Flux applies them, and
+three of the four source volumes are empty, so a restore of the *new* repos is not yet
+possible. What is provable now is the exact machinery the new sources reuse: `backup/`
+generates the same ReplicationSource/ReplicationDestination YAML with only `${APP}`
+differing, against the same S3 endpoints, secrets and restic repositories. So the restore
+was proved against the parent claims of two of the affected apps.
+
+Method: `kubectl port-forward` to the RGW Service (creates no Kubernetes objects) plus a
+local restic 0.18.0 using read-only subcommands with `--no-lock`, so not even a transient
+lock object was written to the repositories.
+
+### `selfhosted/paperless-ngx` (local Ceph repo)
+
+```
+$ restic snapshots --no-lock
+4eaaaf10  2026-08-22 00:01:38  volsync  /data  20.852 MiB
+30 snapshots
+
+$ restic restore latest --no-lock --target <scratch>
+restoring snapshot 4eaaaf10 of [/data] at 2026-08-22 00:01:38 by @volsync
+Summary: Restored 34 files/dirs (20.852 MiB) in 0:00
+```
+
+32 files across 3 directories restored. Checksummed against the live PVC:
+
+| File | Live sha256 | Restored | |
+|---|---|---|---|
+| `.index_version` | `2e6d31a5…` | `2e6d31a5…` | match |
+| `index/.index_settings.json` | `4a5cadf3…` | `4a5cadf3…` | match |
+| `index/.managed.json` | `0a4c0352…` | `0a4c0352…` | match |
+| `index/meta.json` | `6f9d51a0…` | `6f9d51a0…` | match |
+| `log/celery.log.20` | `6b5564e6…` | `6b5564e6…` | match |
+| `log/paperless.log` | `6f27ab11…` | `9d9209ee…` | **differs - as it should** |
+
+`paperless.log` is appended continuously, so a snapshot from five hours earlier must differ.
+It was checked the falsifiable way instead: the restored file is 448,294 bytes, the live file
+448,387. `sha256(head -c 448294 <live file>)` = `9d9209ee…` = the restored file's checksum
+exactly. The restored log is the live log as of the snapshot instant, byte for byte, and has
+only grown since. That one file differing is what shows the other five matches are real
+rather than trivially equal.
+
+### `selfhosted/syncthing` (local Ceph repo)
+
+```
+$ restic restore latest --no-lock --target <scratch>
+restoring snapshot b2a677df of [/data] at 2026-08-22 00:10:44 by @volsync
+Summary: Restored 14 files/dirs (2.870 MiB) in 0:00
+```
+
+12 files restored; `config.xml`, `cert.pem`, `key.pem` and `https-cert.pem` all
+byte-identical to the live PVC.
+
+### Repository integrity
+
+```
+$ restic check --no-lock          # paperless-ngx
+check snapshots, trees and blobs
+[0:00] 100.00%  30 / 30 snapshots
+no errors were found
+
+$ restic check --no-lock          # syncthing
+[0:00] 100.00%  30 / 30 snapshots
+no errors were found
+```
+
+### All three destinations confirmed live
+
+`paperless-ngx` reachable and decryptable on all three, latest snapshot on each:
+
+| Target | Snapshots | Latest | Raw repo size |
+|---|---|---|---|
+| Ceph | 30 | 2026-08-22 00:01 | (bucket total 53.9 GB) |
+| MinIO | 24 | 2026-08-21 18:31 | 5.472 MiB (13.93x compression) |
+| R2 | 43 | 2026-08-21 02:01 | 1.577 GiB |
+
+### Cleanup
+
+The scratch restore directories and the extracted credentials were deleted and the
+port-forward stopped. No Kubernetes object was created at any point: `kubectl get
+replicationdestination -A` and `kubectl get pvc -A` show no scratch resources, because none
+was ever created.
+
+### What is still unproven
+
+A restore of `syncthing-data`, `paperless-ngx-media`, `perplexica-dbstore` and
+`perplexica-uploads` from **their own** repositories. Those repositories do not exist until
+this change merges and Flux applies it, and three of the four volumes are empty so they will
+not produce a snapshot at all until real data lands. **After merge, `perplexica-dbstore` is
+the one to check first** - it has real content and should show a snapshot within four hours
+of its first `50 */4 * * *` window.
+
+## 6. Recommended follow-ups (not done here)
+
+1. Check NAS MinIO free space before syncthing is pointed at a large dataset (§4).
+2. Cover `database/surrealdb` - a live database with no backup at all (§2.2).
+3. Decide on `ai/perplexica`'s redundant source and unused PVC (§2.4).
+4. Reclaim ~22 GB of orphaned restic repositories (§2.5).
+5. Clean up the 2 orphaned `emqx-core-data-emqx-core-597bbb9c7c-*` PVCs (§2.2).

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -24,3 +24,5 @@ Start with the operator files, then the topic notes under `docs/`.
 | [`kubernetes/components/volsync/Readme.md`](../kubernetes/components/volsync/Readme.md) | Volsync schedules and restore |
 
 [`flux-migration-validation-report.md`](flux-migration-validation-report.md) is a historical snapshot from 2026-03-29. Do not treat its FAILs as open work.
+
+[`backups/volsync-coverage-2026-08-22.md`](backups/volsync-coverage-2026-08-22.md) is a historical snapshot of a full PVC-vs-VolSync coverage audit from 2026-08-22. Re-measure before trusting any figure in it.

--- a/kubernetes/apps/ai/perplexica/ks.yaml
+++ b/kubernetes/apps/ai/perplexica/ks.yaml
@@ -35,3 +35,81 @@ spec:
     namespace: flux-system
   targetNamespace: *namespace
   timeout: 5m
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+# Perplexica keeps nothing in the default ${APP} claim - the HelmRelease mounts
+# `perplexica-dbstore` (chat history / settings sqlite) and `perplexica-uploads`
+# instead. Both need their own Kustomization: Flux allows one postBuild.substitute
+# map per Kustomization, so one component instance can only cover one claim.
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app perplexica-dbstore
+  namespace: &namespace ai
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: perplexica
+  interval: 30m
+  timeout: 5m
+  path: "./kubernetes/components/volsync/backup"
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false
+  dependsOn:
+    - name: volsync
+      namespace: system
+    - name: perplexica
+      namespace: *namespace
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+    substitute:
+      APP: *app
+      VOLSYNC_CLAIM: *app
+      VOLSYNC_CAPACITY: 1Gi
+      VOLSYNC_SCHEDULE_CEPH: "50 */4 * * *"
+      VOLSYNC_SCHEDULE_MINIO: "50 */6 * * *"
+      VOLSYNC_SCHEDULE_R2: "50 2 * * *"
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app perplexica-uploads
+  namespace: &namespace ai
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: perplexica
+  interval: 30m
+  timeout: 5m
+  path: "./kubernetes/components/volsync/backup"
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false
+  dependsOn:
+    - name: volsync
+      namespace: system
+    - name: perplexica
+      namespace: *namespace
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+    substitute:
+      APP: *app
+      VOLSYNC_CLAIM: *app
+      VOLSYNC_CAPACITY: 5Gi
+      VOLSYNC_SCHEDULE_CEPH: "55 */4 * * *"
+      VOLSYNC_SCHEDULE_MINIO: "55 */6 * * *"
+      VOLSYNC_SCHEDULE_R2: "55 2 * * *"

--- a/kubernetes/apps/selfhosted/paperless-ngx/ks.yaml
+++ b/kubernetes/apps/selfhosted/paperless-ngx/ks.yaml
@@ -47,3 +47,46 @@ spec:
       VOLSYNC_CLAIM: paperless-ngx
       VOLSYNC_CAPACITY: 10Gi
       GATUS_GROUP: *namespace
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+# Second volume: the volsync component above only protects the single ${VOLSYNC_CLAIM}
+# (`paperless-ngx`, the data PVC). `paperless-ngx-media` is the scanned-document store -
+# the originals and their archived PDFs - and is not reconstructible from the database.
+# The `paperless-ngx-consume` inbox is deliberately NOT backed up: paperless deletes
+# files from it once they are ingested into media, so it only ever holds transient state.
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app paperless-ngx-media
+  namespace: &namespace selfhosted
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: paperless-ngx
+  interval: 30m
+  timeout: 5m
+  path: "./kubernetes/components/volsync/backup"
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false
+  dependsOn:
+    - name: volsync
+      namespace: system
+    - name: paperless-ngx
+      namespace: *namespace
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+    substitute:
+      APP: *app
+      VOLSYNC_CLAIM: *app
+      VOLSYNC_CAPACITY: 50Gi
+      VOLSYNC_CACHE_CAPACITY: 5Gi
+      VOLSYNC_SCHEDULE_CEPH: "50 */4 * * *"
+      VOLSYNC_SCHEDULE_MINIO: "25 */6 * * *"
+      VOLSYNC_SCHEDULE_R2: "50 4 * * *"

--- a/kubernetes/apps/selfhosted/syncthing/ks.yaml
+++ b/kubernetes/apps/selfhosted/syncthing/ks.yaml
@@ -37,3 +37,44 @@ spec:
       VOLSYNC_SCHEDULE_CEPH: "10 */4 * * *"
       VOLSYNC_SCHEDULE_MINIO: "45 */6 * * *"
       VOLSYNC_SCHEDULE_R2: "15 4 * * *"
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+# Second volume: the volsync component above only protects the single ${VOLSYNC_CLAIM}
+# (`syncthing`, the config PVC). `syncthing-data` holds the synced files and needs its
+# own Kustomization, because Flux allows exactly one postBuild.substitute map each.
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app syncthing-data
+  namespace: &namespace selfhosted
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: syncthing
+  interval: 30m
+  timeout: 5m
+  path: "./kubernetes/components/volsync/backup"
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false
+  dependsOn:
+    - name: volsync
+      namespace: system
+    - name: syncthing
+      namespace: *namespace
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+    substitute:
+      APP: *app
+      VOLSYNC_CLAIM: *app
+      VOLSYNC_CAPACITY: 100Gi
+      VOLSYNC_CACHE_CAPACITY: 5Gi
+      VOLSYNC_SCHEDULE_CEPH: "40 */4 * * *"
+      VOLSYNC_SCHEDULE_MINIO: "15 */6 * * *"
+      VOLSYNC_SCHEDULE_R2: "45 4 * * *"

--- a/kubernetes/components/volsync/Readme.md
+++ b/kubernetes/components/volsync/Readme.md
@@ -9,8 +9,77 @@ kubernetes/components/volsync/
 ├── ceph/                    # Local Ceph cluster backups (every 4 hours)
 ├── minio/                   # MinIO S3-compatible storage backups (every 6 hours)
 ├── r2/                      # Cloudflare R2 storage backups (daily)
-└── kustomization.yaml       # Combines all components
+├── backup/                  # The three destinations, without the PVC - for a claim that already exists
+├── pvc.yaml                 # Creates ${VOLSYNC_CLAIM} seeded from the ReplicationDestination
+└── kustomization.yaml       # Component: ./backup + ./pvc.yaml
 ```
+
+`backup/` is the single definition of "back this PVC up to all three destinations".
+The parent Component adds `pvc.yaml` on top of it; `backup/` on its own is also a
+valid Flux Kustomization `path`, which is what the multi-volume pattern below uses.
+
+## Apps with more than one volume
+
+Every resource in this component is named from `${APP}`, and Flux allows exactly **one**
+`postBuild.substitute` map per Kustomization. So one instance of the component can only
+ever protect one claim - `${VOLSYNC_CLAIM:-${APP}}`. An app with a second volume needs a
+second Flux Kustomization; there is no way to include the component twice in one.
+
+Add it to the app's existing `ks.yaml` as a second document. Point `path` at
+`./kubernetes/components/volsync/backup` (the backup-only bundle - the PVC already
+exists, so `pvc.yaml` must not be included), and set `APP` to the **claim name**:
+
+```yaml
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app myapp-media          # == the PVC name; drives every object name
+  namespace: &namespace mynamespace
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: myapp    # the parent app, so it groups with it
+  interval: 30m
+  timeout: 5m
+  path: "./kubernetes/components/volsync/backup"
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false
+  dependsOn:
+    - name: volsync
+      namespace: system
+    - name: myapp                 # so the PVC exists before the first snapshot
+      namespace: *namespace
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+    substitute:
+      APP: *app
+      VOLSYNC_CLAIM: *app
+      VOLSYNC_CAPACITY: 50Gi      # used by the ReplicationDestination on restore
+      VOLSYNC_CACHE_CAPACITY: 5Gi
+      VOLSYNC_SCHEDULE_CEPH: "50 */4 * * *"   # stagger against the app's own sources
+      VOLSYNC_SCHEDULE_MINIO: "25 */6 * * *"
+      VOLSYNC_SCHEDULE_R2: "50 4 * * *"
+```
+
+Because `APP` is the claim name, this gets its own restic repository
+(`s3://.../<claim>`), its own ExternalSecrets and its own `<claim>-dst`
+ReplicationDestination - nothing collides with the parent app's.
+
+Live examples: `kubernetes/apps/selfhosted/syncthing/ks.yaml` (`syncthing-data`),
+`kubernetes/apps/selfhosted/paperless-ngx/ks.yaml` (`paperless-ngx-media`) and
+`kubernetes/apps/ai/perplexica/ks.yaml` (`perplexica-dbstore`, `perplexica-uploads`).
+
+**Pick the schedule minutes so they do not collide** with the other ReplicationSources
+in the same namespace - three movers snapshotting the same Ceph pool at the same minute
+is the one avoidable way to make backups slow.
 
 ## Backup Schedules & Execution
 

--- a/kubernetes/components/volsync/backup/kustomization.yaml
+++ b/kubernetes/components/volsync/backup/kustomization.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# Backup-only bundle: the three ReplicationSources (+ the ceph ReplicationDestination)
+# for an EXISTING PVC named ${VOLSYNC_CLAIM:-${APP}}. It deliberately does NOT create
+# the PVC, so it can protect a claim that the app (or its Helm chart) already owns.
+#
+# Two ways to use it:
+#   1. via the ../ parent Component - the normal single-claim case, which also creates
+#      the PVC from ../pvc.yaml so a restore can seed it.
+#   2. as the `path` of a dedicated Flux Kustomization - the multi-claim case, where an
+#      app has more than one volume. Flux allows one postBuild.substitute map per
+#      Kustomization, so each extra claim needs its own Kustomization with its own
+#      APP/VOLSYNC_CLAIM pair. See ../Readme.md "Apps with more than one volume".
+resources:
+  - ../ceph
+  - ../minio
+  - ../r2

--- a/kubernetes/components/volsync/kustomization.yaml
+++ b/kubernetes/components/volsync/kustomization.yaml
@@ -3,7 +3,5 @@
 apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 resources:
-  - ./ceph
-  - ./minio
-  - ./r2
+  - ./backup
   - ./pvc.yaml


### PR DESCRIPTION
> ## Read this first - the premise changed
>
> **Both target volumes are empty.** Re-verifying live before acting showed
> `selfhosted/syncthing-data` holds **28 KiB** (a `lost+found` directory and nothing else)
> and `selfhosted/paperless-ngx-media` holds **32 KiB** (an empty `documents/` and a
> zero-byte `media.lock`); `select count(*) from documents_document` in the `paperless`
> database returns **0**.
>
> The "160 GiB unbacked" figure that motivated this work was **provisioned capacity, not
> stored data**. So this PR closes a **future** exposure, not a live one - and now is the
> cheapest possible moment to close it, because the first document scanned is protected
> from its first backup window onward instead of after the next audit.
>
> **Expect zero snapshots at first.** VolSync logs `== Directory is empty skipping backup ===`
> and creates no snapshot for an empty source, so three of the four new sources will
> legitimately produce nothing until real data arrives (`selfhosted/rsshub` and
> `rsshub-playwright` already sit in exactly that state today). Only `perplexica-dbstore`
> has content and will snapshot immediately - **it is the one to check after merge.**

### The three other things worth knowing before you read the diff

1. **The refactor is behaviour-preserving, and that is proven.** Splitting
   `kubernetes/components/volsync/` into a reusable `backup/` bundle plus `pvc.yaml`
   leaves `kustomize build` output for the **34 existing single-claim apps byte-identical
   to `HEAD`** - verified by diffing a build of the component before and after the change.
   Nothing already backed up changes behaviour.

2. **NAS MinIO free capacity could not be measured, and is reported as unmeasured rather
   than guessed.** `https://nas.sklab.dev:9000/minio/v2/metrics/cluster` returns HTTP 403
   and the VolSync credential is not a MinIO admin key. Ceph (3.6 TiB usable headroom vs a
   156 GiB worst case) and R2 (usage-billed) were measured. **No schedule or retention was
   tightened on the strength of an unmeasured number** - please check NAS free space
   manually before syncthing is pointed at a large dataset.

3. **Four things were found and deliberately left unfixed** - each is a separate decision
   that is not the implementer's to make, and each is written up in the report:
   - `database/surrealdb` is a live database with **no backup at all** (outside this defect class).
   - `ai/perplexica`'s **existing** coverage points at the wrong volume - it sets no
     `VOLSYNC_CLAIM`, so the component created and has been faithfully backing up a PVC
     named `perplexica` that the HelmRelease never mounts, while the real data sat
     unprotected. Left alone because removing it means pruning a live PVC.
   - **~22 GB (41%)** of the Ceph backup bucket is restic repositories for apps that no
     longer exist (`my-claw`, `openclaw`, `homeops-claw`, `qbittorrent`, `cross-seed`,
     `open-notebook`). Reclaiming it is a deletion.
   - Two orphaned `emqx-core-data-emqx-core-597bbb9c7c-*` PVCs from a dead ReplicaSet.

Full inventory (75 PVCs, 34 backed / 41 not, with a written verdict for every uncovered
volume), the capacity numbers, and the restore evidence are in
[`docs/backups/volsync-coverage-2026-08-22.md`](docs/backups/volsync-coverage-2026-08-22.md).

---

## Intent

GOAL: Two volumes holding real data were reported to have no backup at all (selfhosted/syncthing-data 100Gi and selfhosted/paperless-ngx-media 50Gi, scanned documents). Fix that, and prove a restore actually works. Cause: the volsync component only covers the single VOLSYNC_CLAIM per app, and these apps have more than one volume. Every StorageClass is reclaimPolicy: Delete, so a deleted PVC takes the data with it.

REQUIRED SCOPE, all three parts explicitly asked for:
1. Find EVERY unbacked volume, not just those two. Enumerate every PVC in the cluster against what VolSync actually backs up and report the full list; cover the others too or say explicitly why not. A fix that closes two known gaps and leaves three unknown ones is worse than it looks.
2. Extend coverage. Decide how to cover multiple claims per app - second component instance, parameterised list, or per-app ReplicationSources - and justify the choice. Prefer the shape the next app needing this can reuse without a new pattern. Match the backup target the existing coverage uses (ceph/minio/r2) unless there is a reason not to.
3. Size it honestly. Check the target's actual free capacity before committing to schedule and retention, and report the numbers. A backup config that silently fills its destination is worse than no backup because it also takes down the backups that were working.

VERIFICATION WAS THE POINT OF THE TASK: a ReplicationSource existing is not a backup. Prove a restore - confirm a snapshot completes with size and duration, restore and verify contents are real (file count, checksum of a sample, something falsifiable), and clean up afterwards. Cluster access was READ-ONLY for inspection; backup config ships through Git and Flux, not by hand. If a restore required a cluster write, the instruction was to stop and raise it rather than ship unverified backup config.

EXPLICITLY OUT OF SCOPE (do not flag as missing): the `selfhosted` namespace rename - the captain decided against it, partly because of this very gap; do not rename anything. The `monitoring` namespace - it has its own separate ~170 GiB backup gap and its own pending decision, deliberately untouched here.

DEFINITION OF DONE additions: the report must contain the complete unbacked-volume inventory, the target's free capacity against what is being added, and the restore evidence - or an explicit statement that the restore could not be tested and why.

WHAT I FOUND AND DECIDED (a reviewer reading only the diff would not know these):

PREMISE CORRECTION - deliberate, not an oversight. Re-verifying live showed BOTH target volumes are EMPTY: syncthing-data holds 28 KiB (a lost+found directory only), paperless-ngx-media holds 32 KiB (empty documents/ plus a zero-byte media.lock), and `select count(*) from documents_document` in the paperless database returns 0. The "160 GiB unbacked" figure in the originating scout report was PROVISIONED capacity, not stored data. So this change closes a FUTURE exposure, not a live one - and now is the cheapest moment to close it, because the first document scanned is then protected from its first backup window instead of after the next audit. A consequence the reviewer should expect: VolSync logs "== Directory is empty skipping backup ===" and creates NO snapshot for an empty source, so three of the four new sources will legitimately produce zero snapshots until real data arrives. selfhosted/rsshub and rsshub-playwright already sit in exactly that state today. Only perplexica-dbstore has content and will snapshot immediately. This is correct mover behaviour, not a defect in the new config.

DESIGN CHOICE, deliberately made among the three offered: a dedicated Flux Kustomization per extra volume. A second component instance in the same Kustomization is IMPOSSIBLE - Flux permits one postBuild.substitute map per Kustomization and every volsync object name derives from ${APP}. A parameterised claim list inside the component was rejected because Kustomize has no conditionals, so an unset second claim would emit a broken ReplicationSource for all 34 apps already using the component. So the component was split: new kubernetes/components/volsync/backup/ holds ceph+minio+r2 WITHOUT pvc.yaml (the PVC already exists and is owned by the app or its Helm chart), and is simultaneously a valid Flux Kustomization `path`. The parent Component now composes ./backup + ./pvc.yaml. VERIFIED: kustomize build output for the 34 existing apps is BYTE-IDENTICAL to HEAD (diffed a build of the component before and after) - this refactor is intentionally behaviour-preserving. Multi-document ks.yaml is already used by 14 apps in this repo, so no new convention is introduced. All three targets (ceph, minio, r2) are used, matching existing coverage as instructed.

COVERAGE DECIDED: 75 PVCs cluster-wide excluding VolSync's own cache/temp volumes; 34 backed, 41 not. Covered 4: selfhosted/syncthing-data, selfhosted/paperless-ngx-media, and - found by the required full sweep, same defect class - ai/perplexica-dbstore (chat-history sqlite) and ai/perplexica-uploads. Every one of the other 37 has a written verdict in docs/backups/volsync-coverage-2026-08-22.md. Deliberate non-coverage worth knowing: paperless-ngx-consume is a watched inbox that paperless DELETES from once ingested, so it only holds transient state; postgres-17-{1,5,6} are already protected by CloudNativePG barmanObjectStore (6 consecutive daily backups completed); sabnzbd-incomplete/shared-downloads/tdarr-temp are scratch; comfyui and vllm model stores are re-downloadable; jellyfin-metadata is a regenerable cache and is called out in the report as the one judgement call someone could reasonably disagree with.

CAPACITY, measured not assumed: local Ceph volsync bucket holds 53.9 GB across 11,092 objects with NO bucket quota, against 3.6 TiB MAX AVAIL on the RGW data pool (raw 17 TiB, 12 TiB free, 30.31% used). R2 is usage-billed with no fixed ceiling. What is actually added today is ~144 KiB because all four volumes are empty; worst case if all four fill to provisioned size is 156 GiB, about 4% of Ceph's usable headroom. NAS MinIO free capacity is DELIBERATELY REPORTED AS UNMEASURABLE rather than guessed: https://nas.sklab.dev:9000/minio/v2/metrics/cluster returns HTTP 403 and the VolSync credential is not a MinIO admin key. No schedule or retention was tightened on the strength of an unmeasured number; the report states the bound and recommends checking NAS free space manually before syncthing is pointed at a large dataset. Retention is left at component defaults. Schedule minutes were chosen to avoid collision with every existing ReplicationSource in the same namespace.

RESTORE PROVEN, and the read-only constraint was honoured - no needs-decision was required because no write was needed. kubectl port-forward creates no Kubernetes objects, and restic --no-lock avoids even a transient lock object in the repository, so the restore was done with ZERO cluster writes and ZERO repository writes. paperless-ngx repo: 30 snapshots, restored 34 files/dirs (20.852 MiB); 5 of 6 sampled files byte-identical to the live PVC. The 6th, log/paperless.log, differs BY DESIGN because it is appended continuously - checked the falsifiable way instead: restored file is 448,294 bytes, live is 448,387, and sha256(head -c 448294 <live>) equals the restored file's sha256 exactly, proving the restored log is the live log as of the snapshot instant. That one deliberate mismatch is what shows the other five matches are real rather than trivially equal. syncthing repo: restored 14 files/dirs (2.870 MiB), config.xml/cert.pem/key.pem/https-cert.pem all byte-identical. `restic check --no-lock` reports no errors across 30/30 snapshots on both repos. All three destinations confirmed live and decryptable for paperless-ngx (Ceph 30 snapshots, MinIO 24, R2 43). Scratch dirs and extracted credentials deleted, port-forward stopped, and confirmed no scratch PVC or ReplicationDestination was ever created. What remains unproven is stated explicitly in the report: a restore from the four NEW repositories, which cannot exist until this merges and Flux applies it.

FLAGGED BUT DELIBERATELY NOT FIXED - each is a separate decision that is not mine to make, and each is documented in the report; do NOT treat these as incomplete work: (1) database/surrealdb is a live database with no backup at all, outside this defect class; (2) ai/perplexica's EXISTING coverage points at the wrong volume - it sets no VOLSYNC_CLAIM so the component created and has been faithfully backing up a PVC named `perplexica` that the HelmRelease never mounts, while the real data sat unprotected; the redundant source and unused PVC are left alone because removing them means pruning a live PVC; (3) roughly 22 GB (41%) of the Ceph backup bucket belongs to restic repositories for apps that no longer exist (my-claw, openclaw, homeops-claw, qbittorrent, cross-seed, open-notebook) - reclaiming it is a deletion; (4) two orphaned emqx-core-data-emqx-core-597bbb9c7c-* PVCs from an old ReplicaSet with no pod.

DOCS: AGENTS.md and CLAUDE.md both described the component as if a single include protected an app; both were given a pointer to the new multi-volume pattern rather than restating it. fm-ensure-agents-md.sh refuses to run here because AGENTS.md and CLAUDE.md are both real divergent files - that divergence is a known pre-existing separate issue and was deliberately left alone, with both copies updated consistently instead.

VALIDATION ALREADY RUN LOCALLY: `task flux:test:all` passes 229/229. pre-commit passes on all changed files.

PR DESCRIPTION REQUIREMENT (explicitly requested): the PR description must lead with the premise correction at the TOP - both target volumes are empty, so this closes a future exposure rather than a live one - and must also include the byte-identical build proof for the 34 existing apps, the unmeasurable MinIO capacity, and the four items flagged but not fixed.

## What Changed

**Premise correction (found during verification, not assumed):** both originally-reported target volumes (`syncthing-data`, `paperless-ngx-media`) are currently empty (28 KiB lost+found and 32 KiB empty documents/ + zero-byte lock file respectively; `paperless` DB has 0 rows in `documents_document`). The provisioned-capacity figure that motivated this work was not stored data. This PR closes a future exposure - the moment real data lands, it's already backed up - not a live data-loss gap.

- Split `kubernetes/components/volsync` into a reusable `backup/` bundle (ceph+minio+r2 ReplicationSources, no `pvc.yaml`) composed by the parent `Component`, so a second (or further) volume on an app can be protected via a dedicated Flux Kustomization pointed at `components/volsync/backup` without creating a second PVC. Kustomize build output for all 34 existing single-claim apps is byte-identical to `HEAD`, confirming the refactor is behavior-preserving.
- Added a second `ks.yaml` document (multi-doc Kustomization, an existing pattern already used by 14 apps) wiring the new `backup` bundle to `selfhosted/syncthing` (`syncthing-data`), `selfhosted/paperless-ngx` (`paperless-ngx-media`), and `ai/perplexica` (`perplexica-dbstore` and `perplexica-uploads`), each with its own `VOLSYNC_CLAIM`/`APP` substitution and schedule offsets to avoid colliding with existing ReplicationSources in the same namespace.
- Updated `kubernetes/components/volsync/Readme.md`, `AGENTS.md`, `CLAUDE.md`, and `docs/reference.md` to point at the new multi-volume pattern instead of implying one component include covers an entire app; added `docs/backups/volsync-coverage-2026-08-22.md`, a full audit of all 75 cluster PVCs (34 backed / 41 not) with capacity numbers and restore verification evidence.

**Capacity (measured):** local Ceph volsync bucket is 53.9 GB / 11,092 objects with no bucket quota against 3.6 TiB MAX AVAIL (12 TiB free, 30.31% used) on the RGW data pool; worst case if all four new/affected volumes fill to provisioned size is ~156 GiB (~4% of usable headroom). NAS MinIO free capacity is reported as unmeasurable - `https://nas.sklab.dev:9000/minio/v2/metrics/cluster` returns HTTP 403 and the VolSync credential is not a MinIO admin key - so no schedule/retention was tightened against a guessed number; the report recommends a manual check before pointing syncthing at a large dataset. Retention left at component defaults.

**Restore verified (read-only, zero cluster/repo writes via `kubectl port-forward` + `restic --no-lock`):** paperless-ngx repo (30 snapshots) restored 34 files/dirs (20.852 MiB), 5/6 sampled files byte-identical to the live PVC, and the 6th (`paperless.log`, an actively-appended file) verified via `sha256(head -c <restored-size> <live>)` matching the restored file exactly. syncthing repo restored 14 files/dirs (2.870 MiB), all sampled config/cert files byte-identical. `restic check --no-lock` reports no errors on 30/30 snapshots in both repos; all three destinations confirmed reachable for paperless-ngx (Ceph 30, MinIO 24, R2 43 snapshots). Restores from the four newly-added repositories remain unproven since they don't exist until Flux applies this change.

**Flagged but deliberately not fixed in this PR (each a separate decision):** (1) `database/surrealdb` has no backup at all; (2) `ai/perplexica`'s pre-existing coverage backs up an unused PVC named `perplexica` (no `VOLSYNC_CLAIM` was ever set) while the real data sat unprotected - left alone rather than pruning a live PVC; (3) ~22 GB (41%) of the Ceph backup bucket belongs to restic repos for apps that no longer exist; (4) two orphaned `emqx-core-data-emqx-core-597bbb9c7c-*` PVCs from a dead ReplicaSet.

## Risk Assessment

✅ Low: The change is a well-scoped, behavior-preserving refactor (verified byte-identical kustomize output for 34 existing apps) plus additive multi-document Kustomizations that follow an established repo pattern (14 prior examples); every claim in the intent (PVC names/sizes, schedule non-collision, retention defaults, dependsOn wiring, capacity math) checks out against the actual source files.

## Testing

Used the project's own documented toolchain (flux-local matched to this repo's pinned kustomize/helm versions, set up in an isolated /tmp venv since no tools were preinstalled) to build and Helm-inflate exactly the changed Flux Kustomizations, and independently diffed the component refactor's kustomize output across all 38 pre-existing consumers between base and target commits - all byte-identical, and all new/changed nodes built cleanly. A parallel manual check of postBuild.substitute values and cross-namespace cron schedules found the four new backup sources use correct PVC names/capacities and don't collide with any existing ReplicationSource, matching the PR's own claims. One early flux-local run appeared to show cross-app schedule collisions (paperless-ngx vs paperless-ngx-media on all three targets) but that was a parsing error on my part - paperless-ngx actually relies on component defaults rather than an explicit override, and a corrected YAML-aware pass confirmed no collision; no defect found. Live restore verification for the four new repositories was not attempted and could not be: those restic repositories don't exist until this merges and Flux reconciles it, exactly as the PR's own report states as a known, deliberate limitation - not a gap introduced by my testing. Cluster access was not available or attempted, consistent with the read-only constraint the PR itself operated under.

<details>
<summary>Evidence: flux-local test results for the four new backup Kustomizations and their parent apps (all PASSED)</summary>

```text
kubernetes/flux/cluster::syncthing-data::kustomization PASSED
kubernetes/flux/cluster::paperless-ngx-media::kustomization PASSED
kubernetes/flux/cluster::perplexica-dbstore::kustomization PASSED
kubernetes/flux/cluster::perplexica-uploads::kustomization PASSED
kubernetes/flux/cluster::syncthing::kustomization PASSED
kubernetes/flux/cluster::syncthing::selfhosted/syncthing PASSED
kubernetes/flux/cluster::syncthing-data::kustomization PASSED
kubernetes/flux/cluster::paperless-ngx::kustomization PASSED
kubernetes/flux/cluster::paperless-ngx::selfhosted/paperless-ngx PASSED
kubernetes/flux/cluster::paperless-ngx-media::kustomization PASSED
kubernetes/flux/cluster::perplexica::kustomization PASSED
kubernetes/flux/cluster::perplexica::ai/perplexica PASSED
kubernetes/flux/cluster::perplexica-dbstore::kustomization PASSED
kubernetes/flux/cluster::perplexica-uploads::kustomization PASSED
```
</details>
<details>
<summary>Evidence: kustomize build diff of the volsync component&#39;s 38 existing consumers, base vs target - empty (byte-identical)</summary>

```text
$ diff base-build.yaml target-build.yaml && echo IDENTICAL
IDENTICAL - byte-for-byte match confirmed (repeated per-app for all 38 pre-existing volsync consumers via kustomize build)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"f78a82d22c3b1e0d6cee41932e7be8179432dc50","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>kubectl kustomize diff of `kubernetes/components/volsync` build output between base (d4399e37) and target (49aaafbf) for all 38 pre-existing Kustomizations that reference the component - byte-identical, confirming the ceph/minio/r2+pvc.yaml -&gt; backup/{ceph,minio,r2}+pvc.yaml refactor is behavior-preserving</code>
- <code>kubectl kustomize build of `kubernetes/components/volsync/backup` standalone - confirms it emits 3 ExternalSecrets, 1 ReplicationDestination and 3 ReplicationSources, and deliberately no PersistentVolumeClaim</code>
- <code>flux-local test (v7.11.0, with the repo&#39;s pinned kustomize v5.8.1 and helm v4.2.4 from .mise.toml, --enable-helm, node-filtered) against `kubernetes/flux/cluster::syncthing-data`, `::paperless-ngx-media`, `::perplexica-dbstore`, `::perplexica-uploads`, and their parent apps `::syncthing`, `::paperless-ngx`, `::perplexica` - all Kustomization builds and HelmRelease inflations PASSED</code>
- `manual postBuild.substitute simulation for all four new Kustomizations - confirmed correct sourcePVC name, capacity (100Gi/50Gi/1Gi/5Gi), and cron schedules per app`
- <code>cross-namespace VOLSYNC_SCHEDULE_{CEPH,MINIO,R2} collision check (YAML-parsed across every volsync-backed Kustomization in `selfhosted` and `ai`, respecting component defaults for apps that don&#39;t override) - none of the four new sources collide with any pre-existing ReplicationSource; the namespaces do have several pre-existing collisions among older apps, unrelated to and unchanged by this PR</code>
- `arithmetic check of the 156Gi worst-case capacity figure (100+50+1+5Gi) claimed in docs/backups/volsync-coverage-2026-08-22.md against the actual VOLSYNC_CAPACITY values in the four new ks.yaml documents - matches`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>

