### PR TITLE
fix(network): point cloudflare Kustomizations at their app directory

### DIFF
--- a/kubernetes/apps/network/cloudflare-dns/ks.yaml
+++ b/kubernetes/apps/network/cloudflare-dns/ks.yaml
@@ -10,7 +10,7 @@ spec:
     labels:
       app.kubernetes.io/name: *app
   interval: 1h
-  path: ./kubernetes/apps/network/cloudflare-dns
+  path: ./kubernetes/apps/network/cloudflare-dns/app
   postBuild:
     substituteFrom:
       - name: cluster-secrets

--- a/kubernetes/apps/network/cloudflare-tunnel/ks.yaml
+++ b/kubernetes/apps/network/cloudflare-tunnel/ks.yaml
@@ -10,7 +10,7 @@ spec:
     labels:
       app.kubernetes.io/name: *app
   interval: 1h
-  path: ./kubernetes/apps/network/cloudflare-tunnel
+  path: ./kubernetes/apps/network/cloudflare-tunnel/app
   postBuild:
     substituteFrom:
       - name: cluster-secrets


### PR DESCRIPTION
## Intent

Step 2 of a deliberate 3-PR sequence removing a self-deletion landmine from the Flux Kustomizations network/cloudflare-dns and network/cloudflare-tunnel. Step 1 (PR #1415, prune: true -> false on both) is already merged and live-verified: both reconcile Ready with prune=false at merge commit cc67b9b3. This PR must contain ONLY the two-line spec.path change on those two ks.yaml files - nothing else.

The change: spec.path ./kubernetes/apps/network/<app> -> ./kubernetes/apps/network/<app>/app.

Background a reviewer cannot see in the diff: each Kustomization's spec.path pointed at its OWN directory, which also contains its ks.yaml, and that directory has no kustomization.yaml. Flux's kustomize-controller therefore autodetects every yaml under the path, picking up ks.yaml itself, so each Kustomization rendered and owned a copy of itself and carried its own <ns>_<name>_kustomize.toolkit.fluxcd.io_Kustomization entry in status.inventory. Verified live: these two were the only self-referencing objects in the entire cluster. That is the landmine - with prune enabled, dropping the self entry makes each Kustomization garbage-collect ITSELF and cascade into the cloudflare tunnel Deployment, DNSEndpoint, PodDisruptionBudget, ExternalSecret and OCIRepository, i.e. all public ingress.

Why pointing at app/ is the right fix and is NOT an arbitrary path change: the other six Kustomizations in this same namespace (echo, unifi-dns, flaresolverr, envoy-gateway, and both certificates entries) already point at a subdirectory rather than their own root. This change makes these two consistent with that existing convention, and it matches the eventual target split layout where they become base/network/<app>/app. The app/ directory already contains an explicit kustomization.yaml listing only the real resources, so ks.yaml can never be autodetected again and the self-render shape cannot regress. That is why no new kustomization.yaml file is added by this PR - the anti-regression guard already exists at the destination, and adding one at the now-unused app root would be inert because nothing references that directory.

Rendering is otherwise unchanged, and this was proven before commit with kustomize build of the new paths:
cloudflare-dns/app -> ExternalSecret, HelmRelease, OCIRepository, PrometheusRule (4 resources)
cloudflare-tunnel/app -> DNSEndpoint, ExternalSecret, GrafanaDashboard, HelmRelease, OCIRepository, PodDisruptionBudget (6 resources)
'kind: Kustomization' count is 0 for both.
Those are exactly the resources already live in each Kustomization's status.inventory (5 and 7 entries) minus the self entry. No real resource is dropped, added or modified - the ONLY behavioral delta is that each Kustomization stops rendering itself.

Safety: prune is still false from step 1, so dropping the self entry from the inventory cannot delete anything. Step 3 (a separate later PR) restores prune: true once the inventories are confirmed clean live. Do not expand this PR's scope to also restore prune or to perform the wider namespace restructure - those are deliberately separate and gated on this PR being merged and live-verified first.

## What Changed

- Changed `spec.path` on `kubernetes/apps/network/cloudflare-dns/ks.yaml` from `./kubernetes/apps/network/cloudflare-dns` to `./kubernetes/apps/network/cloudflare-dns/app`.
- Changed `spec.path` on `kubernetes/apps/network/cloudflare-tunnel/ks.yaml` from `./kubernetes/apps/network/cloudflare-tunnel` to `./kubernetes/apps/network/cloudflare-tunnel/app`.
- Both Kustomizations now build from the `app/` subdirectory, which has its own `kustomization.yaml` listing only the real resources, so `kustomize-controller` no longer autodetects and renders each Kustomization's own `ks.yaml` as a self-referencing object in its inventory.

## Risk Assessment

✅ Low: The diff is exactly the two one-line spec.path changes described, verified live: prune is still false on both Kustomizations (so no GC can occur regardless), the new app/ paths already carry a scoped kustomization.yaml, and kubectl kustomize on both new paths renders precisely the claimed resource sets with zero Kustomization-kind self-references, matching the eventual live inventory minus the self entry.

## Testing

Targeted validation confirms this PR is scoped to exactly the two-line spec.path change on network/cloudflare-dns and network/cloudflare-tunnel's ks.yaml files, and that kustomize builds of the two new app/ paths render precisely the resource sets and zero-Kustomization-count claimed in the intent (4 resources for cloudflare-dns, 6 for cloudflare-tunnel), with prune: false left untouched from step 1. No repo-native flux-local automated test exists locally (flux-local requires Docker/the CI container action and is not installed in this environment, and its --all-namespaces mode would exceed targeted scope per project notes on task flux:test:ns), so kubectl kustomize against the exact changed paths served as the smallest relevant direct reproduction of the intent's own pre-commit proof. All checks pass; no findings.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"cd1d2b8f07175083fc258e1043a976a8a145f6e0","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`git diff cc67b9b3..cd1d2b8f --stat` / full diff — confirms only 2 files changed, 2 insertions/2 deletions total, both being the spec.path edit</code>
- <code>`kubectl kustomize kubernetes/apps/network/cloudflare-dns/app --load-restrictor LoadRestrictionsNone` — renders exactly ExternalSecret, HelmRelease, OCIRepository, PrometheusRule (4 resources), 0 Kustomization kind</code>
- <code>`kubectl kustomize kubernetes/apps/network/cloudflare-tunnel/app --load-restrictor LoadRestrictionsNone` — renders exactly DNSEndpoint, ExternalSecret, GrafanaDashboard, HelmRelease, OCIRepository, PodDisruptionBudget (6 resources), 0 Kustomization kind</code>
- <code>`kubectl kustomize kubernetes/apps/network/cloudflare-dns` (old root path) — confirms client-side kustomize now errors without an explicit kustomization.yaml at that root (the app/ directory&#39;s kustomization.yaml is the anti-regression guard the intent describes; the original Flux-controller autodetect landmine on the old root path is a live-cluster behavior already verified per the intent, not reproducible with client-side kustomize)</code>
- <code>`grep prune: kubernetes/apps/network/cloudflare-dns/ks.yaml kubernetes/apps/network/cloudflare-tunnel/ks.yaml` — confirms prune: false is untouched in both files, preserving the step-1 safety invariant</code>
- <code>`git status --porcelain` — confirms clean worktree, no stray files added (no new kustomization.yaml, no scope creep)</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
