### PR TITLE
test(ci): throwaway - exercise validate/versions gate (expected RED)

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -1,0 +1,144 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+#
+# CI gates for the parts of this repo Flux never sees. `talos/`, `bootstrap/` and
+# `.renovate/` are outside the `kubernetes/**` paths that Flux Local and Image Pull
+# filter on, so before this workflow a PR touching only `talos/` ran exactly one
+# check: the labeler.
+#
+# Scope, honestly: `talosctl validate` is a *schema* check. It catches render
+# breakage and machine-config keys Talos does not know. It does NOT catch invalid
+# enum values, malformed or wrong CIDRs, or a missing install disk - all three were
+# tested directly and pass validation. A green run here is not permission to apply
+# a config to a node; the dry-run, one-node-at-a-time discipline in talos/AGENTS.md
+# is what covers that.
+name: Validate
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches:
+      - main
+    paths:
+      - .github/workflows/validate.yaml
+      - .mise.toml
+      - .renovate/**
+      - .renovaterc.json5
+      - kubernetes/apps/system-upgrade/**
+      - scripts/ci/**
+      - talos/**
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  # Per-job path filtering. The workflow-level `paths:` above is the union of all
+  # three gates, so without this a `.renovate/`-only PR would also run the Talos
+  # jobs. Same pattern as flux-local.yaml / image-pull.yaml.
+  filter:
+    name: Validate - Filter
+    runs-on: gha-runner-scale-set-aviator-coding-home-ops
+    timeout-minutes: 5
+    outputs:
+      talos: ${{ steps.talos.outputs.changed_files }}
+      versions: ${{ steps.versions.outputs.changed_files }}
+      renovate: ${{ steps.renovate.outputs.changed_files }}
+    steps:
+      - name: Talos Changes
+        id: talos
+        uses: bjw-s-labs/action-changed-files@a9a36fb08ce06db9b02fbd8026cc2c0945eb9841 # v0.6.0
+        with:
+          patterns: |-
+            talos/**
+            .github/workflows/validate.yaml
+            .mise.toml
+            scripts/ci/talos-validate.sh
+
+      - name: Version Pin Changes
+        id: versions
+        uses: bjw-s-labs/action-changed-files@a9a36fb08ce06db9b02fbd8026cc2c0945eb9841 # v0.6.0
+        with:
+          patterns: |-
+            talos/**
+            kubernetes/apps/system-upgrade/**
+            .github/workflows/validate.yaml
+            .mise.toml
+            scripts/ci/version-consistency.sh
+
+      - name: Renovate Config Changes
+        id: renovate
+        uses: bjw-s-labs/action-changed-files@a9a36fb08ce06db9b02fbd8026cc2c0945eb9841 # v0.6.0
+        with:
+          patterns: |-
+            .renovaterc.json5
+            .renovate/**
+            .github/workflows/validate.yaml
+
+  talos:
+    if: ${{ needs.filter.outputs.talos != '[]' }}
+    needs: filter
+    name: talos
+    runs-on: gha-runner-scale-set-aviator-coding-home-ops
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      # minijinja-cli and talosctl come from .mise.toml so CI renders with the same
+      # versions `just talos render-config` uses locally.
+      - name: Setup Tools
+        uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
+        with:
+          install_args: aqua:mitsuhiko/minijinja aqua:siderolabs/talos aqua:mikefarah/yq
+
+      - name: Render and Validate Talos Configs
+        run: ./scripts/ci/talos-validate.sh
+
+  versions:
+    if: ${{ needs.filter.outputs.versions != '[]' }}
+    needs: filter
+    name: versions
+    runs-on: gha-runner-scale-set-aviator-coding-home-ops
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Tools
+        uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
+        with:
+          install_args: aqua:mikefarah/yq
+
+      - name: Check Machineconfig Versions Against tuppr CRs
+        run: ./scripts/ci/version-consistency.sh
+
+  renovate-config:
+    if: ${{ needs.filter.outputs.renovate != '[]' }}
+    needs: filter
+    name: renovate-config
+    runs-on: gha-runner-scale-set-aviator-coding-home-ops
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "24"
+
+      # Unpinned on purpose: renovate.yaml runs `renovate-version: latest`, so the
+      # config has to be valid against whatever Renovate is current, not against a
+      # version this workflow froze months ago.
+      - name: Validate Renovate Config
+        run: npx --yes --package renovate renovate-config-validator .renovaterc.json5 .renovate/*.json5

--- a/kubernetes/apps/system-upgrade/tuppr/upgrades/kubernetesupgrade.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/upgrades/kubernetesupgrade.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   kubernetes:
     # renovate: datasource=docker depName=ghcr.io/siderolabs/kubelet
-    version: v1.36.3
+    version: v1.36.4
   healthChecks:
     - apiVersion: volsync.backube/v1alpha1
       kind: ReplicationSource

--- a/scripts/ci/talos-validate.sh
+++ b/scripts/ci/talos-validate.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Render every Talos template and run `talosctl validate` over the result.
+#
+# Runs with no secrets and no cluster access: the `ref+op://` vals references are
+# stubbed with a dummy value and the factory schematic id is faked, because
+# neither takes part in schema validation.
+#
+# WHAT THIS CATCHES
+#   - template render breakage: undefined variables, malformed Jinja, output
+#     that is not parseable YAML
+#   - machine-config keys Talos does not know (unknown/misspelled fields)
+#   - patch failures between machineconfig.yaml.j2 and a node overlay
+#
+# WHAT THIS DOES NOT CATCH - tested directly, do not oversell this check
+#   - invalid enum values (e.g. `machine.type: notarealtype`)
+#   - malformed or simply wrong CIDRs
+#   - a missing or wrong `machine.install.disk`
+# `talosctl validate` is a schema check, not a semantic one. Green here does not
+# mean the config is safe to apply to a node; the dry-run, one-node-at-a-time
+# discipline in talos/AGENTS.md is what covers that.
+set -euo pipefail
+
+cd "$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+for tool in minijinja-cli talosctl yq; do
+    command -v "${tool}" >/dev/null 2>&1 || {
+        printf 'missing required tool: %s\n' "${tool}" >&2
+        exit 1
+    }
+done
+
+# Any 64-char hex id renders; the real one is computed from a live call to
+# factory.talos.dev, which CI deliberately does not make.
+export SCHEMATIC=0000000000000000000000000000000000000000000000000000000000000000
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "${tmp}"' EXIT
+
+# vals resolves these at apply time. Substitute a base64 value so fields typed as
+# base64 (certs, keys) still parse.
+stub() { sed -E 's#ref\+op://[^[:space:]]+#ZHVtbXk=#g'; }
+
+nodes=()
+for template in talos/nodes/*.yaml.j2; do
+    nodes+=("$(basename "${template}" .yaml.j2)")
+done
+[[ ${#nodes[@]} -gt 0 ]] || {
+    printf 'no node templates found under talos/nodes/\n' >&2
+    exit 1
+}
+
+for node in "${nodes[@]}"; do
+    minijinja-cli "talos/nodes/${node}.yaml.j2" | stub >"${tmp}/${node}.overlay.yaml"
+
+    # Mirrors `just talos render-config`: machine.type lives in the node overlay
+    # and gates the control-plane-only blocks of machineconfig.yaml.j2.
+    CONTROLPLANE="$(yq 'select(.machine) | (.machine.type == "controlplane") // ""' "${tmp}/${node}.overlay.yaml")"
+    export CONTROLPLANE
+
+    minijinja-cli talos/machineconfig.yaml.j2 | stub >"${tmp}/${node}.base.yaml"
+    talosctl machineconfig patch "${tmp}/${node}.base.yaml" \
+        -p "@${tmp}/${node}.overlay.yaml" >"${tmp}/${node}.yaml"
+    talosctl validate -m metal -c "${tmp}/${node}.yaml"
+done
+
+minijinja-cli talos/schematic.yaml.j2 >"${tmp}/schematic.yaml"
+yq -e '.customization' "${tmp}/schematic.yaml" >/dev/null
+
+printf 'OK: %d node config(s) render and validate; schematic renders\n' "${#nodes[@]}"

--- a/scripts/ci/version-consistency.sh
+++ b/scripts/ci/version-consistency.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Assert the Talos and Kubernetes versions pinned in talos/machineconfig.yaml.j2
+# match the tuppr CRs that actually drive cluster upgrades.
+#
+# WHY THIS EXISTS
+# The template holds a second, Renovate-managed copy of versions that tuppr
+# already owns. Flux never applies the template - `just talos apply-node` does,
+# by hand - so the two copies drift silently in both directions: a Renovate PR
+# bumping the template does not upgrade the cluster, and a tuppr-driven upgrade
+# does not update the template. Applying a stale template then downgrades a
+# running node. See AGENTS.md, "talos/machineconfig.yaml.j2's 6 version pins".
+#
+# This compares declared version against declared version. It says nothing about
+# what the nodes are actually running - check that with `kubectl get nodes -o wide`
+# before any apply-node.
+set -euo pipefail
+
+cd "$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+command -v yq >/dev/null 2>&1 || {
+    printf 'missing required tool: yq\n' >&2
+    exit 1
+}
+
+machineconfig=talos/machineconfig.yaml.j2
+kubernetes_cr=kubernetes/apps/system-upgrade/tuppr/upgrades/kubernetesupgrade.yaml
+talos_cr=kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml
+
+for file in "${machineconfig}" "${kubernetes_cr}" "${talos_cr}"; do
+    [[ -f "${file}" ]] || {
+        printf 'missing expected file: %s\n' "${file}" >&2
+        exit 1
+    }
+done
+
+kubernetes_want="$(yq -e '.spec.kubernetes.version' "${kubernetes_cr}")"
+talos_want="$(yq -e '.spec.talos.version' "${talos_cr}")"
+
+fail=0
+checked=0
+
+# machine.install.image - the Talos installer, matched against the TalosUpgrade CR.
+while read -r image; do
+    checked=$((checked + 1))
+    version="${image##*:}"
+    [[ "${version}" == "${talos_want}" ]] || {
+        printf 'MISMATCH  %s  %s  != TalosUpgrade %s\n' \
+            "${machineconfig}" "${image}" "${talos_want}"
+        fail=1
+    }
+done < <(grep -oE 'factory\.talos\.dev/installer/[^:]+:v[0-9.]+' "${machineconfig}")
+
+# kubelet + control-plane images, matched against the KubernetesUpgrade CR.
+while read -r image; do
+    checked=$((checked + 1))
+    version="${image##*:}"
+    [[ "${version}" == "${kubernetes_want}" ]] || {
+        printf 'MISMATCH  %s  %s  != KubernetesUpgrade %s\n' \
+            "${machineconfig}" "${image}" "${kubernetes_want}"
+        fail=1
+    }
+done < <(grep -oE '(ghcr\.io/siderolabs/kubelet|registry\.k8s\.io/kube-[a-z-]+):v[0-9.]+' "${machineconfig}")
+
+# A refactor that renames or drops the pins must fail loudly, not pass silently.
+expected=6
+[[ "${checked}" -eq "${expected}" ]] || {
+    printf 'found %d version pin(s) in %s, expected %d - has the template been restructured?\n' \
+        "${checked}" "${machineconfig}" "${expected}" >&2
+    fail=1
+}
+
+if [[ "${fail}" -ne 0 ]]; then
+    exit 1
+fi
+
+printf 'OK: %d machineconfig version pin(s) match the tuppr CRs (Talos %s, Kubernetes %s)\n' \
+    "${checked}" "${talos_want}" "${kubernetes_want}"


### PR DESCRIPTION
Throwaway PR to verify the new `validate / versions` gate actually fails on a deliberate version mismatch (KubernetesUpgrade bumped to v1.36.4 while the machineconfig template stays at v1.36.3). **Expected to be red.** Will be closed and the branch deleted once the checks report. Do not merge.