### PR TITLE
fix(rook-ceph): stop CephMonitorQuorumAtRisk firing critical on healthy clusters

### DIFF
--- a/docs/ceph-cluster-changelog.md
+++ b/docs/ceph-cluster-changelog.md
@@ -83,6 +83,18 @@ Notes / evidence / sources.
 
 ## Change log
 
+### [2026-08-23] Fix CephMonitorQuorumAtRisk gauge-vs-count alert bug  (commits `649869b0`, `c1431311`)
+
+| Field | Value |
+|-------|-------|
+| **Change** | `CephMonitorQuorumAtRisk` alert `expr` in `cluster/prometheusrules.yaml`: `ceph_mon_quorum_status < 3` → `sum(ceph_mon_quorum_status) < 3`. |
+| **Why** | `ceph_mon_quorum_status` is a per-mon gauge (1 = in quorum, 0 = not), not a count. Comparing the gauge directly to `3` meant every healthy mon evaluated `1 < 3` = true, firing the alert as `critical` permanently on a healthy 3-mon cluster - confirmed firing continuously since 16:02:53Z 2026-08-23, when the metric resumed being exported after a prior mgr-module disable. `sum()` totals the gauge across all mons so it only trips below 3 when fewer are actually in quorum. An initial fix used `count(ceph_mon_quorum_status == 1) < 3`, but was corrected to `sum()` to avoid an empty-vector blind spot: `count()` over a matcher with zero matching series (e.g. every mon reporting `quorum_status == 0`, total quorum loss) returns no series at all, and Prometheus never fires an alert on an absent series. Verified no other rule in this file has the same gauge-vs-count mistake. |
+| **Risk** | None: this only fixes a false-positive-always-firing alert; the corrected expression trips only on genuine quorum loss, the condition the alert is meant to catch. |
+| **Rollback** | Revert the `expr` back to `ceph_mon_quorum_status < 3` (reintroduces the bug - not recommended). |
+| **Verify** | `kustomize build kubernetes/apps/rook-ceph/rook-ceph/cluster --load-restrictor LoadRestrictionsNone` and `task flux:test:all` render the corrected rule. Live confirmation against Prometheus/VictoriaMetrics that the alert clears on the healthy 3-mon cluster is a separate operational check, not covered by this render-only pass. |
+
+Applied via GitOps only (Flux reconciles the PrometheusRule); no direct live-cluster mutation was made.
+
 ### [2026-08-23] Set `rgw_sigv4_insecure` to unbreak S3 writes on Ceph v20.2.4  (PR pending, branch `fm/homeops-ceph-s3-write-outage`)
 
 | Field | Value |

--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/prometheusrules.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/prometheusrules.yaml
@@ -36,7 +36,7 @@ spec:
             description: "OSD {{ $labels.ceph_daemon }} has {{ $value }} slow operations for more than 10 minutes."
 
         - alert: CephMonitorQuorumAtRisk
-          expr: ceph_mon_quorum_status < 3
+          expr: count(ceph_mon_quorum_status == 1) < 3
           for: 1m
           labels:
             severity: critical

--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/prometheusrules.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/prometheusrules.yaml
@@ -36,7 +36,7 @@ spec:
             description: "OSD {{ $labels.ceph_daemon }} has {{ $value }} slow operations for more than 10 minutes."
 
         - alert: CephMonitorQuorumAtRisk
-          expr: count(ceph_mon_quorum_status == 1) < 3
+          expr: sum(ceph_mon_quorum_status) < 3
           for: 1m
           labels:
             severity: critical


### PR DESCRIPTION
## Intent

Fix the CephMonitorQuorumAtRisk PrometheusRule so it stops firing critical forever on a healthy cluster.

The rule's expression 'ceph_mon_quorum_status < 3' has a gauge-vs-count bug: the metric is a per-mon gauge (1 = in quorum, 0 = not), not a count. On a healthy 3-mon cluster, each monitor evaluates to '1 < 3' = true, causing the critical alert to fire once per healthy monitor permanently.

Changed to 'count(ceph_mon_quorum_status == 1) < 3' to properly count monitors in quorum and alert only when fewer than 3 are in quorum.

Verified that no other identical gauge-vs-count mistakes exist in the file. The metric has been firing continuously since 16:02:53Z 2026-08-23 when the mgr module resumed exporting after a prior disable.

## What Changed

- Fixed the `CephMonitorQuorumAtRisk` alert expression in `kubernetes/apps/rook-ceph/rook-ceph/cluster/prometheusrules.yaml` from `ceph_mon_quorum_status < 3` to `sum(ceph_mon_quorum_status) < 3`, since the metric is a per-mon gauge (1 = in quorum, 0 = not) rather than a count, and comparing it directly to `3` made every healthy mon evaluate `1 < 3 = true`, firing the alert as critical permanently on a healthy 3-mon cluster.
- `sum()` was chosen over an earlier `count(ceph_mon_quorum_status == 1) < 3` fix to avoid an empty-vector blind spot, where a matcher with zero matching series (e.g. total quorum loss) would return no series and never fire.
- Documented the root cause, fix, risk assessment, and rollback/verification steps in `docs/ceph-cluster-changelog.md`.

## Risk Assessment

✅ Low: The fix-round change is a single-line PromQL expression edit (count-with-filter to sum) that correctly resolves both the original gauge-vs-count false-positive and the round-1 empty-vector-at-zero-quorum blind spot, with no other files touched.

## Testing

<code>Using a locally-fetched promtool (Prometheus v3.14.0, downloaded to a scratch /tmp dir and removed afterward) I wrote unit-test scenarios simulating healthy, degraded, and total-quorum-loss cluster states against the actual rule expressions from each commit: the base-commit buggy expr fires on all three healthy monitors (reproducing the reported bug exactly), an intermediate count(==1) variant silently misses the total-outage case (empty-vector blind spot), and the target commit&#39;s shipped `sum(ceph_mon_quorum_status) &lt; 3` correctly stays silent when healthy and fires in both degraded scenarios. A kustomize build of the cluster directory also confirms the fix renders correctly into the deployed PrometheusRule. Note the shipped expression differs from the literal text in the user intent (`count(...==1)` vs `sum(...)`) because a same-branch follow-up review commit (c1431311) improved on the first fix (649869b0) to close the exact blind-spot demonstrated above - the final code still fully satisfies and exceeds the stated requirement. No issues found; all transient test files and the downloaded promtool binary were removed and the worktree is clean.</code>

<details>
<summary>Evidence: promtool unit-test transcript: pre-fix bug repro, blind-spot regression, and passing fix</summary>

```text
### promtool test rules -- target commit fix: sum(ceph_mon_quorum_status) < 3
$ promtool test rules test_after.yml
  SUCCESS

exit: 0

### promtool test rules -- base commit (pre-fix) expr: ceph_mon_quorum_status < 3
$ promtool test rules test_before.yml
  FAILED:
    name: healthy 3-mon cluster must NOT alert,
    alertname: CephMonitorQuorumAtRisk, time: 5m, 
        exp:[], 
        got:[
            0:
              Labels:{alertname="CephMonitorQuorumAtRisk", ceph_daemon="mon-a", severity="critical"}
              Annotations:{summary="Ceph monitor quorum has fewer than 3 members"},
            1:
              Labels:{alertname="CephMonitorQuorumAtRisk", ceph_daemon="mon-b", severity="critical"}
              Annotations:{summary="Ceph monitor quorum has fewer than 3 members"},
            2:
              Labels:{alertname="CephMonitorQuorumAtRisk", ceph_daemon="mon-c", severity="critical"}
              Annotations:{summary="Ceph monitor quorum has fewer than 3 members"}
            ]

    name: one mon down (2 of 3 in quorum) must alert,
    alertname: CephMonitorQuorumAtRisk, time: 5m, 
        exp:[
            0:
              Labels:{alertname="CephMonitorQuorumAtRisk", severity="critical"}
              Annotations:{summary="Ceph monitor quorum has fewer than 3 members"}
            ], 
        got:[
            0:
              Labels:{alertname="CephMonitorQuorumAtRisk", ceph_daemon="mon-a", severity="critical"}
              Annotations:{summary="Ceph monitor quorum has fewer than 3 members"},
            1:
              Labels:{alertname="CephMonitorQuorumAtRisk", ceph_daemon="mon-b", severity="critical"}
              Annotations:{summary="Ceph monitor quorum has fewer than 3 members"},
            2:
              Labels:{alertname="CephMonitorQuorumAtRisk", ceph_daemon="mon-c", severity="critical"}
              Annotations:{summary="Ceph monitor quorum has fewer than 3 members"}
            ]

    name: total quorum loss (all mons down) must still alert, no blind spot,
    alertname: CephMonitorQuorumAtRisk, time: 5m, 
        exp:[
            0:
              Labels:{alertname="CephMonitorQuorumAtRisk", severity="critical"}
              Annotations:{summary="Ceph monitor quorum has fewer than 3 members"}
            ], 
        got:[
            0:
              Labels:{alertname="CephMonitorQuorumAtRisk", ceph_daemon="mon-a", severity="critical"}
              Annotations:{summary="Ceph monitor quorum has fewer than 3 members"},
            1:
              Labels:{alertname="CephMonitorQuorumAtRisk", ceph_daemon="mon-b", severity="critical"}
              Annotations:{summary="Ceph monitor quorum has fewer than 3 members"},
            2:
              Labels:{alertname="CephMonitorQuorumAtRisk", ceph_daemon="mon-c", severity="critical"}
              Annotations:{summary="Ceph monitor quorum has fewer than 3 members"}
            ]


exit: 1

### promtool test rules -- intermediate variant: count(ceph_mon_quorum_status == 1) < 3
$ promtool test rules test_count_variant.yml
  FAILED:
    name: total quorum loss (all mons down) must still alert, no blind spot,
    alertname: CephMonitorQuorumAtRisk, time: 5m, 
        exp:[
            0:
              Labels:{alertname="CephMonitorQuorumAtRisk", severity="critical"}
              Annotations:{summary="Ceph monitor quorum has fewer than 3 members"}
            ], 
        got:[]


exit: 1
```
</details>
<details>
<summary>Evidence: kustomize build of kubernetes/apps/rook-ceph/rook-ceph/cluster showing rendered rule</summary>

```text
- alert: CephMonitorQuorumAtRisk
annotations:
summary: Ceph monitor quorum has fewer than 3 members
expr: sum(ceph_mon_quorum_status) < 3
for: 1m
labels:
severity: critical
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"fb5f2bb47991c5d63d19e77a5d43655146d0ee84","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `kubernetes/apps/rook-ceph/rook-ceph/cluster/prometheusrules.yaml:39` - The new expr `count(ceph_mon_quorum_status == 1) &lt; 3` fixes the stated gauge-vs-count false-positive on a healthy cluster, but introduces a false-negative blind spot in the exact worst-case scenario the alert exists to catch: total quorum loss. `ceph_mon_quorum_status == 1` filters the instant vector to only series currently equal to 1; if zero monitors are in quorum (all three report 0), that filtered vector is empty. PromQL aggregations (`count`, `sum`, etc.) over an empty vector return an empty result, not the literal number 0 - so `count(...) &lt; 3` never evaluates to true and CephMonitorQuorumAtRisk silently fails to fire precisely when the whole mon quorum is down. Partial loss (1 or 2 of 3 mons in quorum) is unaffected and fires correctly. A more robust expression that doesn&#39;t drop zero-valued series - e.g. `sum(ceph_mon_quorum_status) &lt; 3` (sums the 0/1 gauge directly without filtering) or `(count(ceph_mon_quorum_status == 1) or vector(0)) &lt; 3` - would keep the comparison well-defined at zero mons in quorum.

🔧 Fix: fix(rook-ceph): use sum() to avoid empty-vector blind spot at zero quorum
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`promtool check rules` on the exact rule text from prometheusrules.yaml</code>
- <code>`promtool test rules` against a healthy 3-mon cluster (all ceph_mon_quorum_status=1): fix produces no alert</code>
- <code>`promtool test rules` against a degraded cluster (1 of 3 mons out of quorum): fix correctly fires the alert</code>
- <code>`promtool test rules` against total quorum loss (0 of 3 mons in quorum): fix correctly fires, unlike the count(==1) intermediate variant which returns an empty vector and silently misses this case</code>
- <code>`promtool test rules` against the base-commit (pre-fix) expr `ceph_mon_quorum_status &lt; 3`: reproduces the reported bug, firing on all 3 healthy monitors</code>
- <code>`kubectl kustomize kubernetes/apps/rook-ceph/rook-ceph/cluster --load-restrictor LoadRestrictionsNone` to confirm the PrometheusRule still renders correctly with the new expression</code>
- `Manual review of the full prometheusrules.yaml file to confirm no other alert repeats the same per-instance-gauge-vs-count-threshold mistake`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
