### PR TITLE
fix(github-action): stop diff comment failing on large PR diffs

### DIFF
--- a/.github/workflows/flux-local.yaml
+++ b/.github/workflows/flux-local.yaml
@@ -125,22 +125,24 @@ jobs:
             --sources "flux-system"
             --output-file diff.patch
 
-      - name: Generate Diff
+      - name: Truncate Diff
         id: diff
         run: |-
-          echo 'diff<<EOF' >> $GITHUB_OUTPUT
-          cat diff.patch >> $GITHUB_OUTPUT
-          echo 'EOF' >> $GITHUB_OUTPUT
+          truncate --size='<60000' diff.patch
+          if [ -s diff.patch ]; then
+            echo 'has-diff=true' >> "$GITHUB_OUTPUT"
+          fi
 
-      - if: ${{ steps.diff.outputs.diff != '' }}
+      - if: ${{ steps.diff.outputs.has-diff == 'true' }}
         name: Add Comment
         uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
         with:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           header: ${{ github.event.pull_request.number }}/kubernetes/${{ matrix.resource }}
+          path: diff.patch
           message: |-
             ```diff
-            ${{ steps.diff.outputs.diff }}
+            {{{content}}}
             ```
 
   success:


### PR DESCRIPTION
## Intent

Fix .github/workflows/flux-local.yaml's PR diff-comment step, which fails with 'Argument list too long' on any PR with a large rendered diff (confirmed reproducer: a Renovate branch bumping kube-prometheus-stack to 87.x/88.x failed 3 times this way). Root cause: the 'Generate Diff' step in the diff job round-trips the rendered flux-local diff.patch through $GITHUB_OUTPUT, which has a hard size cap that a large diff (e.g. ~400KB from a chart bump touching ~40 resources) blows past, hitting ARG_MAX/E2BIG. The per-resource --limit-bytes 10000 flag on the flux-local diff command does not bound this since it applies per resource, not to the whole file. Fix applied: drop the $GITHUB_OUTPUT round-trip entirely; truncate diff.patch to 60,000 bytes (under GitHub's 65,536 comment-body cap) in a shell step; pass the truncated file directly to marocchino/sticky-pull-request-comment via its 'path:' input with a '{{{content}}}' placeholder in 'message:', confirmed against the action's actual action.yml as the supported mechanism (rather than assuming). Only the diff-comment step (lines ~128-144 of the diff job) was touched; flux-local test, flux-local build, and every other job/workflow are explicitly out of scope and were left untouched. Verification requirement: a syntactically valid workflow proves nothing about the real failure being fixed, so I reproduced the large-diff scenario end-to-end rather than just checking gh workflow run exits 0 - I opened a throwaway PR (#1385, since closed without merging) that changed kube-prometheus-stack's OCIRepository tag from 88.5.3 to 87.14.0 (mirroring in reverse the real 87.x->88.x bump that caused the 3 original failures) to force a genuinely large rendered diff, and confirmed via gh api .../commits/<sha>/check-runs that both 'Flux Local - Diff (helmrelease)' and 'Flux Local - Diff (kustomization)' check-runs completed with conclusion=success (commit 9dc9f6b8), with the PR comment posting at 60,076 bytes (under the GitHub cap). The verification PR and its branch were closed/deleted afterward since they were only a reproducer, not the change to ship.

## What Changed

- In `.github/workflows/flux-local.yaml`'s diff job, renamed the `Generate Diff` step to `Truncate Diff` and removed the `$GITHUB_OUTPUT` round-trip of the rendered `diff.patch` (which hit `ARG_MAX`/E2BIG on large diffs), replacing it with `truncate --size='<60000' diff.patch` and a `has-diff` output flag.
- Changed the `Add Comment` step's condition from `steps.diff.outputs.diff != ''` to `steps.diff.outputs.has-diff == 'true'`.
- Updated the `marocchino/sticky-pull-request-comment` step to pass the truncated file via its `path: diff.patch` input and reference it in `message:` with a `{{{content}}}` placeholder instead of interpolating `steps.diff.outputs.diff` directly.

## Risk Assessment

✅ Low: The change is a narrowly-scoped, single-file workflow fix that removes the $GITHUB_OUTPUT round-trip (the actual root cause of the ARG_MAX/E2BIG failure) and instead truncates diff.patch to under GitHub's comment-body cap and feeds it to marocchino/sticky-pull-request-comment via its documented `path:`/`{{{content}}}` mechanism, which I confirmed against the action.yml at the pinned SHA (5770ad5eb8f42dd2c4f34da00c94c5381e49af88) actually supports exactly this input combination; the diff touches only the intended 8/6 lines in the diff-comment step, leaves every other job/step untouched, and the fix structurally eliminates the failure mode regardless of future diff size rather than just raising a threshold.

## Testing

Reproduced the large-diff scenario locally against the exact shell logic in the fixed 'Truncate Diff' step (using documented GNU truncate semantics, since only BSD truncate was available on this host) and confirmed it eliminates the $GITHUB_OUTPUT round-trip that caused the original ARG_MAX/E2BIG failure: a synthetic 1.77MB diff is truncated to exactly 60000 bytes, GITHUB_OUTPUT only ever carries a tiny boolean flag, small/empty-diff edge cases behave correctly (unchanged/skipped respectively), and the final rendered comment body (60012 bytes) stays under GitHub's 65536 cap - consistent with the author's real-world 60,076-byte verification from PR #1385. Independently verified against the action's live pinned action.yml that the 'path' + '{{{content}}}' mechanism the fix relies on is genuinely supported. The diff is confirmed scoped to exactly this one step in this one file, matching the stated intent. No test failures or issues found.

<details>
<summary>Evidence: Truncate-step simulation across large/small/empty diff cases</summary>

```text
Case 1 (large diff, ~1.77MB synthetic, mirroring the reported 400KB+ chart-bump diff):
before truncate: 1771940 bytes -> after truncate --size='<60000': 60000 bytes
GITHUB_OUTPUT content: has-diff=true (14 bytes total; diff content never enters GITHUB_OUTPUT)
rendered PR comment body: 60012 bytes -> under GitHub's 65536 cap: True

Case 2 (small diff, 80 bytes): left unchanged (truncate <SIZE never extends) -> rendered comment 92 bytes -> under cap

Case 3 (empty diff, 0 bytes): has-diff NOT set -> Add Comment step skipped via if: condition (matches original no-diff behavior)

Old (pre-fix) step for comparison: cat diff.patch >> $GITHUB_OUTPUT wrote the full 1771954 bytes into GITHUB_OUTPUT for the same synthetic diff - the structural round-trip this fix eliminates.
```
</details>
<details>
<summary>Evidence: marocchino/sticky-pull-request-comment action.yml (pinned SHA) path input definition</summary>

```text
path:
description: "glob path to file(s) containing comment message. When message is also provided and contains `{{{content}}}`, the file content is embedded at that placeholder position."
required: false
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"759b7d56c6ae8993b8ee654309106e632f5f0d5c","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `git diff --stat a1778853..759b7d56 -- confirms only .github/workflows/flux-local.yaml changed, 8 insertions/6 deletions, matching the claimed scope of only the diff-comment step`
- `python3 yaml.safe_load of the workflow file plus structural assertions: Truncate Diff step id=diff writes only to GITHUB_OUTPUT, Add Comment step's if-condition checks has-diff=='true', with.path=diff.patch, message contains {{{content}}} and no longer references steps.diff.outputs.diff`
- <code>Simulated the exact &#39;Truncate Diff&#39; shell script against a synthetic ~1.77MB diff.patch (40 resources x 250 changed lines, mirroring the reported ~400KB kube-prometheus-stack chart-bump diff) using an emulation of GNU coreutils&#39; documented `truncate --size=&#39;&lt;SIZE&#39;` (&#39;at most&#39;) semantics (verified against the official GNU coreutils manual at gnu.org, since this macOS sandbox only has BSD truncate which doesn&#39;t support this syntax, and installing GNU coreutils or using Docker was not available/permitted): confirmed the file shrinks to exactly 60000 bytes and GITHUB_OUTPUT receives only a 14-byte `has-diff=true` line, never the diff content itself</code>
- `Ran the same simulation against a small (80-byte) diff to confirm truncate's '<SIZE' semantics never extend a file that's already under the limit, and against an empty (0-byte) diff.patch to confirm has-diff is correctly left unset so the Add Comment step is skipped, matching original no-diff behavior`
- <code>Rendered the final PR-comment message template (```diff\n{{{content}}}\n```) against the truncated large-diff case and measured the byte size (60012 bytes) against GitHub&#39;s 65536 comment-body cap to confirm it stays under, closely matching the 60,076-byte real-world comment size the author reported from PR #1385</code>
- `Fetched the actual pinned action.yml for marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 from GitHub to independently confirm the 'path' input and '{{{content}}}' message-templating mechanism the fix relies on are genuinely supported by that action version (not assumed)`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
