### PR TITLE
fix(selfhosted): remove obsolete linkwarden runtime chromium install

### DIFF
--- a/kubernetes/apps/selfhosted/linkwarden/app/helmrelease.yaml
+++ b/kubernetes/apps/selfhosted/linkwarden/app/helmrelease.yaml
@@ -27,14 +27,6 @@ spec:
             envFrom: &envFrom
               - secretRef:
                   name: linkwarden-secret
-          init-playwright:
-            image:
-              repository: ghcr.io/linkwarden/linkwarden
-              tag: v2.16.1
-            command:
-              - /bin/sh
-              - -c
-              - npx playwright install chromium
 
         containers:
           app:
@@ -103,10 +95,6 @@ spec:
         existingClaim: ${VOLSYNC_CLAIM:-*app}
         globalMounts:
           - path: /data/data
-      cache:
-        type: emptyDir
-        globalMounts:
-          - path: /home/node/.cache
       next-cache:
         type: emptyDir
         globalMounts:


### PR DESCRIPTION
## Intent

Unstick selfhosted/linkwarden: Flux HelmRelease permanently Stalled=True/RetriesExceeded after 3 failed app-template 5.1.0 upgrade attempts each timed out waiting for Deployment/selfhosted/linkwarden status InProgress (Flux's default 5m HelmRelease timeout). Cluster currently runs the rolled-back chart 5.0.1 (linkwarden.v48/v50) which Git no longer declares; the pod itself is healthy.

Diagnosis performed: compared the rendered Helm manifests of the failed 5.1.0 release (helm secret v47/v49) against the working 5.0.1 rollback (v46) - the only diffs are the chart version label and two image tag bumps: ghcr.io/linkwarden/linkwarden v2.14.1 -> v2.16.1 and ghcr.io/home-operations/postgres-init 18.4 -> 18.6. The app-template chart's rendered Deployment (strategy, probes, resources, all fields) is byte-identical between 5.0.1 and 5.1.0 for this app's values, ruling out a chart-level regression - consistent with other apps on 5.1.0 upgrading fine.

Root cause is the linkwarden image bump, not the chart bump. Confirmed via linkwarden's upstream Dockerfile history (fetched via gh api at tags v2.14.1 and v2.16.1): v2.16.1 shipped 'Added support for running the Docker container as a non-root user' (upstream PR #1483) which bakes chromium-headless-shell into the image at BUILD time and sets ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright (root-owned, created during the image build). Our HelmRelease's initContainers.init-playwright ran at every pod startup (needed for the OLD v2.14.1 image, which did not bake in a browser and used playwright's default /Users/coder/.cache/ms-playwright location - matched by our /home/node/.cache emptyDir mount under our non-root runAsUser:1000 securityContext). Against the new image, that command now targets the new PLAYWRIGHT_BROWSERS_PATH=/ms-playwright instead, which is owned by root from the image build and not writable by our non-root uid 1000 pod - the init container fails/hangs on that permission failure, the Deployment never reaches Ready, and Flux's upgrade action times out after 5 minutes on all 3 attempts, exhausting retries and going Stalled=True/RetriesExceeded.

Fix applied (values-only, kubernetes/apps/selfhosted/linkwarden/app/helmrelease.yaml): removed the now-obsolete initContainers.init-playwright block entirely, since v2.16.1 already ships chromium-headless-shell baked into the image and needs no runtime install. Also removed the now-unused persistence.cache emptyDir volume (/home/node/.cache) that existed solely to give the old runtime playwright install a writable browser cache - nothing else references it.

Explicit constraint from the captain: do not delete or recreate the linkwarden PVC under any circumstances, no matter what. This change does not touch persistence.data (the app's data PVC, existingClaim) at all - only the initContainers and the unrelated emptyDir cache volume were touched.

Deliberately NOT done as part of this change: resetting/reconciling the live stalled HelmRelease on the cluster. Flux only reconciles against the main branch, so resetting the Stalled=True/RetriesExceeded state before this fix merges to main would just cause Flux to retry the still-broken currently-committed values again, re-triggering the same failure and needlessly recreating (Deployment strategy: Recreate) the currently-healthy pod for no benefit. That reset should happen as a follow-up operational step once this PR is merged.

## What Changed

- Removed the `init-playwright` init container from the linkwarden HelmRelease, which ran `npx playwright install chromium` on every pod startup.
- Removed the now-unused `cache` emptyDir volume (`/home/node/.cache`) that existed solely to give that runtime playwright install a writable browser cache.
- No changes to `persistence.data` (the app's existing-claim data PVC) or any other values.

## Risk Assessment

✅ Low: Minimal, well-scoped 12-line deletion in a single HelmRelease values file that removes a now-dead initContainer and its supporting emptyDir volume, with no other references left dangling, no shared resources (OCIRepository, PVC) touched, and behavior fully consistent with the stated diagnosis and explicit no-PVC constraint.

## Testing

Rendered the linkwarden HelmRelease values through the actual pinned app-template 5.1.0 chart for both the base and target commits and diffed the resulting Kubernetes Deployment manifests: the only change is exactly what the intent describes (init-playwright initContainer and cache emptyDir volume removed), with the app container, probes, resources, Deployment strategy, Service, HTTPRoute, and the data PVC's existingClaim reference byte-identical, confirming the PVC was untouched; both renders and a namespace-scoped kustomize build succeed cleanly. No findings.

<details>
<summary>Evidence: Rendered Deployment diff: pre-fix (init-playwright + cache volume) vs post-fix, via real app-template 5.1.0 chart</summary>

<code>--- render-base.yaml&#10;+++ render-target.yaml&#10;@@ init-db initContainer volumeMounts @@&#10;- - mountPath: /home/node/.cache&#10;- name: cache&#10;- mountPath: /data/data&#10;name: data&#10;@@ removed entire init-playwright initContainer block @@&#10;- - command:&#10;- - /bin/sh&#10;- - -c&#10;- - npx playwright install chromium&#10;- image: ghcr.io/linkwarden/linkwarden:v2.16.1&#10;- name: init-playwright&#10;- volumeMounts: [cache, data, next-cache]&#10;@@ app container volumeMounts @@&#10;- - mountPath: /home/node/.cache&#10;- name: cache&#10;@@ pod volumes @@&#10;- - emptyDir: {}&#10;- name: cache&#10;(everything else - app container image/env/probes/resources, Deployment strategy: Recreate, Service, HTTPRoute, and the `data` PVC existingClaim - is byte-identical between base and target)</code>

```text
--- render-base.yaml	2026-08-23 16:12:39
+++ render-target.yaml	2026-08-23 16:12:39
@@ -97,25 +97,10 @@
           image: ghcr.io/home-operations/postgres-init:18.6
           name: init-db
           volumeMounts:
-          - mountPath: /home/node/.cache
-            name: cache
           - mountPath: /data/data
             name: data
           - mountPath: /data/apps/web/.next/cache
             name: next-cache
-        - command:
-          - /bin/sh
-          - -c
-          - npx playwright install chromium
-          image: ghcr.io/linkwarden/linkwarden:v2.16.1
-          name: init-playwright
-          volumeMounts:
-          - mountPath: /home/node/.cache
-            name: cache
-          - mountPath: /data/data
-            name: data
-          - mountPath: /data/apps/web/.next/cache
-            name: next-cache
       containers: 
         - env:
           - name: CUSTOM_OPENAI_BASE_URL
@@ -164,15 +149,11 @@
               cpu: 250m
               memory: 512Mi
           volumeMounts:
-          - mountPath: /home/node/.cache
-            name: cache
           - mountPath: /data/data
             name: data
           - mountPath: /data/apps/web/.next/cache
             name: next-cache
       volumes: 
-        - emptyDir: {}
-          name: cache
         - name: data
           persistentVolumeClaim:
             claimName: ${VOLSYNC_CLAIM:-*app}
```
</details>
<details>
<summary>Evidence: Full rendered Deployment manifest, base commit (12b2a76a, values with init-playwright + cache volume)</summary>

```text
---
# Source: app-template/templates/common.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: linkwarden
  labels:
    app.kubernetes.io/instance: linkwarden
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: linkwarden
    helm.sh/chart: app-template-5.1.0
  namespace: selfhosted





---
# Source: app-template/templates/common.yaml
apiVersion: v1
kind: Service
metadata:
  name: linkwarden
  labels:
    app.kubernetes.io/instance: linkwarden
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: linkwarden
    app.kubernetes.io/service: linkwarden
    helm.sh/chart: app-template-5.1.0
  namespace: selfhosted
spec:
  type: ClusterIP
  ports:
    - port: 3000
      targetPort: 3000
      protocol: TCP
      name: http
  selector:
    app.kubernetes.io/controller: linkwarden
    app.kubernetes.io/instance: linkwarden
    app.kubernetes.io/name: linkwarden





  

---
# Source: app-template/templates/common.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: linkwarden
  labels:
    app.kubernetes.io/controller: linkwarden
    app.kubernetes.io/instance: linkwarden
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: linkwarden
    helm.sh/chart: app-template-5.1.0
  annotations:
    reloader.stakater.com/auto: "true"
  namespace: selfhosted
spec:
  revisionHistoryLimit: 3
  replicas: 1
  strategy:
    type: Recreate
  selector:
    matchLabels:
      app.kubernetes.io/controller: linkwarden
      app.kubernetes.io/name: linkwarden
      app.kubernetes.io/instance: linkwarden
  template:
    metadata:
      labels: 
        app.kubernetes.io/controller: linkwarden
        app.kubernetes.io/instance: linkwarden
        app.kubernetes.io/name: linkwarden
    spec: 
      enableServiceLinks: false
      serviceAccountName: linkwarden
      automountServiceAccountToken: false
      securityContext: 
        fsGroup: 1000
        fsGroupChangePolicy: OnRootMismatch
        runAsGroup: 1000
        runAsUser: 1000
      hostIPC: false
      hostNetwork: false
      hostPID: false
      dnsPolicy: ClusterFirst
      initContainers: 
        - envFrom:
          - secretRef:
              name: linkwarden-secret
          image: ghcr.io/home-operations/postgres-init:18.6
          name: init-db
          volumeMounts:
          - mountPath: /home/node/.cache
            name: cache
          - mountPath: /data/data
            name: data
          - mountPath: /data/apps/web/.next/cache
            name: next-cache
        - command:
          - /bin/sh
          - -c
          - npx playwright install chromium
          image: ghcr.io/linkwarden/linkwarden:v2.16.1
          name: init-playwright
          volumeMounts:
          - mountPath: /home/node/.cache
            name: cache
          - mountPath: /data/data
            name: data
          - mountPath: /data/apps/web/.next/cache
            name: next-cache
      containers: 
        - env:
          - name: CUSTOM_OPENAI_BASE_URL
            value: http://internal-noauth.ai.svc.cluster.local/v1
          - name: MONOLITH_MAX_BUFFER
            value: "256"
          - name: NEXTAUTH_URL
            value: https://links.${SECRET_DOMAIN}
          - name: NEXT_PUBLIC_CREDENTIALS_ENABLED
            value: "true"
          - name: NEXT_PUBLIC_DISABLE_REGISTRATION
            value: "true"
          - name: NEXT_SHARP_PATH
            value: /data/node_modules/sharp
          - name: OPENAI_MODEL
            value: qwen3.6-35b-a3b
          envFrom:
          - secretRef:
              name: linkwarden-secret
          image: ghcr.io/linkwarden/linkwarden:v2.16.1
          livenessProbe:
            failureThreshold: 3
            httpGet:
              path: /
              port: 3000
            initialDelaySeconds: 10
            periodSeconds: 10
            timeoutSeconds: 1
          name: app
          ports:
          - containerPort: 3000
            name: http
          readinessProbe:
            failureThreshold: 3
            httpGet:
              path: /
              port: 3000
            initialDelaySeconds: 10
            periodSeconds: 10
            timeoutSeconds: 1
          resources:
            limits:
              cpu: "2"
              memory: 4Gi
            requests:
              cpu: 250m
              memory: 512Mi
          volumeMounts:
          - mountPath: /home/node/.cache
            name: cache
          - mountPath: /data/data
            name: data
          - mountPath: /data/apps/web/.next/cache
            name: next-cache
      volumes: 
        - emptyDir: {}
          name: cache
        - name: data
          persistentVolumeClaim:
            claimName: ${VOLSYNC_CLAIM:-*app}
        - emptyDir: {}
          name: next-cache


  

---
# Source: app-template/templates/common.yaml
apiVersion: gateway.networking.k8s.io/v1alpha2
kind: HTTPRoute
metadata:
  name: linkwarden
  labels:
    app.kubernetes.io/instance: linkwarden
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: linkwarden
    helm.sh/chart: app-template-5.1.0
  annotations:
    external-dns.alpha.kubernetes.io/target: internal.${SECRET_DOMAIN}
    gatus.home-operations.com/endpoint: |-
      url: https://links.${SECRET_DOMAIN}/
      conditions:
        - "[STATUS] == any(200, 307)"
      group: selfhosted
    gethomepage.dev/enabled: "true"
    gethomepage.dev/group: Selfhosted
    gethomepage.dev/icon: linkwarden.svg
    gethomepage.dev/name: Linkwarden
  namespace: selfhosted
spec:
  parentRefs:
    - group: gateway.networking.k8s.io
      kind: Gateway
      name: envoy-internal
      namespace: "network"
      sectionName: "https"
  hostnames:
    - "links.${SECRET_DOMAIN}"
  rules:
    - backendRefs:
        - group: ""
          kind: Service
          name: linkwarden
          namespace: selfhosted
          port: 3000
          weight: 1
```
</details>
<details>
<summary>Evidence: Full rendered Deployment manifest, target commit (a9c4840d, fix applied)</summary>

```text
---
# Source: app-template/templates/common.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: linkwarden
  labels:
    app.kubernetes.io/instance: linkwarden
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: linkwarden
    helm.sh/chart: app-template-5.1.0
  namespace: selfhosted





---
# Source: app-template/templates/common.yaml
apiVersion: v1
kind: Service
metadata:
  name: linkwarden
  labels:
    app.kubernetes.io/instance: linkwarden
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: linkwarden
    app.kubernetes.io/service: linkwarden
    helm.sh/chart: app-template-5.1.0
  namespace: selfhosted
spec:
  type: ClusterIP
  ports:
    - port: 3000
      targetPort: 3000
      protocol: TCP
      name: http
  selector:
    app.kubernetes.io/controller: linkwarden
    app.kubernetes.io/instance: linkwarden
    app.kubernetes.io/name: linkwarden





  

---
# Source: app-template/templates/common.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: linkwarden
  labels:
    app.kubernetes.io/controller: linkwarden
    app.kubernetes.io/instance: linkwarden
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: linkwarden
    helm.sh/chart: app-template-5.1.0
  annotations:
    reloader.stakater.com/auto: "true"
  namespace: selfhosted
spec:
  revisionHistoryLimit: 3
  replicas: 1
  strategy:
    type: Recreate
  selector:
    matchLabels:
      app.kubernetes.io/controller: linkwarden
      app.kubernetes.io/name: linkwarden
      app.kubernetes.io/instance: linkwarden
  template:
    metadata:
      labels: 
        app.kubernetes.io/controller: linkwarden
        app.kubernetes.io/instance: linkwarden
        app.kubernetes.io/name: linkwarden
    spec: 
      enableServiceLinks: false
      serviceAccountName: linkwarden
      automountServiceAccountToken: false
      securityContext: 
        fsGroup: 1000
        fsGroupChangePolicy: OnRootMismatch
        runAsGroup: 1000
        runAsUser: 1000
      hostIPC: false
      hostNetwork: false
      hostPID: false
      dnsPolicy: ClusterFirst
      initContainers: 
        - envFrom:
          - secretRef:
              name: linkwarden-secret
          image: ghcr.io/home-operations/postgres-init:18.6
          name: init-db
          volumeMounts:
          - mountPath: /data/data
            name: data
          - mountPath: /data/apps/web/.next/cache
            name: next-cache
      containers: 
        - env:
          - name: CUSTOM_OPENAI_BASE_URL
            value: http://internal-noauth.ai.svc.cluster.local/v1
          - name: MONOLITH_MAX_BUFFER
            value: "256"
          - name: NEXTAUTH_URL
            value: https://links.${SECRET_DOMAIN}
          - name: NEXT_PUBLIC_CREDENTIALS_ENABLED
            value: "true"
          - name: NEXT_PUBLIC_DISABLE_REGISTRATION
            value: "true"
          - name: NEXT_SHARP_PATH
            value: /data/node_modules/sharp
          - name: OPENAI_MODEL
            value: qwen3.6-35b-a3b
          envFrom:
          - secretRef:
              name: linkwarden-secret
          image: ghcr.io/linkwarden/linkwarden:v2.16.1
          livenessProbe:
            failureThreshold: 3
            httpGet:
              path: /
              port: 3000
            initialDelaySeconds: 10
            periodSeconds: 10
            timeoutSeconds: 1
          name: app
          ports:
          - containerPort: 3000
            name: http
          readinessProbe:
            failureThreshold: 3
            httpGet:
              path: /
              port: 3000
            initialDelaySeconds: 10
            periodSeconds: 10
            timeoutSeconds: 1
          resources:
            limits:
              cpu: "2"
              memory: 4Gi
            requests:
              cpu: 250m
              memory: 512Mi
          volumeMounts:
          - mountPath: /data/data
            name: data
          - mountPath: /data/apps/web/.next/cache
            name: next-cache
      volumes: 
        - name: data
          persistentVolumeClaim:
            claimName: ${VOLSYNC_CLAIM:-*app}
        - emptyDir: {}
          name: next-cache


  

---
# Source: app-template/templates/common.yaml
apiVersion: gateway.networking.k8s.io/v1alpha2
kind: HTTPRoute
metadata:
  name: linkwarden
  labels:
    app.kubernetes.io/instance: linkwarden
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: linkwarden
    helm.sh/chart: app-template-5.1.0
  annotations:
    external-dns.alpha.kubernetes.io/target: internal.${SECRET_DOMAIN}
    gatus.home-operations.com/endpoint: |-
      url: https://links.${SECRET_DOMAIN}/
      conditions:
        - "[STATUS] == any(200, 307)"
      group: selfhosted
    gethomepage.dev/enabled: "true"
    gethomepage.dev/group: Selfhosted
    gethomepage.dev/icon: linkwarden.svg
    gethomepage.dev/name: Linkwarden
  namespace: selfhosted
spec:
  parentRefs:
    - group: gateway.networking.k8s.io
      kind: Gateway
      name: envoy-internal
      namespace: "network"
      sectionName: "https"
  hostnames:
    - "links.${SECRET_DOMAIN}"
  rules:
    - backendRefs:
        - group: ""
          kind: Service
          name: linkwarden
          namespace: selfhosted
          port: 3000
          weight: 1
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"a9c4840da1bbfb899e111a628111a52c658fbecf","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `git diff 12b2a76a..a9c4840d — confirmed the only change is removal of initContainers.init-playwright and persistence.cache in kubernetes/apps/selfhosted/linkwarden/app/helmrelease.yaml`
- `helm pull oci://ghcr.io/bjw-s-labs/helm/app-template --version 5.1.0 (the exact chart version pinned in kubernetes/components/common/repos/app-template/ocirepository.yaml)`
- `helm template linkwarden ./chart/app-template -f <base-commit values> — rendered successfully`
- `helm template linkwarden ./chart/app-template -f <target-commit values> — rendered successfully`
- `diff -u of the two rendered manifests — confirmed the only Kubernetes-object-level change is removal of the init-playwright initContainer and the cache emptyDir volume/mounts; Deployment strategy, app container, probes, resources, Service, HTTPRoute, and the data PVC existingClaim are unchanged`
- `kustomize build kubernetes/apps/selfhosted --load-restrictor LoadRestrictionsNone — succeeds, includes linkwarden resources`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
