### PR TITLE
fix(rook-ceph): disable rook mgr module to stop crash storm

### DIFF
--- a/docs/ceph-cluster-changelog.md
+++ b/docs/ceph-cluster-changelog.md
@@ -83,6 +83,18 @@ Notes / evidence / sources.
 
 ## Change log
 
+### [2026-08-22] Disable rook mgr module - stop crash storm blocking node upgrades  (commit `2014395e`)
+
+| Field | Value |
+|-------|-------|
+| **Change** | `mgr.modules` in `cluster/helmrelease.yaml`: `rook` entry `enabled: true` → `enabled: false` |
+| **Why** | Root-caused the 2026-08-21 `HEALTH_ERR Module 'crash' has failed` entry below: prometheus mgr module calls `node_proxy_fullreport()` on every scrape (15s), unimplemented by the rook orchestrator backend → `NotImplementedError` → crash record for module `rook`. Crash module's `do_post()` mutates `self.crashes` without `crashes_lock` (the only mutator missing it), racing the `serve()` thread's locked iteration → `RuntimeError` → `MGR_MODULE_ERROR` → `HEALTH_ERR` every ~15s, pinning cluster health and blocking every future Talos/Kubernetes node upgrade. Confirmed against the live mgr pod and upstream trackers: rook/rook#18124, ceph/ceph#71041, ceph/ceph#71180 - all open, no released fix as of Ceph Tentacle. |
+| **Risk** | None found: nothing in this repo uses `ceph orch` (only `docs/ceph/toolbox.md` documents it as the wrong control plane here). Dashboard and every other mgr module stay functional. The Rook operator reconciles from its own CRDs, not through this mgr module. |
+| **Rollback** | Set the `rook` entry in `mgr.modules` back to `enabled: true`. Revert once a Tentacle point release ships both upstream fixes. |
+| **Verify** | `ceph mgr module ls` no longer dispatches to `rook` for orchestrator calls; `ceph crash ls-new` count/timestamps flat (was climbing ~4/min); `ceph -s` returns to `HEALTH_OK` within the 2h self-heal window (`mgr/crash/warn_recent_interval=7200s`, already set - no manual `ceph crash archive-all` needed). |
+
+Applied via GitOps only (Flux reconciles the HelmRelease); no direct live-cluster mutation was made.
+
 ### [2026-08-21] Default `csi` subvolumegroup still broken on Ceph v20.2.3  (docs; no GitOps / PVC change)
 
 | Field | Value |

--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -130,8 +130,14 @@ spec:
             enabled: true
           - name: pg_autoscaler
             enabled: true
+          # Disabled: on Ceph Tentacle, the rook orchestrator backend triggers a
+          # crash storm via prometheus mgr module's node_proxy_fullreport() calls
+          # (NotImplementedError, unimplemented outside cephadm), which in turn
+          # races the crash module's unlocked do_post() into HEALTH_ERR.
+          # Upstream: rook/rook#18124, ceph/ceph#71041, ceph/ceph#71180 (all open).
+          # Revert once a tentacle point release ships both fixes.
           - name: rook
-            enabled: true
+            enabled: false
           - name: nfs
             enabled: true
           - name: rgw


### PR DESCRIPTION
## Intent

Disable the rook mgr module to stop a Ceph crash storm that is currently pinning cluster health at HEALTH_ERR/HEALTH_WARN and blocks every future Talos and Kubernetes node upgrade.

Root cause (from completed investigation, primary-source verified against the running mgr pod and upstream Ceph/Rook trackers): the prometheus mgr module unconditionally calls node_proxy_fullreport() on every scrape (15s), which the rook orchestrator backend does not implement, raising NotImplementedError. The mgr's C++ dispatch layer records a crash report for module 'rook' before the exception reaches prometheus's own try/except. This produces a crash every 15s. The crash module's do_post() mutates self.crashes without taking crashes_lock (the only mutator missing this), and the serve() thread iterating that same dict under the lock eventually collides with it, raising RuntimeError -> MGR_MODULE_ERROR -> HEALTH_ERR. Both are confirmed, open, unfixed upstream bugs (rook/rook#18124, ceph/ceph#71041, ceph/ceph#71180) with no released fix, including on ceph main.

Change: in kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml, set the mgr.modules 'rook' entry from enabled: true to enabled: false, with a comment linking rook/rook#18124, ceph/ceph#71041, ceph/ceph#71180, noting this should be reverted once a tentacle point release ships containing both fixes.

Why safe: nothing in this repo uses ceph orch (grepped; only docs/ceph/toolbox.md documents it as the wrong control plane for this Rook-based cluster). The Ceph dashboard stays functional for everything else. The Rook operator reconciles from its own CRDs, not through this mgr module. This repo already sets mgr/crash/warn_recent_interval to 7200s (2h), so once the crash generator stops, RECENT_MGR_MODULE_CRASH self-clears within 2 hours with no manual archive-all/cleanup needed.

Cluster access is read-only for inspection/verification only; nothing was applied, patched, deleted, scaled, or annotated directly on the live cluster - this ships through Git and Flux only. No attempt was made to speed up the self-heal window via ceph crash archive-all or a manual mgr restart.

This is a live cluster mutation once merged: it only takes effect when Flux reconciles the HelmRelease change. Post-merge 'fixed' means: ceph mgr module ls no longer dispatches to rook for orchestrator calls; no new crash records accumulate over a several-minute window (ceph crash ls-new count/timestamps flat, not climbing at the ~4/minute rate previously measured); ceph -s returns to HEALTH_OK within the 2-hour self-heal window with no manual intervention.

Out of scope: do not touch kubernetes/apps/system-upgrade/tuppr/upgrades/kubernetesupgrade.yaml or talosupgrade.yaml. Do not attempt to fix the separately-flagged, lower-priority CephCrashesDetected alert's wrong health-check name in prometheusrules.yaml (RECENT_CRASH vs RECENT_MGR_MODULE_CRASH) - note only as a candidate follow-up, not part of this change.

## What Changed

- Set the `rook` entry under `mgr.modules` in `kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml` from `enabled: true` to `enabled: false`, with an inline comment explaining the crash storm root cause and linking rook/rook#18124, ceph/ceph#71041, ceph/ceph#71180, noting it should be reverted once a Tentacle point release ships both fixes.
- Added a `[2026-08-22]` entry to `docs/ceph-cluster-changelog.md` documenting the change, why, risk assessment, rollback steps, and verification criteria.

## Risk Assessment

✅ Low: Single-line config flip (mgr module enabled: true -> false) with a well-documented rationale and upstream tracker links; scoped exactly to the stated intent, touches no other files, and is a reversible GitOps change that Flux applies declaratively.

## Testing

All verification was static/manifest-level since this is a GitOps repo with no live cluster access in the test environment and the fix only takes effect on post-merge Flux reconciliation; I confirmed the diff is exactly the single intended file/field change with the required comment and no out-of-scope edits, that it survives the repo's actual Kustomize build path cleanly, and by pulling the real pinned upstream Rook Helm chart and templating it with the actual HelmRelease values at both commits, that the only difference in the entire rendered CephCluster custom resource (1849 lines) is `spec.mgr.modules[].enabled` for the `rook` module flipping true→false - i.e. exactly the change the Rook operator will apply to the live cluster once Flux reconciles. Live-cluster evidence (ceph -s HEALTH_OK, crash rate flattening) is inherently unavailable pre-merge and is called out in the intent itself as a post-merge observation.

<details>
<summary>Evidence: Base-vs-target rendered CephCluster CR diff (real upstream chart, real HelmRelease values)</summary>

```text
# Rook mgr module chart-render evidence

Base commit:   a161d503fd14623b8b5540ebbc95141ffdcc2ace
Target commit: 2014395eff80de22cdc65077fd63a3015f68df48
Chart: oci://ghcr.io/rook/rook-ceph-cluster:v1.20.4 (real upstream chart pulled from ghcr.io,
       the exact version pinned in kubernetes/apps/rook-ceph/rook-ceph/cluster/ocirepository.yaml)

Method: 'helm template' the real chart with the values.spec.values block extracted (via yq)
from the HelmRelease at each commit. This is the same rendering step Flux's helm-controller
performs before applying the CephCluster CR, so this shows what actually reaches the Rook operator.

## spec.mgr.modules in the rendered CephCluster CR, base commit
- enabled: true
  name: diskprediction_local
- enabled: true
  name: insights
- enabled: true
  name: pg_autoscaler
- enabled: true
  name: rook
- enabled: true
  name: nfs
- enabled: true
  name: rgw

## spec.mgr.modules in the rendered CephCluster CR, target commit
- enabled: true
  name: diskprediction_local
- enabled: true
  name: insights
- enabled: true
  name: pg_autoscaler
- enabled: false
  name: rook
- enabled: true
  name: nfs
- enabled: true
  name: rgw

## Full diff of the entire rendered manifest set (1849 lines), base vs target
`` `diff
341c341
<     - enabled: true
---
>     - enabled: false
`` `

Only the 'rook' module's enabled flag changed anywhere in the rendered output -
confirms the value change flows correctly into the CR Rook consumes, with no side effects.
```
</details>
<details>
<summary>Evidence: Full rendered manifest set at target commit (helm template output, 1849 lines, from the real oci://ghcr.io/rook/rook-ceph-cluster:v1.20.4 chart)</summary>

```text
---
# Source: rook-ceph-cluster/templates/cephblockpool.yaml
kind: StorageClass
apiVersion: storage.k8s.io/v1
metadata:
  name: "ceph-block"
  annotations:
    storageclass.kubernetes.io/is-default-class: "true"
provisioner: rook-ceph.rbd.csi.ceph.com
parameters:
  pool: "ceph-blockpool"
  clusterID: "rook-ceph"
  compression_algorithm: zstd
  compression_mode: aggressive
  csi.storage.k8s.io/controller-expand-secret-name: rook-csi-rbd-provisioner
  csi.storage.k8s.io/controller-expand-secret-namespace: 'rook-ceph'
  csi.storage.k8s.io/fstype: ext4
  csi.storage.k8s.io/node-stage-secret-name: rook-csi-rbd-node
  csi.storage.k8s.io/node-stage-secret-namespace: 'rook-ceph'
  csi.storage.k8s.io/provisioner-secret-name: rook-csi-rbd-provisioner
  csi.storage.k8s.io/provisioner-secret-namespace: 'rook-ceph'
  imageFeatures: layering,fast-diff,object-map,deep-flatten,exclusive-lock
  imageFormat: "2"
reclaimPolicy: Delete
allowVolumeExpansion: true
volumeBindingMode: Immediate

---
# Source: rook-ceph-cluster/templates/cephfilesystem.yaml
kind: StorageClass
apiVersion: storage.k8s.io/v1
metadata:
  name: ceph-filesystem
  annotations:
    storageclass.kubernetes.io/is-default-class: "false"
provisioner: rook-ceph.cephfs.csi.ceph.com
parameters:
  fsName: ceph-filesystem
  pool: ceph-filesystem-data0
  clusterID: rook-ceph
  csi.storage.k8s.io/controller-expand-secret-name: rook-csi-cephfs-provisioner
  csi.storage.k8s.io/controller-expand-secret-namespace: 'rook-ceph'
  csi.storage.k8s.io/fstype: ext4
  csi.storage.k8s.io/node-stage-secret-name: rook-csi-cephfs-node
  csi.storage.k8s.io/node-stage-secret-namespace: 'rook-ceph'
  csi.storage.k8s.io/provisioner-secret-name: rook-csi-cephfs-provisioner
  csi.storage.k8s.io/provisioner-secret-namespace: 'rook-ceph'
reclaimPolicy: Delete
allowVolumeExpansion: true
volumeBindingMode: Immediate

---
# Source: rook-ceph-cluster/templates/cephobjectstore.yaml
kind: StorageClass
apiVersion: storage.k8s.io/v1
metadata:
  name: ceph-bucket
provisioner: rook-ceph.ceph.rook.io/bucket
reclaimPolicy: Delete
volumeBindingMode: Immediate
parameters:
  objectStoreName: ceph-objectstore
  objectStoreNamespace: rook-ceph
  region: us-east-1

---
# Source: rook-ceph-cluster/templates/deployment.yaml
kind: Deployment
apiVersion: apps/v1
metadata:
  name: rook-ceph-tools
  namespace: rook-ceph # namespace:cluster
  labels:
    app: rook-ceph-tools
spec:
  replicas: 1
  selector:
    matchLabels:
      app: rook-ceph-tools
  template:
    metadata:
      labels:
        app: rook-ceph-tools
    spec:
      dnsPolicy: ClusterFirstWithHostNet
      hostNetwork: true
      containers:
        - name: rook-ceph-tools
          image: "quay.io/ceph/ceph:v20.2.3"
          command:
            - /bin/bash
            - -c
            - |
              # Replicate the script from toolbox.sh inline so the ceph image
              # can be run directly, instead of requiring the rook toolbox
              CEPH_CONFIG="/etc/ceph/ceph.conf"
              MON_CONFIG="/etc/rook/mon-endpoints"
              KEYRING_FILE="/etc/ceph/keyring"
              CONFIG_OVERRIDE="/etc/rook-config-override/config"

              # create a ceph config file in its default location so ceph/rados tools can be used
              # without specifying any arguments
              write_endpoints() {
                endpoints=$(cat ${MON_CONFIG})

                # filter out the mon names
                # external cluster can have numbers or hyphens in mon names, handling them in regex
                # shellcheck disable=SC2001
                mon_endpoints=$(echo "${endpoints}"| sed 's/[a-z0-9_-]\+=//g')

                DATE=$(date)
                echo "$DATE writing mon endpoints to ${CEPH_CONFIG}: ${endpoints}"
                  cat <<EOF > ${CEPH_CONFIG}
              [global]
              mon_host = ${mon_endpoints}

              [client.admin]
              keyring = ${KEYRING_FILE}
              EOF

                # Merge the config override if it exists and is not empty
                if [ -f "${CONFIG_OVERRIDE}" ] && [ -s "${CONFIG_OVERRIDE}" ]; then
                  echo "$DATE merging config override from ${CONFIG_OVERRIDE}"
                  echo "" >> ${CEPH_CONFIG}
                  cat ${CONFIG_OVERRIDE} >> ${CEPH_CONFIG}
                fi
              }

              # watch the endpoints config file and update if the mon endpoints ever change
              watch_endpoints() {
                # get the timestamp for the target of the soft link
                real_path=$(realpath ${MON_CONFIG})
                initial_time=$(stat -c %Z "${real_path}")
                while true; do
                  real_path=$(realpath ${MON_CONFIG})
                  latest_time=$(stat -c %Z "${real_path}")

                  if [[ "${latest_time}" != "${initial_time}" ]]; then
                    write_endpoints
                    initial_time=${latest_time}
                  fi

                  sleep 10
                done
              }

              # read the secret from an env var (for backward compatibility), or from the secret file
              ceph_secret=${ROOK_CEPH_SECRET}
              if [[ "$ceph_secret" == "" ]]; then
                ceph_secret=$(cat /var/lib/rook-ceph-mon/secret.keyring)
              fi

              # create the keyring file
              cat <<EOF > ${KEYRING_FILE}
              [${ROOK_CEPH_USERNAME}]
              key = ${ceph_secret}
              EOF

              # write the initial config file
              write_endpoints

              # continuously update the mon endpoints if they fail over
              watch_endpoints
          imagePullPolicy: IfNotPresent
          tty: true
          securityContext:
            capabilities:
              drop:
              - ALL
            runAsGroup: 2016
            runAsNonRoot: true
            runAsUser: 2016
          env:
            - name: ROOK_CEPH_USERNAME
              valueFrom:
                secretKeyRef:
                  name: rook-ceph-mon
                  key: ceph-username
          resources:
            limits:
              memory: 1Gi
            requests:
              cpu: 100m
              memory: 128Mi
          volumeMounts:
            - mountPath: /etc/ceph
              name: ceph-config
            - name: mon-endpoint-volume
              mountPath: /etc/rook
            - name: ceph-admin-secret
              mountPath: /var/lib/rook-ceph-mon
            - name: rook-config-override
              mountPath: /etc/rook-config-override
              readOnly: true
      serviceAccountName: rook-ceph-default
      volumes:
        - name: ceph-admin-secret
          secret:
            secretName: rook-ceph-mon
            optional: false
            items:
              - key: ceph-secret
                path: secret.keyring
        - name: mon-endpoint-volume
          configMap:
            name: rook-ceph-mon-endpoints
            items:
              - key: data
                path: mon-endpoints
        - name: rook-config-override
          configMap:
            name: rook-config-override
            optional: true
        - name: ceph-config
          emptyDir: {}
      tolerations:
        - key: "node.kubernetes.io/unreachable"
          operator: "Exists"
          effect: "NoExecute"
          tolerationSeconds: 5

---
# Source: rook-ceph-cluster/templates/cephblockpool.yaml
kind: CephBlockPool
apiVersion: ceph.rook.io/v1
metadata:
  name: ceph-blockpool
  namespace: rook-ceph # namespace:cluster
spec:
  compressionMode: none
  failureDomain: host
  parameters:
    bulk: "true"
    compression_mode: none
  replicated:
    size: 3

---
# Source: rook-ceph-cluster/templates/cephcluster.yaml
apiVersion: ceph.rook.io/v1
kind: CephCluster
metadata:
  name: "rook-ceph"
  namespace: "rook-ceph" # namespace:cluster
spec:
  monitoring:
    enabled: true
  cephVersion:
    image: "quay.io/ceph/ceph:v20.2.3"
    allowUnsupported: false
  cephConfig:
    client.rgw:
      rgw_realm: ceph-objectstore
    global:
      auth_client_required: cephx
      auth_cluster_required: cephx
      auth_service_requi

... [65085 bytes truncated] ...

:.*)?"))
            >= 128.00
          for: 1m
          labels:
            severity: warning
            type: ceph_default
        - alert: NVMeoFTooManyNamespaces
          annotations:
            description: 'NVMeoF gateway {{ $labels.gateway_host }} has reached or exceeded
              the supported maximum of 4096 namespaces. Current count: {{ $value }}.'
            summary: The number of namespaces defined to the NVMeoF gateway reached or exceeded
              supported values on cluster {{ $labels.cluster }}
          expr: sum by(gateway_host, cluster) (label_replace(ceph_nvmeof_subsystem_namespace_count,"gateway_host","$1","instance","(.*?)(?::.*)?"))
            >= 4096.00
          for: 1m
          labels:
            severity: warning
            type: ceph_default
        - alert: NVMeoFVersionMismatch
          annotations:
            description: This may indicate an issue with deployment. Check cephadm logs
            summary: Too many different NVMe-oF gateway releases active on cluster {{ $labels.cluster
              }}
          expr: count(count(ceph_nvmeof_gateway_info) by (cluster, version)) by (cluster)
            > 1
          for: 1h
          labels:
            severity: warning
            type: ceph_default
        - alert: NVMeoFHighClientCount
          annotations:
            description: The supported limit for clients connecting to a subsystem is 128
            summary: The number of clients connected to {{ $labels.nqn }} is too high on cluster
              {{ $labels.cluster }}
          expr: ceph_nvmeof_subsystem_host_count > 128.00
          for: 1m
          labels:
            severity: warning
            type: ceph_default
        - alert: NVMeoFMissingListener
          annotations:
            description: For every subsystem, each gateway should have a listener to balance
              traffic between gateways.
            summary: No listener added for {{ $labels.instance }} NVMe-oF Gateway to {{ $labels.nqn
              }} subsystem
          expr: ceph_nvmeof_subsystem_listener_count == 0 and on(nqn) sum(ceph_nvmeof_subsystem_listener_count)
            by (nqn) > 0
          for: 10m
          labels:
            severity: warning
            type: ceph_default
        - alert: NVMeoFZeroListenerSubsystem
          annotations:
            description: NVMeoF gateway configuration incomplete; one of the subsystems have
              zero listeners.
            summary: No listeners added to {{ $labels.nqn }} subsystem
          expr: sum(ceph_nvmeof_subsystem_listener_count) by (nqn) == 0
          for: 10m
          labels:
            severity: warning
            type: ceph_default
        - alert: NVMeoFHighHostCPU
          annotations:
            description: High CPU on a gateway host can lead to CPU contention and performance
              degradation
            summary: The CPU is high ({{ $value }}%) on NVMeoF Gateway host ({{ $labels.host
              }}) on cluster {{ $labels.cluster }}
          expr: 100-((100*(avg by(cluster,host) (label_replace(rate(node_cpu_seconds_total{mode="idle"}[5m]),"host","$1","instance","(.*):.*"))
            * on(cluster, host) group_right label_replace(ceph_nvmeof_gateway_info,"host","$1","instance","(.*):.*"))))
            >= 80.00
          for: 10m
          labels:
            severity: warning
            type: ceph_default
        - alert: NVMeoFInterfaceDown
          annotations:
            description: A NIC used by one or more subsystems is in a down state
            summary: Network interface {{ $labels.device }} is down on cluster {{ $labels.cluster
              }}
          expr: ceph_nvmeof_subsystem_listener_iface_info{operstate="down"}
          for: 30s
          labels:
            oid: 1.3.6.1.4.1.50495.1.2.1.14.1
            severity: warning
            type: ceph_default
        - alert: NVMeoFInterfaceDuplex
          annotations:
            description: Until this is resolved, performance from the gateway will be degraded
            summary: Network interface {{ $labels.device }} is not running in full duplex
              mode on cluster {{ $labels.cluster }}
          expr: ceph_nvmeof_subsystem_listener_iface_info{duplex!="full"}
          for: 30s
          labels:
            severity: warning
            type: ceph_default
        - alert: NVMeoFHighReadLatency
          annotations:
            description: High latencies may indicate a constraint within the cluster e.g.
              CPU, network. Please investigate
            summary: The average read latency over the last 5 mins has reached 10 ms or more
              on {{ $labels.gateway }}
          expr: label_replace((avg by(instance) ((rate(ceph_nvmeof_bdev_read_seconds_total[1m])
            / rate(ceph_nvmeof_bdev_reads_completed_total[1m])))),"gateway","$1","instance","(.*):.*")
            > 0.01
          for: 5m
          labels:
            severity: warning
            type: ceph_default
        - alert: NVMeoFHighWriteLatency
          annotations:
            description: High latencies may indicate a constraint within the cluster e.g.
              CPU, network. Please investigate
            summary: The average write latency over the last 5 mins has reached 20 ms or more
              on {{ $labels.gateway }}
          expr: label_replace((avg by(instance) ((rate(ceph_nvmeof_bdev_write_seconds_total[5m])
            / rate(ceph_nvmeof_bdev_writes_completed_total[5m])))),"gateway","$1","instance","(.*):.*")
            > 0.02
          for: 5m
          labels:
            severity: warning
            type: ceph_default
        - alert: NVMeoFHostKeepAliveTimeout
          annotations:
            description: Host was disconnected due to host keep alive timeout
            summary: Host ({{ $labels.host_nqn }}) was disconnected {{ $value }} times from
              subsystem ({{ $labels.nqn }}) in last 24 hours
          expr: ceil(changes(ceph_nvmeof_host_keepalive_timeout[24h:]) / 2) > 0
          for: 1m
          labels:
            severity: warning
            type: ceph_default
    - name: certmgr
      rules:
        - alert: CephCertificateError
          annotations:
            description: '{{ $labels.message }}. Please check ''ceph health detail'' for more
              information and take appropriate action to resolve the certificate issue.'
            summary: Ceph certificate error detected on cluster {{ $labels.cluster }}
          expr: ceph_health_detail{name="CEPHADM_CERT_ERROR"} == 1
          for: 1m
          labels:
            oid: 1.3.6.1.4.1.50495.1.2.1.15.1
            severity: critical
            type: ceph_default
        - alert: CephCertificateWarning
          annotations:
            description: '{{ $labels.message }}. Please check ''ceph health detail'' for more
              information and take appropriate action to resolve the certificate issue.'
            summary: Ceph certificate warning detected on cluster {{ $labels.cluster }}
          expr: ceph_health_detail{name="CEPHADM_CERT_WARNING"} == 1
          for: 1m
          labels:
            oid: 1.3.6.1.4.1.50495.1.2.1.15.2
            severity: warning
            type: ceph_default

---
# Source: rook-ceph-cluster/templates/volumesnapshotclass.yaml
kind: VolumeSnapshotClass
apiVersion: snapshot.storage.k8s.io/v1
metadata:
  name: csi-ceph-filesystem
  annotations:
    snapshot.storage.kubernetes.io/is-default-class: "false"
driver: rook-ceph.cephfs.csi.ceph.com
parameters:
  clusterID: rook-ceph
  csi.storage.k8s.io/snapshotter-secret-name: rook-csi-cephfs-provisioner
  csi.storage.k8s.io/snapshotter-secret-namespace: rook-ceph
deletionPolicy: Delete

---
# Source: rook-ceph-cluster/templates/volumesnapshotclass.yaml
kind: VolumeSnapshotClass
apiVersion: snapshot.storage.k8s.io/v1
metadata:
  name: csi-ceph-blockpool
  annotations:
    snapshot.storage.kubernetes.io/is-default-class: "false"
driver: rook-ceph.rbd.csi.ceph.com
parameters:
  clusterID: rook-ceph
  csi.storage.k8s.io/snapshotter-secret-name: rook-csi-rbd-provisioner
  csi.storage.k8s.io/snapshotter-secret-namespace: rook-ceph
deletionPolicy: Delete
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"16c189697aab8d97027fce3b4759ce3b21c1a9fe","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `git diff --stat a161d503..2014395e (confirms single file, 7 insertions/1 deletion)`
- `git diff scoped to kubernetes/apps/system-upgrade/tuppr/upgrades/{kubernetesupgrade,talosupgrade}.yaml and **/prometheusrules.yaml between base and target (empty, confirms out-of-scope files untouched)`
- `yq '.spec.values.cephClusterSpec.mgr.modules' on the target helmrelease.yaml (confirms rook: enabled: false with the required comment/issue links present)`
- `kustomize build kubernetes/apps/rook-ceph/rook-ceph/cluster --load-restrictor LoadRestrictionsNone (the same manifest-build step task flux:test:all/CI exercises; renders cleanly, and yq on the output confirms the rendered HelmRelease carries enabled: false through)`
- <code>helm pull oci://ghcr.io/rook/rook-ceph-cluster --version v1.20.4 (the exact chart version pinned in ocirepository.yaml) then `helm template` it against the real `spec.values` block extracted from the HelmRelease at both base and target commits, diffing the two full rendered manifest sets</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
