### PR TITLE
docs: document main branch protection ruleset

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -186,7 +186,7 @@ success:
       run: echo "All jobs passed or skipped"
 ```
 
-**Why:** GitHub branch protection requires a single status check. This pattern aggregates results from all jobs.
+**Why:** a required status check needs a single aggregated result, so multi-job workflows expose one. This pattern is what makes a workflow *safe to require* - it doesn't mean it currently is: see [`docs/branch-protection.md`](../../docs/branch-protection.md) for what `main`'s ruleset actually requires today and why.
 
 ### Concurrency Control
 
@@ -246,9 +246,10 @@ runs-on: gha-runner-scale-set-aviator-coding-home-ops
 
 ### Branch Protection Issues
 
-1. Ensure success job name matches branch protection rule
+1. Ensure success job name matches the required status check's context string
 2. Verify all required jobs are listed in `needs`
 3. Check workflow permissions are correct
+4. See [`docs/branch-protection.md`](../../docs/branch-protection.md) for which checks `main`'s ruleset actually requires today
 
 ## Related Documentation
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,7 @@ Gatus is an app under `kubernetes/apps/monitoring/gatus`, not a component. Endpo
 | Talos node config | `talos/machineconfig.yaml.j2` + `talos/nodes/*.yaml.j2` + `talos/schematic.yaml.j2` | Rendered by `just talos`, not Flux |
 | Task commands | `Taskfile.yaml` + `.taskfiles/{domain}/` | `task --list-all`. Split with `just`: see UNIQUE STYLES |
 | CI workflows | `.github/workflows/` | flux-local, renovate, codeql, image-pull, label-sync, validate, plus build-talosctl-busybox, labeler, tag, test-runner |
+| Branch protection | GitHub ruleset on `main`, applied via `gh api` (not in Git) | `docs/branch-protection.md`. Only `Labeler - Labeler` is a required status check today - flux-local/image-pull/validate all path-filter at the `on: pull_request:` trigger level, so they never post a check outside their paths and are unsafe to require as-is (see doc for the live-measured proof and the follow-up needed to close the gap) |
 | Renovate config | `.renovaterc.json5` + `.renovate/` | Extends from Aviator-Coding/mortyops + local presets, incl. `.renovate/talos.json5` (Talos-scoped datasource + managers) |
 | Tool versions | `.mise.toml` | kubectl, flux, talos, helm, vals, 1password-cli, just, minijinja, etc. |
 | AI stack | `kubernetes/apps/ai/` | Hermes + ToolHive (`toolhive.stacklok.dev/v1alpha1` `MCPServer`) + agentgateway. kagent/kmcp tombstones: `docs/ai-system/{kagent,kmcp}`. Retired 2026-08-22: `docs/ai-system/retired-2026-08-22.md` |

--- a/docs/branch-protection.md
+++ b/docs/branch-protection.md
@@ -1,0 +1,138 @@
+# Branch protection (`main`)
+
+Before 2026-08-23, `main` carried zero branch protection and zero rulesets (`GET
+/repos/Aviator-Coding/home-ops/branches/main/protection` returned 404 "Branch not
+protected", `GET /repos/Aviator-Coding/home-ops/rulesets` returned `[]`). Nothing stopped a
+direct push to `main`, and nothing stopped merging a pull request whose checks were red. One
+such PR had already landed.
+
+This is now closed by a repository ruleset, applied via `gh api` (branch protection is a
+GitHub repo setting, not a Flux/Git-managed resource, so it lives outside `kubernetes/` and is
+documented here instead of expressed as YAML in the repo).
+
+## What's live
+
+**Ruleset:** `main-branch-protection` (id `21250320`), target `refs/heads/main`, enforcement
+`active`. Verify any time with:
+
+```bash
+gh api repos/Aviator-Coding/home-ops/rulesets/21250320
+```
+
+Rules:
+
+| Rule | Effect |
+|---|---|
+| `deletion` | `main` cannot be deleted |
+| `non_fast_forward` | force-pushes to `main` are rejected |
+| `pull_request` | changes must land through a PR (`required_approving_review_count: 0` — this is a solo-maintainer repo; the owner merges their own PRs) |
+| `required_status_checks` | `Labeler - Labeler` (GitHub Actions app, `integration_id: 15368`) must pass; `strict_required_status_checks_policy: false` (branch need not be up to date) |
+
+**Bypass:** `actor_type: RepositoryRole`, `actor_id: 5` (Admin), `bypass_mode: always`. On this
+repo the only collaborator with admin permission is the owner (`Aviator-Coding`, verified via
+`GET /repos/.../collaborators`), so this is equivalent to "the repo owner is never
+hard-locked" without hardcoding a user id — it also still applies correctly if the owner ever
+adds another admin collaborator.
+
+**`mortyops[bot]` (Renovate) is deliberately *not* in the bypass list.** It has no standing
+exemption, so it is gated by `required_status_checks` exactly like a human-authored PR — this
+is the intended effect of turning protection on. Separately, `.renovate/autoMerge.json5`
+already sets `ignoreTests: false` on every automerge rule, so Renovate itself already refuses
+to automerge a branch with failing checks; the ruleset adds enforcement at the platform level
+on top of that self-restraint. Requiring a PR (`pull_request` rule) may also change some
+`automergeType: "branch"` updates (currently digest/patch) from a direct branch merge into a
+PR that auto-merges once green — same outcome, more visible in the PR list.
+
+## Why only `Labeler - Labeler` is required — and why that's deliberate, not incomplete
+
+Required status checks and path-filtered workflows interact badly: if a required check's
+workflow never triggers for a given PR, GitHub leaves that check `Expected` forever and the PR
+can never merge. This repo's three substantive validation workflows —
+[`flux-local.yaml`](../.github/workflows/flux-local.yaml),
+[`image-pull.yaml`](../.github/workflows/image-pull.yaml), and
+[`validate.yaml`](../.github/workflows/validate.yaml) — all filter on `paths:` **at the
+`on: pull_request:` trigger level**, not inside a job. A PR that touches none of those paths
+never starts the workflow at all — no check run is ever created, skipped or otherwise. Requiring
+any of them today would permanently block every PR outside their path list.
+
+This is not hypothetical — it is what actually happens, measured live against real merged PRs:
+
+| PR | What it touched | Checks that actually posted |
+|---|---|---|
+| [#1400](https://github.com/Aviator-Coding/home-ops/pull/1400) (2026-08-23, docs-only) | `docs/ceph-cluster-changelog.md` only | `Labeler - Labeler` only |
+| [#1390](https://github.com/Aviator-Coding/home-ops/pull/1390) (talos-only, before `validate.yaml` existed) | `talos/machineconfig.yaml.j2`, `docs/` | `Labeler - Labeler` only — the historical "one check" case `validate.yaml` (#1391) was written to close |
+| [#1399](https://github.com/Aviator-Coding/home-ops/pull/1399) (`kubernetes/apps/**` change) | `kubernetes/apps/monitoring/...`, `docs/` | `Labeler`, `Flux Local - *` (incl. `Flux Local - Success`), `Image Pull - *` (incl. `Image Pull - Success`) |
+
+`validate.yaml` itself demonstrably works for its own scoped paths (e.g. runs 7-8, triggered on
+the open `renovate/kubectl-1.x` PR which touches `.mise.toml`) — the problem isn't that it's
+broken, it's that its trigger-level path filter means it simply never runs, and posts nothing,
+for PRs outside `talos/**`, `bootstrap/**`, `.renovate/**`, `.renovaterc.json5`,
+`kubernetes/apps/system-upgrade/**`, `scripts/ci/**`, `.mise.toml`, or its own workflow file.
+The same is true of `flux-local.yaml` / `image-pull.yaml` outside `kubernetes/**`. Root-level
+docs, `README.md`, `Taskfile.yaml`, `.taskfiles/**`, and most of `docs/**` are covered by none
+of the three.
+
+`labeler.yaml` is the only PR-triggered workflow with **no path filter on its trigger** — it
+runs on every PR to `main`, full stop. Its job does carry a same-repo fork guard
+(`if: github.event.pull_request.head.repo.full_name == github.repository`, mirrored from the
+`image-pull`/`validate` fork guards documented in `AGENTS.md`), but a job-level `if` still
+creates a check run (`skipped`), and GitHub treats a skipped required check as passing — unlike
+a trigger-level `paths:` mismatch, which creates no check run at all. That's what makes it the
+only check in this repo that is safe to mark required today: it is guaranteed to resolve, one
+way or another, for every PR.
+
+**This means the ruleset does not yet gate the checks that actually catch a broken
+Kustomization or a bad Talos config** — that gap is real and is the direct consequence of how
+`flux-local.yaml` / `image-pull.yaml` / `validate.yaml` are triggered, not a gap in this task.
+
+## Follow-up to close the gap
+
+To safely require `Flux Local - Success` / `Image Pull - Success` / a `validate.yaml`
+aggregate check, those three workflows need their path filtering moved from the `on:
+pull_request: paths:` trigger down into a job-level check (they already compute a `filter` job
+internally for exactly this kind of path detection — see each workflow's `filter` job) so the
+workflow — and therefore its check run — always starts, and reports success-via-skip when
+nothing relevant changed, the same way `labeler.yaml`'s fork guard already does. Once that's
+done, add those check contexts to this ruleset's `required_status_checks.required_status_checks`
+array with `gh api -X PUT repos/Aviator-Coding/home-ops/rulesets/21250320` (or via the ruleset
+edit UI) and this document should be updated to match.
+
+## Full applied payload
+
+```json
+{
+  "name": "main-branch-protection",
+  "target": "branch",
+  "enforcement": "active",
+  "bypass_actors": [
+    { "actor_id": 5, "actor_type": "RepositoryRole", "bypass_mode": "always" }
+  ],
+  "conditions": {
+    "ref_name": { "include": ["refs/heads/main"], "exclude": [] }
+  },
+  "rules": [
+    { "type": "deletion" },
+    { "type": "non_fast_forward" },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 0,
+        "dismiss_stale_reviews_on_push": false,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": false
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": false,
+        "do_not_enforce_on_create": false,
+        "required_status_checks": [
+          { "context": "Labeler - Labeler", "integration_id": 15368 }
+        ]
+      }
+    }
+  ]
+}
+```

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -22,6 +22,7 @@ Start with the operator files, then the topic notes under `docs/`.
 | [`organisation-services-1password-setup.md`](organisation-services-1password-setup.md) | 1Password setup |
 | [`kubernetes/components/volsync/Readme.md`](../kubernetes/components/volsync/Readme.md) | Volsync schedules and restore |
 | [`ai-system/retired-2026-08-22.md`](ai-system/retired-2026-08-22.md) | What the `ai` namespace retirements kept, and how to revive each app |
+| [`branch-protection.md`](branch-protection.md) | `main`'s GitHub ruleset: what's enforced, why only `Labeler` is a required check today, and what closes the gap |
 
 [`flux-migration-validation-report.md`](flux-migration-validation-report.md) is a historical snapshot from 2026-03-29. Do not treat its FAILs as open work.
 


### PR DESCRIPTION
## Intent

Turn on branch protection for main in Aviator-Coding/home-ops: required green checks before merge, so a red PR can never land again (one already did). Today main has zero protection and zero rulesets. Apply it as a GitHub ruleset via gh api (already done live, ruleset id 21250320, verified by API read-back), and document the applied configuration in a small docs page in the repo (docs/branch-protection.md) - that documentation is this task's PR; the ruleset itself was applied via API as part of this task, not through this PR's diff.

Key constraint: required status checks interact badly with path-conditional workflows - a required check that never starts on a PR blocks that PR forever. I enumerated which of this repo's PR-triggered workflows run on EVERY pull request versus only on path-filtered subsets: flux-local.yaml and image-pull.yaml trigger only on kubernetes/** paths, validate.yaml triggers only on talos/**, bootstrap/**, .renovate/**, .renovaterc.json5, kubernetes/apps/system-upgrade/**, scripts/ci/**, and .mise.toml (all filtered at the on:pull_request:paths: trigger level, so the workflow never even starts, and posts no check at all, for a PR outside those paths). labeler.yaml is the only PR-triggered workflow with no path filter on its trigger, so it is the only check proven to always post a resolvable status (success, or skipped-counts-as-passing via its same-repo fork guard) on every PR. I verified this empirically against real merged PRs via the GitHub API (not just by reading the YAML): PR #1400 (docs-only, 2026-08-23) posted only the Labeler check; PR #1390 (talos-only, before validate.yaml existed) posted only the Labeler check - this is the historical 'one check' case referenced in the task; PR #1399 (kubernetes/apps/** change) posted Flux Local, Image Pull, and Labeler checks; validate.yaml's own recent runs (its own workflow-runs history) confirm it correctly triggers for PRs that do touch its scoped paths (e.g. a currently open renovate/kubectl-1.x PR touching .mise.toml).

Given that evidence, I deliberately required only 'Labeler - Labeler' (GitHub Actions app, integration_id 15368) as the required status check in the ruleset, and did NOT require flux-local/image-pull/validate's checks, because doing so today would permanently block every PR that doesn't touch their specific paths (proven by the #1400 and #1390 examples above) - exactly the trap the task warned about. I documented this decision, the concrete evidence, and the follow-up needed to close the gap (moving path filtering from the workflow's on:pull_request:paths: trigger down into a job-level check, the same way labeler.yaml's job-level fork-guard already works, so the workflow's check always posts and can then be safely required) in docs/branch-protection.md.

Other ruleset rules applied: pull_request (require a PR before merging main, required_approving_review_count: 0 since this is a solo-maintainer repo where the owner merges their own PRs), non_fast_forward (block force-push), deletion (block branch deletion). Bypass: actor_type RepositoryRole, actor_id 5 (Admin), bypass_mode always - equivalent to 'the repo owner is never hard-locked' since Aviator-Coding is the sole admin collaborator on this personal (non-org) repo, verified via the collaborators API. The merge bot app/mortyops (Renovate) was deliberately given no bypass entry, so required_status_checks now formally gates it too (in addition to its own existing ignoreTests:false automerge setting) - this is intentional per the task and is documented as such.

No test PRs were created to probe this - verification was done by reading the ruleset back via the API (gh api repos/Aviator-Coding/home-ops/rulesets/21250320, confirmed enforcement: active) and by reasoning from/measuring real workflow trigger history against already-merged PRs, per the task's explicit instruction not to probe with test PRs.

Also added a one-line pointer to the new doc in docs/reference.md's index table, and a row in AGENTS.md's WHERE TO LOOK table (this repo's CLAUDE.md is a symlink to AGENTS.md) summarizing where branch protection lives and why only Labeler is required today, since this is durable knowledge future sessions will want (AGENTS.md already documents other GitHub Actions path-filter gaps in its NOTES section, e.g. the postBuild.substitute collision and the flux-local blind spot, so this fits the file's existing pattern).

## What Changed

- Add `docs/branch-protection.md`, documenting the GitHub ruleset now applied to `main` (id `21250320`): rules (`deletion`, `non_fast_forward`, `pull_request` with 0 required approvals, `required_status_checks`), the admin bypass actor, and the full applied JSON payload.
- Explain why only `Labeler - Labeler` is required today - `flux-local.yaml`, `image-pull.yaml`, and `validate.yaml` all path-filter at the `on: pull_request:` trigger level and never post a check outside their paths, backed by a table of real merged-PR check results (#1400, #1390, #1399) - and describe the follow-up (move path filtering to job level) needed to safely require them.
- Update `.github/workflows/README.md`'s "Why" note and Branch Protection Issues troubleshooting list to point at the new doc, and add pointer rows in `AGENTS.md`'s WHERE TO LOOK table and `docs/reference.md`'s index.

## Risk Assessment

✅ Low: Docs-only change (branch-protection.md + two index pointers) with no code or config touched; I independently verified every factual claim against the live GitHub ruleset, collaborators API, and actual check-run history for the three cited PRs, and all matched exactly.

## Testing

This is a documentation-only change with no application code or automated test suite to run, so validation consisted of fact-checking every empirical claim in docs/branch-protection.md against live state: the GitHub ruleset API read-back matches the doc's payload exactly, the three cited PRs' actual posted check names match the doc's evidence table exactly, and the workflow trigger path-filters/fork-guard behavior described matches the current YAML. All claims verified true; no discrepancies found.

<details>
<summary>Evidence: Live GitHub API verification of ruleset and PR check-history claims</summary>

```text
gh api repos/Aviator-Coding/home-ops/rulesets/21250320 -> id 21250320, enforcement "active", rules [deletion, non_fast_forward, pull_request(required_approving_review_count:0), required_status_checks([Labeler - Labeler, integration_id 15368])], bypass_actors [{RepositoryRole, actor_id 5, always}] -- matches docs/branch-protection.md's "Full applied payload" JSON block exactly.

gh pr view 1400 --json statusCheckRollup -q '.statusCheckRollup[].name' -> "Labeler - Labeler" (only)
gh pr view 1390 --json statusCheckRollup -q '.statusCheckRollup[].name' -> "Labeler - Labeler" (only)
gh pr view 1399 --json statusCheckRollup -q '.statusCheckRollup[].name' -> Flux Local (Filter/Test/Diff x2/Success), Image Pull (Filter/Extract x2/Diff/Pull/Success), Labeler - Labeler
All three match the doc's evidence table exactly.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"a9e2431ead157e17f7770d4ce79be16d3003cd77","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `gh api repos/Aviator-Coding/home-ops/rulesets/21250320 — live ruleset matches the doc's "Full applied payload" JSON block byte-for-byte (rules, bypass_actors, required_status_checks all identical)`
- <code>gh pr view 1400 --json statusCheckRollup -q &#39;.statusCheckRollup[].name&#39; — confirms PR #1400 (docs-only) posted only `Labeler - Labeler`, as claimed in the doc&#39;s evidence table</code>
- <code>gh pr view 1390 --json statusCheckRollup -q &#39;.statusCheckRollup[].name&#39; — confirms PR #1390 (talos-only, pre-validate.yaml) posted only `Labeler - Labeler`</code>
- `gh pr view 1399 --json statusCheckRollup -q '.statusCheckRollup[].name' — confirms PR #1399 (kubernetes/apps/** change) posted the full Flux Local + Image Pull + Labeler check set`
- <code>Read .github/workflows/flux-local.yaml, image-pull.yaml, validate.yaml, labeler.yaml — confirmed trigger-level `paths:` filters (kubernetes/**, and validate.yaml&#39;s 7-item list) match the doc exactly, and labeler.yaml has no trigger path filter with a job-level fork guard as described</code>
- `gh api repos/Aviator-Coding/home-ops/collaborators -q '.[] | {login, permissions: .permissions.admin, role: .role_name}' — confirms Aviator-Coding is the sole admin collaborator, supporting the bypass_actors claim`
- <code>grep ignoreTests .renovate/autoMerge.json5 — confirms `ignoreTests: false` on all three automerge rules as cited in the doc</code>
- `ls -la CLAUDE.md AGENTS.md — confirmed CLAUDE.md is a symlink to AGENTS.md as the doc's cross-references assume`
- `Verified all relative markdown links in docs/branch-protection.md resolve to existing files (.github/workflows/*.yaml)`
- `git status --short — clean working tree, no stray files from this change or from verification`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
