### PR TITLE
docs: fix stale VictoriaMetrics reference and mod.just quoting bug

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 Home-ops GitOps repo for a 3-node Talos Linux Kubernetes cluster managed by Flux v2. `CLAUDE.md` is a symlink to this file. For narrower operator detail see [`talos/AGENTS.md`](talos/AGENTS.md) and [`bootstrap/AGENTS.md`](bootstrap/AGENTS.md).
 
-**Core stack**: Talos Linux (immutable OS) + Flux v2 (GitOps) + Cilium (CNI, BGP LoadBalancer, kube-proxy replacement, no L2 announcements) + Rook-Ceph (storage) + External Secrets Operator/1Password (secrets) + Cloudflare Tunnel (external access) + External-DNS (split DNS: `network/cloudflare-dns` public, `network/unifi-dns` internal) + VolSync (triple-destination backup). Gateway API `HTTPRoute`s front `envoy-internal`/`envoy-external` gateways in `network`. Monitoring: kube-prometheus-stack (metrics) + Loki/Promtail (logs) + Tempo (traces) + Grafana + Alertmanager + Gatus, all in `monitoring`.
+**Core stack**: Talos Linux (immutable OS) + Flux v2 (GitOps) + Cilium (CNI, BGP LoadBalancer, kube-proxy replacement, no L2 announcements) + Rook-Ceph (storage) + External Secrets Operator/1Password (secrets) + Cloudflare Tunnel (external access) + External-DNS (split DNS: `network/cloudflare-dns` public, `network/unifi-dns` internal) + VolSync (triple-destination backup). Gateway API `HTTPRoute`s front `envoy-internal`/`envoy-external` gateways in `network`. Monitoring: kube-prometheus-stack + Loki + Promtail + Tempo + Grafana + Alertmanager + Gatus + kromgo + KEDA + unpoller, all in `monitoring`.
 
 ## STRUCTURE
 

--- a/docs/downloads/sabnzbd-disk-space-runbook.md
+++ b/docs/downloads/sabnzbd-disk-space-runbook.md
@@ -134,8 +134,8 @@ Fires on kubelet volume stats for the `shared-downloads` PVC:
 
 Rationale: SAB pauses at 100 G free ≈ **5%** of 2 Ti, so both thresholds fire
 *before* the pipeline freezes — the whole point is that a human acts first.
-(Consumed by the VictoriaMetrics operator's PrometheusRule→VMRule converter,
-same as every other rule in this repo.)
+(Consumed natively by kube-prometheus-stack's Prometheus Operator, same as
+every other rule in this repo.)
 
 ---
 

--- a/kubernetes/mod.just
+++ b/kubernetes/mod.just
@@ -67,7 +67,7 @@ restore ns app previous='0':
 [script]
 snapshot:
     kubectl get replicationsources --no-headers -A | while read -r ns name _; do
-        kubectl -n "$ns" patch replicationsources "$name" --type merge -p '{"spec":{"trigger":{"manual":"$(date +%s)"}}}'
+        kubectl -n "$ns" patch replicationsources "$name" --type merge -p "{\"spec\":{\"trigger\":{\"manual\":\"$(date +%s)\"}}}"
     done
 
 [arg('resource', pattern='hr|ks|gitrepo|ocirepo|es')]


### PR DESCRIPTION
## Intent

Fix two factual errors: (1) AGENTS.md monitoring stack description is false - VictoriaMetrics/VictoriaLogs/Vector are not deployed; live stack is kube-prometheus-stack + Loki + Promtail + Tempo + Grafana + Alertmanager + Gatus + kromgo + KEDA + unpoller. (2) kubernetes/mod.just snapshot recipe uses single quotes so $(date +%s) writes literally - change to double quotes to expand timestamp.

## What Changed

- Corrected `AGENTS.md`'s core stack description: replaced the inaccurate VictoriaMetrics/VictoriaLogs/Vector monitoring stack with the actual deployed stack - kube-prometheus-stack + Loki + Promtail + Tempo + Grafana + Alertmanager + Gatus + kromgo + KEDA + unpoller.
- Updated `docs/downloads/sabnzbd-disk-space-runbook.md` to state that PrometheusRules are consumed natively by kube-prometheus-stack's Prometheus Operator, replacing the stale reference to a VictoriaMetrics operator PrometheusRule-to-VMRule converter.
- Fixed the `snapshot` recipe in `kubernetes/mod.just` to use double quotes around the `kubectl patch` JSON payload so `$(date +%s)` expands to the current timestamp instead of being written literally.

## Risk Assessment

✅ Low: Two isolated, verified-correct fixes (one doc correction confirmed against the actual monitoring kustomization.yaml, one shell-quoting fix confirmed to expand correctly and consistent with an existing working pattern in the same file) with no functional or behavioral risk beyond their stated scope.

## Testing

Verified the diff between base 12b2a76a and target 5cb03f59 contains exactly the two intended changes (no unrelated edits). For fix #1, cross-checked the corrected AGENTS.md monitoring-stack sentence against kubernetes/apps/monitoring/kustomization.yaml and confirmed VictoriaMetrics/VictoriaLogs/Vector are present as directories but commented out of the namespace's resource list (not deployed), while every app named in the fixed text (kube-prometheus-stack, Loki, Promtail, Tempo, Grafana, Alertmanager, Gatus, kromgo, KEDA, unpoller) is an active resource. For fix #2, reproduced the bug end-to-end by extracting the actual snapshot recipe body from both commits and executing each under the same shell `just` configures (bash -euo pipefail -c) with a stubbed kubectl capturing its patch payload: the base (single-quoted) version sent the literal, non-expanding string \"$(date +%s)\" to kubectl patch, while the target (double-quoted) version sent a real expanded epoch timestamp, confirming the fix works as intended. No linters or test suites were run per phase scope; worktree left clean with no leftover test artifacts.

<details>
<summary>Evidence: End-to-end reproduction of mod.just snapshot recipe: base (single-quoted) sends literal $(date +%s) vs target (double-quoted) sends expanded timestamp</summary>

```text
##### BASE COMMIT (single-quoted) #####
kubectl called with args: test-ns patch replicationsources test-replicationsource-name --type merge -p {"spec":{"trigger":{"manual":"$(date +%s)"}}}

##### TARGET COMMIT (double-quoted) #####
kubectl called with args: test-ns patch replicationsources test-replicationsource-name --type merge -p {"spec":{"trigger":{"manual":"1787515592"}}}
```
</details>
<details>
<summary>Evidence: kubernetes/apps/monitoring/kustomization.yaml confirming VictoriaMetrics/VictoriaLogs/Vector are commented out (not deployed)</summary>

```text
resources:
- ./alertmanager/ks.yaml
- ./grafana/ks.yaml
- ./keda/ks.yaml
- ./kube-state-metrics/ks.yaml
- ./kube-prometheus-stack/ks.yaml
- ./loki/ks.yaml
- ./prometheus-operator/ks.yaml
- ./tempo/ks.yaml
- ./promtail/ks.yaml
- ./gatus/ks.yaml
- ./kromgo/ks.yaml
# - ./victoriametrics/ks.yaml
# - ./victorialogs/ks.yaml
# - ./vector/ks.yaml
- ./unpoller/ks.yaml
- ./exporters/graphite-exporter/ks.yaml
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"c2da3fb0b088c2ae5d2af84f4d44b1f378010322","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `git diff 12b2a76a45986c7165b157ecbb44fc16d3267752 5cb03f59c857ddd66bff5b45bba11bdb476111ff (confirmed scope: only AGENTS.md and kubernetes/mod.just changed)`
- `Inspected kubernetes/apps/monitoring/kustomization.yaml to confirm victoriametrics/victorialogs/vector are commented out and the other named apps are active`
- <code>Manual end-to-end reproduction: extracted the snapshot recipe body from both commits and ran each via `bash -euo pipefail -c` (just&#39;s configured shell) with a stubbed kubectl function, comparing the literal patch payload sent in each case</code>
- `git status --porcelain (confirmed worktree clean after testing, no residue)`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
