### PR TITLE
fix(container): update image quay.io/ceph/ceph ( v20.2.3 -> v20.2.4 ) [security]

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -31,7 +31,7 @@ spec:
     # renovate: datasource=docker depName=quay.io/ceph/ceph
     cephImage:
       repository: quay.io/ceph/ceph
-      tag: v20.2.3
+      tag: v20.2.4
     cephClusterSpec:
       csi:
         cephfs:


### PR DESCRIPTION
Security patch release. v20.2.4 (2026-08-19) fixes three High-severity CVEs, all affecting v20.2.3:

- **CVE-2025-30156** - CephX authentication bypass: AES-CBC bit-flipping on encrypted service tickets lets an attacker with any low-privilege key (or on-path network position) escalate to admin. Full remediation additionally requires CephX key rotation to the new aes256k key type as a follow-up; that rotation needs Linux kernel >= 7.0 on CephFS/RBD kernel clients (Talos currently ships 6.18), so it is deliberately NOT part of this change. Upstream states the version upgrade alone resolves the most serious aspects.
- **CVE-2026-54330** - RGW SigV4 presigned-URL header injection: unsigned x-amz-* headers bypass signature verification (e.g. x-amz-copy-source can read anything the signer can). This cluster runs RGW (2 daemons). Single-zone deployment, so the multisite rgw_sigv4_insecure pre-upgrade step does not apply.
- **CVE-2026-50152** - Monitor config-key store unauthorized read.

Branch prepared by Renovate; PR opened manually ahead of its schedule due to security severity.

Merge effect: Rook (v1.20.4) performs a health-gated rolling restart of all Ceph daemons onto v20.2.4. In-flight deep-scrubs re-queue automatically. Post-merge verification: `ceph versions` shows every daemon on 20.2.4 and health returns to HEALTH_OK.