### PR TITLE
fix(actions-runner-system): stop deleting mid-registration runners and fix zeroed cleanup counters

### DIFF
--- a/kubernetes/apps/actions-runner-system/TROUBLESHOOTING.md
+++ b/kubernetes/apps/actions-runner-system/TROUBLESHOOTING.md
@@ -327,7 +327,13 @@ The runner system includes automated maintenance mechanisms to prevent and recov
 A CronJob (`runner-maintenance`) runs every 15 minutes against **home-ops only**
 (`REPO_NAME=home-ops`) to automatically:
 
-1. **Clean stale runners**: Removes offline runners from GitHub's API that are no longer active
+1. **Clean stale runners**: Deletes an offline runner from GitHub's API only when no
+   backing Kubernetes Pod of that name exists in `actions-runner-system` (ARC names
+   each ephemeral runner after its Pod). The GitHub API exposes no per-runner
+   timestamp, so Pod existence is the staleness signal instead of elapsed time. A
+   runner mid-registration still has its Pod present and is left alone. If the Pod
+   list can't be fetched, the run skips deletions entirely rather than deleting
+   every offline runner.
 2. **Cancel stuck runs**: Cancels workflow runs stuck in "queued" state for more than 30 minutes
 3. **Log anomalies**: Reports long-running jobs that may need manual attention
 
@@ -371,7 +377,7 @@ Ghost jobs occur when GitHub's Actions service has stale job assignments that no
 ### Automated Recovery
 
 The maintenance CronJob automatically (home-ops only):
-- Cleans offline runners from GitHub every 15 minutes
+- Every 15 minutes, deletes offline runners from GitHub that have no backing Pod (see [Maintenance CronJob](#maintenance-cronjob) above)
 - Cancels workflow runs stuck for more than 30 minutes
 
 ### Manual Recovery

--- a/kubernetes/apps/actions-runner-system/maintenance/cronjob.yaml
+++ b/kubernetes/apps/actions-runner-system/maintenance/cronjob.yaml
@@ -79,12 +79,32 @@ spec:
 
                   K8S_API="https://kubernetes.default.svc"
                   K8S_CACERT="/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
-                  K8S_TOKEN="$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)"
+                  K8S_TOKEN="$(cat /var/run/secrets/kubernetes.io/serviceaccount/token 2>/dev/null || true)"
 
-                  LIVE_PODS_JSON=$(curl -sS --cacert "${K8S_CACERT}" \
-                    -H "Authorization: Bearer ${K8S_TOKEN}" \
-                    "${K8S_API}/api/v1/namespaces/${POD_NAMESPACE}/pods" 2>/dev/null || echo "{}")
-                  LIVE_POD_NAMES=$(echo "${LIVE_PODS_JSON}" | jq -r '.items[]?.metadata.name // empty')
+                  # Pod-list fetch failures (missing token, unreachable API, non-200
+                  # response) must fail closed: PODS_LOOKUP_OK gates deletion below so
+                  # a lookup we can't trust never gets treated as "no pods exist".
+                  PODS_LOOKUP_OK=true
+                  if [[ -z "${K8S_TOKEN}" ]]; then
+                    echo "  [WARNING] Could not read service account token - skipping pod-backed staleness check this run, no offline runners will be deleted"
+                    PODS_LOOKUP_OK=false
+                  fi
+
+                  LIVE_POD_NAMES=""
+                  if [[ "${PODS_LOOKUP_OK}" == "true" ]]; then
+                    K8S_PODS_TMPFILE=$(mktemp)
+                    K8S_HTTP_STATUS=$(curl -sS -o "${K8S_PODS_TMPFILE}" -w '%{http_code}' --cacert "${K8S_CACERT}" \
+                      -H "Authorization: Bearer ${K8S_TOKEN}" \
+                      "${K8S_API}/api/v1/namespaces/${POD_NAMESPACE}/pods" 2>/dev/null || echo "000")
+
+                    if [[ "${K8S_HTTP_STATUS}" == "200" ]]; then
+                      LIVE_POD_NAMES=$(jq -r '.items[]?.metadata.name // empty' "${K8S_PODS_TMPFILE}" 2>/dev/null || echo "")
+                    else
+                      echo "  [WARNING] Failed to list pods in namespace ${POD_NAMESPACE} (HTTP ${K8S_HTTP_STATUS}) - skipping pod-backed staleness check this run, no offline runners will be deleted"
+                      PODS_LOOKUP_OK=false
+                    fi
+                    rm -f "${K8S_PODS_TMPFILE}"
+                  fi
 
                   DELETED_COUNT=0
 
@@ -103,6 +123,11 @@ spec:
 
                     # Only check offline runners
                     if [[ "${RUNNER_STATUS}" == "offline" ]]; then
+                      if [[ "${PODS_LOOKUP_OK}" != "true" ]]; then
+                        echo "  [SKIP] ${RUNNER_NAME} (id=${RUNNER_ID}): offline, but pod-backed staleness check unavailable this run"
+                        continue
+                      fi
+
                       if grep -qxF "${RUNNER_NAME}" <<<"${LIVE_POD_NAMES}"; then
                         echo "  [SKIP] ${RUNNER_NAME} (id=${RUNNER_ID}): offline but backing pod still present, likely mid-registration"
                         continue

--- a/kubernetes/apps/actions-runner-system/maintenance/cronjob.yaml
+++ b/kubernetes/apps/actions-runner-system/maintenance/cronjob.yaml
@@ -29,10 +29,12 @@ spec:
                   value: "aviator-coding"
                 - name: REPO_NAME
                   value: "home-ops"
-                - name: STALE_RUNNER_MINUTES
-                  value: "10"
                 - name: STUCK_RUN_MINUTES
                   value: "30"
+                - name: POD_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
               command:
                 - /bin/bash
                 - -c
@@ -46,29 +48,48 @@ spec:
 
                   # Configuration
                   REPO="${REPO_OWNER}/${REPO_NAME}"
-                  STALE_THRESHOLD_SECONDS=$((STALE_RUNNER_MINUTES * 60))
                   STUCK_THRESHOLD_SECONDS=$((STUCK_RUN_MINUTES * 60))
+                  CURRENT_TIME=$(date +%s)
 
                   echo ""
                   echo "Configuration:"
                   echo "  Repository: ${REPO}"
-                  echo "  Stale runner threshold: ${STALE_RUNNER_MINUTES} minutes"
                   echo "  Stuck run threshold: ${STUCK_RUN_MINUTES} minutes"
                   echo ""
 
                   # ==========================================
                   # STEP 1: Clean up stale/offline runners
                   # ==========================================
+                  # The GitHub API's /actions/runners endpoint carries no
+                  # last_connected_at (or any other) timestamp, so elapsed-time
+                  # staleness cannot be computed from it. ARC (gha-runner-scale-set)
+                  # names each ephemeral runner after the Kubernetes Pod backing it,
+                  # so pod existence is used as the staleness signal instead: an
+                  # offline, non-busy runner is only deleted when no Pod of that
+                  # name exists in this namespace. A runner that is mid-registration
+                  # (ARC's ephemeral registration window) still has its Pod present
+                  # and is left alone; only registrations orphaned by an already-gone
+                  # Pod are removed. The runner-maintenance Role already grants
+                  # list on pods in this namespace for exactly this purpose.
                   echo "--- Step 1: Checking for stale runners ---"
 
                   RUNNERS_JSON=$(gh api "repos/${REPO}/actions/runners" --jq '.runners' 2>/dev/null || echo "[]")
                   RUNNER_COUNT=$(echo "${RUNNERS_JSON}" | jq 'length')
                   echo "Found ${RUNNER_COUNT} total runners"
 
-                  CURRENT_TIME=$(date +%s)
+                  K8S_API="https://kubernetes.default.svc"
+                  K8S_CACERT="/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+                  K8S_TOKEN="$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)"
+
+                  LIVE_PODS_JSON=$(curl -sS --cacert "${K8S_CACERT}" \
+                    -H "Authorization: Bearer ${K8S_TOKEN}" \
+                    "${K8S_API}/api/v1/namespaces/${POD_NAMESPACE}/pods" 2>/dev/null || echo "{}")
+                  LIVE_POD_NAMES=$(echo "${LIVE_PODS_JSON}" | jq -r '.items[]?.metadata.name // empty')
+
                   DELETED_COUNT=0
 
-                  echo "${RUNNERS_JSON}" | jq -c '.[]' | while read -r runner; do
+                  while read -r runner; do
+                    [[ -z "${runner}" ]] && continue
                     RUNNER_ID=$(echo "${runner}" | jq -r '.id')
                     RUNNER_NAME=$(echo "${runner}" | jq -r '.name')
                     RUNNER_STATUS=$(echo "${runner}" | jq -r '.status')
@@ -82,10 +103,12 @@ spec:
 
                     # Only check offline runners
                     if [[ "${RUNNER_STATUS}" == "offline" ]]; then
-                      echo "  [FOUND] ${RUNNER_NAME} (id=${RUNNER_ID}): offline, checking age..."
+                      if grep -qxF "${RUNNER_NAME}" <<<"${LIVE_POD_NAMES}"; then
+                        echo "  [SKIP] ${RUNNER_NAME} (id=${RUNNER_ID}): offline but backing pod still present, likely mid-registration"
+                        continue
+                      fi
 
-                      # Note: GitHub API doesn't provide last_connected_at for runners
-                      # We'll delete all offline runners that aren't busy as they're likely stale
+                      echo "  [FOUND] ${RUNNER_NAME} (id=${RUNNER_ID}): offline, no backing pod - orphaned"
                       echo "  [DELETE] Removing offline runner: ${RUNNER_NAME} (id=${RUNNER_ID})"
 
                       if gh api -X DELETE "repos/${REPO}/actions/runners/${RUNNER_ID}" 2>/dev/null; then
@@ -97,7 +120,7 @@ spec:
                     else
                       echo "  [OK] ${RUNNER_NAME} (id=${RUNNER_ID}): ${RUNNER_STATUS}"
                     fi
-                  done
+                  done < <(echo "${RUNNERS_JSON}" | jq -c '.[]')
 
                   echo "Deleted ${DELETED_COUNT} stale runners"
                   echo ""
@@ -114,7 +137,8 @@ spec:
 
                   CANCELLED_COUNT=0
 
-                  echo "${QUEUED_RUNS}" | jq -c '.[]' | while read -r run; do
+                  while read -r run; do
+                    [[ -z "${run}" ]] && continue
                     RUN_ID=$(echo "${run}" | jq -r '.databaseId')
                     RUN_NAME=$(echo "${run}" | jq -r '.name')
                     CREATED_AT=$(echo "${run}" | jq -r '.createdAt')
@@ -147,7 +171,7 @@ spec:
                     else
                       echo "  [OK] ${RUN_NAME} (id=${RUN_ID}): queued for ${AGE_MINUTES} minutes"
                     fi
-                  done
+                  done < <(echo "${QUEUED_RUNS}" | jq -c '.[]')
 
                   echo "Cancelled ${CANCELLED_COUNT} stuck workflow runs"
                   echo ""
@@ -164,7 +188,8 @@ spec:
                   # Extended threshold for in_progress (60 minutes - these might be legitimately running)
                   LONG_RUNNING_THRESHOLD=$((60 * 60))
 
-                  echo "${IN_PROGRESS_RUNS}" | jq -c '.[]' | while read -r run; do
+                  while read -r run; do
+                    [[ -z "${run}" ]] && continue
                     RUN_ID=$(echo "${run}" | jq -r '.databaseId')
                     RUN_NAME=$(echo "${run}" | jq -r '.name')
                     CREATED_AT=$(echo "${run}" | jq -r '.createdAt')
@@ -186,7 +211,7 @@ spec:
                     else
                       echo "  [OK] ${RUN_NAME} (id=${RUN_ID}): running for ${AGE_MINUTES} minutes"
                     fi
-                  done
+                  done < <(echo "${IN_PROGRESS_RUNS}" | jq -c '.[]')
 
                   echo ""
                   echo "=========================================="


### PR DESCRIPTION
## Intent

Fix both defects in kubernetes/apps/actions-runner-system/maintenance/cronjob.yaml (fix, don't delete - the queued-run cleanup steps are correct and useful): (1) it deletes EVERY offline non-busy runner unconditionally every 15 minutes, racing ARC's ephemeral registration window; STALE_RUNNER_MINUTES/STALE_THRESHOLD_SECONDS were computed and never used for runners - since the GitHub API's /actions/runners endpoint truly offers no per-runner timestamp, staleness is now derived by correlating each offline runner's name against live Kubernetes Pods in the actions-runner-system namespace (ARC/gha-runner-scale-set names each ephemeral runner after its backing Pod), using the pods-list RBAC the runner-maintenance Role already granted but the script never used; a runner is only deleted when no matching Pod exists, so a runner mid-registration (Pod present, GitHub API briefly reporting offline) is left alone. The now-unused STALE_RUNNER_MINUTES/STALE_THRESHOLD_SECONDS were removed since they cannot be honored from the GitHub API. (2) DELETED_COUNT/CANCELLED_COUNT were incremented inside a `| while read` pipeline subshell, so the job structurally always reported 0 (live-verified: 17:00Z run printed 'Found 1 total runners / Deleted 0 stale runners'); fixed by switching all three read loops in the script to process substitution (`done < <(...)`) so counter updates persist in the parent shell.

## What Changed

- `maintenance/cronjob.yaml`: Step 1 of the runner-maintenance CronJob no longer deletes every offline non-busy runner unconditionally. It now lists Pods in `actions-runner-system` via the Kubernetes API (using the existing pods-list RBAC and a new `POD_NAMESPACE` downward-API env var) and only deletes an offline runner when no backing Pod of that name exists, since ARC names each ephemeral runner after its Pod. If the Pod list can't be fetched (missing service account token or non-200 response), the run fails closed and skips all deletions for that run instead of falling back to deleting every offline runner. The now-unusable `STALE_RUNNER_MINUTES`/`STALE_THRESHOLD_SECONDS` env var and threshold calculation are removed, since the GitHub runners API exposes no per-runner timestamp to honor them.
- `maintenance/cronjob.yaml`: All three `jq ... | while read` pipelines (offline runners, queued runs, in-progress runs) are switched to process substitution (`done < <(...)`) so `DELETED_COUNT`/`CANCELLED_COUNT` increments happen in the parent shell instead of a subshell, fixing counters that always reported 0 regardless of actual deletions/cancellations.
- `TROUBLESHOOTING.md`: Updates the "Clean stale runners" and "Automated Recovery" sections to describe the new Pod-backed staleness check and its fail-closed behavior in place of the old "removes offline runners" description.

## Risk Assessment

✅ Low: The fix round correctly implements fail-closed behavior for both the K8s pod-list HTTP failure and the missing/unreadable service-account-token cases exactly as instructed, preserves Steps 2/3 independence, and the process-substitution counter fix matches the user's stated intent with no other files touched.

## Testing

Extracted the CronJob's embedded bash script from both the base and target commits and ran it end-to-end with mocked `gh`/`curl` (real bash/jq, no live cluster) across 5 scenarios; this reproduced the reported zero-counter bug on the base script, confirmed it reports correct counts on the target script, confirmed the new Pod-correlated staleness check preserves a mid-registration runner while deleting a truly orphaned one, and confirmed the script fails closed (issues zero deletions) when the SA token is missing or the K8s pod-list API errors - all matching the stated intent with no findings.

<details>
<summary>Evidence: Behavioral test transcript: base-vs-fixed counter bug, pod-backed staleness, fail-closed API-error handling</summary>

<code>SCENARIO A1 (base/pre-fix): 2 real DELETE + 2 real CANCEL gh calls issued, yet script prints &#39;Deleted 0 stale runners&#39; / &#39;Cancelled 0 stuck workflow runs&#39;.&#10;SCENARIO A2 (target/fixed): same fixtures -&gt; &#39;Deleted 2 stale runners&#39; / &#39;Cancelled 2 stuck workflow runs&#39;.&#10;SCENARIO B: offline runner with a live backing Pod is SKIPPED (&#39;likely mid-registration&#39;); orphaned offline runner (no Pod) is the only one actually deleted.&#10;SCENARIO C1/C2: missing SA token / HTTP 500 from K8s pod-list API -&gt; fails closed, 0 DELETE_RUNNER calls issued despite offline runners present.</code>

```text
=== Test harness: extracted the CronJob's embedded bash script from both base and
=== target commits of kubernetes/apps/actions-runner-system/maintenance/cronjob.yaml
=== and executed it with mocked gh/curl binaries (real bash/jq, no network, no cluster).

########## SCENARIO A1: BASE (pre-fix) - counter subshell bug repro ##########
  [DELETE] Removing offline runner: runner-pod-aaa (id=101)
  [SUCCESS] Deleted runner runner-pod-aaa
  [DELETE] Removing offline runner: runner-pod-bbb (id=102)
  [SUCCESS] Deleted runner runner-pod-bbb
Deleted 0 stale runners
  [CANCEL] Cancelling stuck run: ci-build
  [SUCCESS] Cancelled run 5001
  [CANCEL] Cancelling stuck run: ci-test
  [SUCCESS] Cancelled run 5002
Cancelled 0 stuck workflow runs
gh DELETE/CANCEL calls actually issued: 4

########## SCENARIO A2: TARGET (fixed) - same fixtures, counters now correct ##########
  [DELETE] Removing offline runner: runner-pod-aaa (id=101)
  [SUCCESS] Deleted runner runner-pod-aaa
  [DELETE] Removing offline runner: runner-pod-bbb (id=102)
  [SUCCESS] Deleted runner runner-pod-bbb
Deleted 2 stale runners
  [CANCEL] Cancelling stuck run: ci-build
  [SUCCESS] Cancelled run 5001
  [CANCEL] Cancelling stuck run: ci-test
  [SUCCESS] Cancelled run 5002
Cancelled 2 stuck workflow runs

########## SCENARIO B: mid-registration protection (live Pod backing an offline runner is preserved) ##########
  [SKIP] runner-pod-live (id=201): offline but backing pod still present, likely mid-registration
  [FOUND] runner-pod-orphan (id=202): offline, no backing pod - orphaned
  [SUCCESS] Deleted runner runner-pod-orphan
  [SKIP] runner-pod-busy (id=203): busy
Deleted 1 stale runners
Runners actually deleted (gh DELETE calls): DELETE_RUNNER:202

########## SCENARIO C1: missing SA token -> fails closed, zero deletions ##########
  [WARNING] Could not read service account token - skipping pod-backed staleness check this run, no offline runners will be deleted
  [SKIP] runner-pod-aaa (id=101): offline, but pod-backed staleness check unavailable this run
  [SKIP] runner-pod-bbb (id=102): offline, but pod-backed staleness check unavailable this run
Deleted 0 stale runners
DELETE_RUNNER calls issued: 0

########## SCENARIO C2: K8s pod-list API returns HTTP 500 -> fails closed, zero deletions ##########
  [WARNING] Failed to list pods in namespace actions-runner-system (HTTP 500) - skipping pod-backed staleness check this run, no offline runners will be deleted
  [SKIP] runner-pod-aaa (id=101): offline, but pod-backed staleness check unavailable this run
  [SKIP] runner-pod-bbb (id=102): offline, but pod-backed staleness check unavailable this run
Deleted 0 stale runners
DELETE_RUNNER calls issued: 0
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"6c732983ffcd24bd8ac034b52f43169ce631446f","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ⚠️ `kubernetes/apps/actions-runner-system/maintenance/cronjob.yaml:84` - The pod-backed staleness check silently degrades to the pre-fix &#39;delete every offline non-busy runner&#39; behavior whenever the in-cluster K8s API call fails or errors. Concrete sequence: gh api .../actions/runners returns an offline runner that is mid-ARC-registration (its backing Pod exists, GitHub just hasn&#39;t marked it online yet - the exact case this fix protects). In the same run, `curl -sS --cacert ... https://kubernetes.default.svc/api/v1/namespaces/${POD_NAMESPACE}/pods` either hard-fails (network blip, apiserver throttling - caught by `2&gt;/dev/null || echo &#34;{}&#34;`) or returns a non-2xx Kubernetes Status body with no `.items` field (curl still exits 0 since `--fail` isn&#39;t passed, e.g. transient 403/5xx). Either path leaves `LIVE_PODS_JSON` without an `.items` array, so `jq -r &#39;.items[]?.metadata.name // empty&#39;` (line 87) emits nothing and `LIVE_POD_NAMES` is empty. In the loop, `grep -qxF &#34;${RUNNER_NAME}&#34; &lt;&lt;&lt;&#34;${LIVE_POD_NAMES}&#34;` (line 106) then matches nothing for that mid-registration runner, the `continue`/[SKIP] branch is never taken, and the runner falls straight into the delete branch - reproducing the original race this change was written to fix, with no log line distinguishing &#39;confirmed orphaned&#39; from &#39;couldn&#39;t check.&#39; The GitHub-API fallback on line 76 defaults to an empty runner list on failure (a safe no-op), but the new K8s pod-list fallback defaults to an empty pod list, which is the unsafe direction here. Recommend treating a failed/non-2xx pod-list fetch as &#39;skip Step 1 deletion this run&#39; (e.g. check curl&#39;s HTTP status or a sentinel, log a warning, and `continue`/return before the delete branch) rather than letting it silently resolve to &#39;no pods exist.&#39;
- ℹ️ `kubernetes/apps/actions-runner-system/maintenance/cronjob.yaml:82` - `K8S_TOKEN=&#34;$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)&#34;` has no `||` fallback, unlike every other fallible call in this script. Under `set -euo pipefail`, if that file is ever unreadable (e.g. automountServiceAccountToken later disabled on this ServiceAccount/pod), the whole job aborts immediately - including Steps 2 and 3&#39;s stuck/queued-run cleanup, which the stated intent explicitly says is &#39;correct and useful&#39; and independent of the pod-based staleness logic. Low likelihood today (the token is mounted by default and nothing in this diff changes that), but worth guarding the same way the curl calls are guarded so an unrelated K8s-API problem can&#39;t take down the GitHub-side cleanup too.

🔧 Fix: {&#34;summary&#34;: &#34;Fail closed on K8s pod-list/token errors instead of deleting all offline runners&#34;}
1 info still open:
- ℹ️ `kubernetes/apps/actions-runner-system/maintenance/cronjob.yaml:95` - The fail-closed gate only flips PODS_LOOKUP_OK=false on a non-200 HTTP status. If the API server ever returns HTTP 200 with a body jq can&#39;t parse (truncated response, proxy interference), `jq -r &#39;.items[]?.metadata.name // empty&#39; ... 2&gt;/dev/null || echo &#34;&#34;` silently swallows the jq failure and LIVE_POD_NAMES stays empty, so every offline runner would look orphaned and get deleted - reproducing the exact race this change fixes. This is a very narrow gap (the K8s API essentially always returns valid JSON on a 200 to this endpoint) so it&#39;s not blocking, but checking jq&#39;s exit status and also setting PODS_LOOKUP_OK=false on parse failure would close it for free.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Extracted the embedded bash command from both base (12b2a76a) and target (ae276424) commits&#39; cronjob.yaml via a YAML-aware parser (not a text diff) and executed each with mocked `gh`/`curl` binaries (real bash+jq, no network/cluster).</code>
- `Scenario A1 (base script, regression repro): 2 offline non-busy runners + 2 stuck queued runs -> gh log shows 2 real DELETE and 2 real CANCEL calls issued, but script prints 'Deleted 0 stale runners' / 'Cancelled 0 stuck workflow runs' (the reported subshell counter bug).`
- `Scenario A2 (target script, fix): identical fixtures -> script prints 'Deleted 2 stale runners' / 'Cancelled 2 stuck workflow runs', matching the 2 real gh calls actually made.`
- `Scenario B (target script, pod-backed staleness): runner with a matching live Pod is skipped ('likely mid-registration'); a runner with no matching Pod is deleted; a busy runner is skipped. gh call log confirms exactly one DELETE (the orphan, id 202) fired.`
- `Scenario C1 (target script, fail-closed): missing serviceaccount token file -> 'skipping pod-backed staleness check this run, no offline runners will be deleted', 0 DELETE calls issued despite 2 offline runners present.`
- `Scenario C2 (target script, fail-closed): K8s pods-list API mocked to return HTTP 500 -> same fail-closed warning and 0 DELETE calls issued.`
- <code>`git status --porcelain` before and after testing confirmed the worktree was left clean (no stray files from the test harness, which lived entirely under /tmp).</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
