### PR TITLE
fix(deps): hold container/helm minor auto-merges for 3 days

### DIFF
--- a/.renovate/autoMerge.json5
+++ b/.renovate/autoMerge.json5
@@ -22,6 +22,7 @@
       matchDatasources: ["docker", "helm", "github-releases", "github-tags"],
       automerge: true,
       matchUpdateTypes: ["minor"],
+      minimumReleaseAge: "3 days",
       ignoreTests: false,
     },
   ],


### PR DESCRIPTION
## Intent

Hold container and helm minor updates for 3 days before Renovate auto-merges them. Add minimumReleaseAge: "3 days" to the container and helm minor automerge rule in .renovate/autoMerge.json5 (the packageRules entry matching matchUpdateTypes: ["minor"]). Leave patch and digest automerge rules untouched. Do not touch overrides.json5's existing pins, and do not touch anything under kubernetes/. Rationale: six post-incident pins in overrides.json5 all trace to auto-merged minor bumps that passed every check and broke something anyway (measured on PR #1137: 12/12 green, merged by bot, app broken); flux-local/manifest linting cannot catch runtime regressions. minimumReleaseAge is already applied to GitHub Actions and mise in the shared mortyops config, so this follows an existing house convention. Verified with npx renovate-config-validator (passed) and pre-commit (passed); no local --platform=local dry-run tooling is available in this repo (no docker, no renovate task). Confirmed the edited rule's matchUpdateTypes (minor) and matchDatasources (docker, helm, github-releases, github-tags) are unchanged from before the edit.

## What Changed

- Added `minimumReleaseAge: "3 days"` to the `packageRules` entry in `.renovate/autoMerge.json5` that governs minor auto-merges for `docker`, `helm`, `github-releases`, and `github-tags` datasources.
- Patch and digest automerge rules, and all other fields on the minor rule (`matchUpdateTypes`, `matchDatasources`, `automerge`, `ignoreTests`), are unchanged.

## Risk Assessment

✅ Low: Single-line, well-scoped addition of minimumReleaseAge to one existing packageRules entry; all other rules, overrides.json5, and kubernetes/ are untouched, matching the stated intent exactly.

## Testing

The diff is exactly the intended single-line addition on the minor automerge rule, with patch/digest rules, overrides.json5, and kubernetes/ all confirmed untouched; renovate-config-validator passes on the target commit with only pre-existing, unrelated errors also present on the base commit; a negative-control (typo'd key) proves the validator genuinely recognizes minimumReleaseAge as a real, scoped config field rather than silently ignoring it; and a live Renovate CLI dry-run against an isolated scratch repo confirmed the engine loads the exact rule and correctly evaluates it against a real container image update. Full branch-level automerge-hold behavior (an actual 3-day suppression on a freshly-released version) could not be demonstrated locally since this Renovate version's platform=local mode stops after the extract/lookup phase before branch decisioning, consistent with the author's own note that no local dry-run tooling with full branch processing is available in this environment; this is a config-schema-level verification limitation, not a defect in the change.

<details>
<summary>Evidence: Renovate config validation and dry-run evidence log</summary>

```text
Change under test: .renovate/autoMerge.json5 (base d4399e37 -> target 02f222b1)
Only file changed (git diff --stat): .renovate/autoMerge.json5 | 1 +

git diff d4399e37..02f222b1 -- .renovate/:
--------------------------------------------------------------------------------
diff --git a/.renovate/autoMerge.json5 b/.renovate/autoMerge.json5
index a73dbae3..70a00997 100644
--- a/.renovate/autoMerge.json5
+++ b/.renovate/autoMerge.json5
@@ -22,6 +22,7 @@
       matchDatasources: ["docker", "helm", "github-releases", "github-tags"],
       automerge: true,
       matchUpdateTypes: ["minor"],
+      minimumReleaseAge: "3 days",
       ignoreTests: false,
     },
   ],
--------------------------------------------------------------------------------

Confirmed via `git diff --name-only d4399e37..02f222b1 | grep -E 'overrides.json5|^kubernetes/'`
-> no matches. overrides.json5 and kubernetes/ are untouched.

1) npx-based renovate-config-validator run against the real repo config, on the
   target commit (02f222b1), inside a scratch copy (git archive) at the same
   commit for isolation. Result: PASSED for the edited rule; the only reported
   errors are pre-existing and unrelated (flux/helm-values/helmfile/kubernetes
   managerFilePatterns options), and are reproduced identically when the same
   validator is run against the base commit (d4399e37), proving this change
   introduces zero new validation errors.

2) Negative-control test (proves the validator actually inspects this field,
   rather than silently ignoring unknown keys): built an isolated scratch repo
   containing byte-identical packageRules content from .renovate/autoMerge.json5.
   Renamed the new key to a typo, `minimumReleaseAgeTYPO`, and ran
   `renovate-config-validator`:

     ERROR: Found errors in configuration
            "message": "Invalid configuration option: packageRules[2].minimumReleaseAgeTYPO"

   Restored the real key name (`minimumReleaseAge: "3 days"`) and re-ran:

     INFO: Config validated successfully

   This confirms `minimumReleaseAge` is recognized by Renovate's real config
   schema (not just JSON5-syntax-valid) and is correctly attached to
   packageRules[2], the minor auto-merge rule (index 2 = third rule: digest=0,
   patch=1, minor=2).

3) Live engine smoke test: ran the actual Renovate CLI (not just the validator)
   with RENOVATE_PLATFORM=local RENOVATE_DRY_RUN=full against a scratch repo
   containing the exact packageRules array plus `FROM nginx:1.24.0`. Renovate
   loaded the config with no validation error, resolved packageRules[2]
   (matchDatasources: docker/helm/github-releases/github-tags,
   matchUpdateTypes: minor, minimumReleaseAge: "3 days") verbatim in its
   resolved config dump, and correctly extracted+looked up a real minor update
   candidate for the nginx image (1.24.0 -> 1.31.4, updateType: minor),
   confirming the rule's matcher scope (datasources/updateTypes) is intact and
   unchanged apart from the added field.

Note: platform=local in this Renovate version stops after the extract/lookup
phase and does not proceed to per-branch automerge decisioning, so it could not
directly demonstrate a *live* 3-day hold on a real, freshly-released package
version (this matches the PR author's own note that no local --platform=local
dry-run tooling with full branch processing, e.g. docker-based github-action,
is available in this repo/environment). Steps (1) and (2) above are the
strongest available local proof that the new field is syntactically and
semantically valid to Renovate's own config schema, scoped to exactly the
intended rule, with no changes to patch/digest rules, overrides.json5, or
kubernetes/.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"02f222b1bc822af8818251c422a032ce9ba55761","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `git diff d4399e37..02f222b1 (confirms only .renovate/autoMerge.json5 changed, +1 line, adding minimumReleaseAge: "3 days" solely to the matchUpdateTypes:["minor"] rule; digest/patch rules, overrides.json5, and kubernetes/ untouched)`
- `npx -p renovate -- renovate-config-validator against target commit (02f222b1) via isolated git-archive copy: passed for the edited rule; only pre-existing unrelated errors (flux/helm-values/helmfile/kubernetes managerFilePatterns) reproduced identically against base commit (d4399e37), proving zero new validation errors`
- <code>Negative-control test in an isolated scratch repo: typo&#39;d key `minimumReleaseAgeTYPO` on an identical copy of packageRules is rejected by renovate-config-validator (&#34;Invalid configuration option: packageRules[2].minimumReleaseAgeTYPO&#34;); restoring the real key name validates successfully, confirming the validator genuinely inspects this field</code>
- `Live Renovate CLI dry-run (RENOVATE_PLATFORM=local RENOVATE_DRY_RUN=full) against a scratch repo with the exact packageRules array plus a real Dockerfile (nginx:1.24.0): config loaded with no validation error, resolved packageRules[2] retained minimumReleaseAge: "3 days" verbatim, and a real minor update candidate (nginx 1.24.0 -> 1.31.4) was correctly extracted and matched against the minor-update rule scope`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
