### PR TITLE
fix(rook): bump WipeDiskJob image to v20.2.4 to match cluster HelmRelease

### DIFF
--- a/.taskfiles/rook/templates/WipeDiskJob.tmpl.yaml
+++ b/.taskfiles/rook/templates/WipeDiskJob.tmpl.yaml
@@ -21,7 +21,7 @@ spec:
       containers:
         - name: main
           # Pin to the same cephImage.tag as cluster/helmrelease.yaml (Tentacle).
-          image: quay.io/ceph/ceph:v20.2.3
+          image: quay.io/ceph/ceph:v20.2.4
           command: ["/bin/bash", "-c"]
           args:
             - |

--- a/docs/ceph/osd-store-corruption-recovery.md
+++ b/docs/ceph/osd-store-corruption-recovery.md
@@ -82,7 +82,7 @@ Replace `N` and `<by-id-disk>` with the affected OSD and its disk
    task --yes rook:reset-disk disk="<by-id-disk>" node="talos-X"
    ```
    The skip-prompt flag is the global `task --yes`, not `--yes` after the task name.
-   The wipe Job image is `quay.io/ceph/ceph:v20.2.3` (same `cephImage.tag` as the
+   The wipe Job image is `quay.io/ceph/ceph:v20.2.4` (same `cephImage.tag` as the
    cluster HelmRelease). Do not zap a Tentacle OSD with a Reef (v19) image.
    > On Windows the `reset-disk` task can choke on its `envsubst < <(...)` process
    > substitution + interactive prompt. Equivalent manual path: render


### PR DESCRIPTION
## Intent

Bump WipeDiskJob template image from v20.2.3 to v20.2.4 to match the current cluster HelmRelease version (unchanged since PR #1392). Update both the template image tag in .taskfiles/rook/templates/WipeDiskJob.tmpl.yaml and the documentation claims in docs/ceph/osd-store-corruption-recovery.md to reflect the correct Ceph version. The Job is a disk wipe utility and this change ensures the wipe tool uses the same Ceph version as the cluster it operates on.

## What Changed

- Bumped the `quay.io/ceph/ceph` image tag in `.taskfiles/rook/templates/WipeDiskJob.tmpl.yaml` from `v20.2.3` to `v20.2.4` so the disk-wipe Job matches the cluster's `cephImage.tag`.
- Updated the matching image tag reference in `docs/ceph/osd-store-corruption-recovery.md` from `v20.2.3` to `v20.2.4` to keep the recovery runbook consistent with the template.

## Risk Assessment

✅ Low: Two-line version-string bump (v20.2.3 to v20.2.4) in a manually-invoked disk-wipe job template plus the matching doc reference; verified the new tag matches the live cluster HelmRelease's cephImage.tag, and no other stale references remain.

## Testing

Rendered the WipeDiskJob template exactly as `task rook:reset-disk` would (variable substitution + kubectl-apply-ready YAML) and confirmed the resulting Job manifest carries image quay.io/ceph/ceph:v20.2.4, matching the live cluster HelmRelease's cephImage.tag; the doc's prose was updated in lockstep and no stale v20.2.3 references remain outside historical changelog entries. This is a two-line declarative version-bump with no test suite to exercise, so end-to-end template rendering plus cross-referencing the source of truth was the appropriate targeted validation; all checks passed with no findings.

<details>
<summary>Evidence: Rendered WipeDiskJob manifest (envsubst-equivalent path, as task rook:reset-disk would produce)</summary>

```text
---
# IMPORTANT: Clears a single OSD disk so the operator re-provisions it cleanly.
# ceph-volume zap removes BlueStore labels, but `wipefs -af` is required to erase
# the blkid signature that lsblk/the operator key on (without it the disk shows
# FSTYPE=ceph_bluestore and is skipped as "already configured"). blkdiscard does a
# full-device TRIM as a final safeguard.
apiVersion: batch/v1
kind: Job
metadata:
  name: wipe-talos-1-nvme0n1
  namespace: default
spec:
  ttlSecondsAfterFinished: 3600
  template:
    spec:
      automountServiceAccountToken: false
      restartPolicy: Never
      nodeName: talos-1
      hostPID: true
      hostNetwork: true
      containers:
        - name: main
          # Pin to the same cephImage.tag as cluster/helmrelease.yaml (Tentacle).
          image: quay.io/ceph/ceph:v20.2.4
          command: ["/bin/bash", "-c"]
          args:
            - |
              echo "== Wiping disk /host/dev/disk/by-id/nvme-Lexar_SSD_NM790_4TB_NME714W100393P2202 =="
              echo "-- before --"; lsblk -f /host/dev/disk/by-id/nvme-Lexar_SSD_NM790_4TB_NME714W100393P2202 2>/dev/null; wipefs /host/dev/disk/by-id/nvme-Lexar_SSD_NM790_4TB_NME714W100393P2202 2>/dev/null
              # Clear BlueStore labels + LVM metadata via ceph-volume
              ceph-volume lvm zap --destroy /host/dev/disk/by-id/nvme-Lexar_SSD_NM790_4TB_NME714W100393P2202 || echo "ceph-volume lvm zap not applicable"
              # Erase any remaining filesystem/BlueStore signatures (this is what
              # lsblk/blkid key on; without it the operator sees a "configured" disk)
              wipefs -af /host/dev/disk/by-id/nvme-Lexar_SSD_NM790_4TB_NME714W100393P2202 || echo "wipefs failed"
              # Destroy the partition table
              sgdisk --zap-all /host/dev/disk/by-id/nvme-Lexar_SSD_NM790_4TB_NME714W100393P2202 || echo "sgdisk not applicable"
              # Full-device TRIM/discard (forced) to clear all data on the SSD
              blkdiscard -f /host/dev/disk/by-id/nvme-Lexar_SSD_NM790_4TB_NME714W100393P2202 || echo "blkdiscard not supported"
              # Belt-and-suspenders: zero the head of the device
              dd if=/dev/zero of=/host/dev/disk/by-id/nvme-Lexar_SSD_NM790_4TB_NME714W100393P2202 bs=1M count=100 oflag=direct conv=fsync || true
              partprobe /host/dev/disk/by-id/nvme-Lexar_SSD_NM790_4TB_NME714W100393P2202 || true
              udevadm settle 2>/dev/null || true
              echo "-- after --"; lsblk -f /host/dev/disk/by-id/nvme-Lexar_SSD_NM790_4TB_NME714W100393P2202 2>/dev/null; wipefs /host/dev/disk/by-id/nvme-Lexar_SSD_NM790_4TB_NME714W100393P2202 2>/dev/null
              echo "Disk wipe complete for /host/dev/disk/by-id/nvme-Lexar_SSD_NM790_4TB_NME714W100393P2202"
          securityContext:
            privileged: true
          resources: {}
          volumeMounts:
            - name: host-dev
              mountPath: /host/dev
              mountPropagation: Bidirectional
      volumes:
        - name: host-dev
          hostPath:
            path: /dev
            type: Directory
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"32a875e4eeeff036a0379565b099b74478a38c98","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `git diff 8f9171d6..32a875e4 to confirm the change is limited to the image tag in .taskfiles/rook/templates/WipeDiskJob.tmpl.yaml and the matching prose in docs/ceph/osd-store-corruption-recovery.md`
- `grep cephImage.tag in kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml to confirm the live cluster HelmRelease is pinned to v20.2.4, matching the bumped template`
- <code>Rendered .taskfiles/rook/templates/WipeDiskJob.tmpl.yaml through the same ${job}/${node}/${disk} variable-substitution path that `task rook:reset-disk` uses (envsubst binary unavailable in the sandbox, so substituted equivalently), then parsed the result with PyYAML to confirm it is a valid Job manifest carrying image: quay.io/ceph/ceph:v20.2.4</code>
- `grep -rn 'v20.2.3' across the repo to confirm no other non-historical reference to the old tag was left stale; remaining hits are all changelog entries correctly describing past cluster state`
- `git status --porcelain after cleanup to confirm no stray artifacts were left in the worktree`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
