### PR TITLE
fix(container): update rook-ceph group ( v1.20.4 -> v1.20.6 )

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/ocirepository.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: v1.20.4
+    tag: v1.20.6
   url: oci://ghcr.io/rook/rook-ceph-cluster

--- a/kubernetes/apps/rook-ceph/rook-ceph/operator/ocirepository.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/operator/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: v1.20.4
+    tag: v1.20.6
   url: oci://ghcr.io/rook/rook-ceph


### PR DESCRIPTION
Rook operator + cluster chart v1.20.4 -> v1.20.6 (Renovate-prepared; opened manually as the prerequisite for CephX daemon-key rotation).

Context: after the Ceph v20.2.4 security upgrade (PR #1392), the monitors now flag every CephX key still using the insecure `aes` cipher (CVE-2025-30156), putting the cluster in HEALTH_ERR. Rotating the daemon keys to the new `aes256k` type clears the two ERR-level checks, and that rotation requires the `keyType` field Rook only supports in **v1.20.5+**. This bump unblocks it. Daemon-key rotation does NOT need a newer kernel (only client/CSI keys do), so it is safe on the current Talos 6.18 kernel.

Merge effect: rolling restart of the Rook operator and a controlled reconcile of Ceph daemons onto the new operator version. The follow-up daemon-key-rotation change lands in a separate PR once this is live.