### PR TITLE
fix(agentmemory): de-harmonise auto-forget timer and raise memory limit to 4Gi

### DIFF
--- a/kubernetes/apps/ai/agentmemory/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/agentmemory/app/helmrelease.yaml
@@ -97,6 +97,16 @@ spec:
               # per-session — now on OpenRouter deepseek-v4-flash (concurrent, cheap).
               CONSOLIDATION_ENABLED: "true"
               GRAPH_EXTRACTION_ENABLED: "true"
+              # De-harmonise auto-forget (default 60 min) from consolidation
+              # (default 120 min). Both setInterval timers are anchored to
+              # process start, so they coincide every 120 min and that tick
+              # allocates +647 MiB of anon in 417 ms past the old 3Gi limit.
+              # 86400000 ms = 24 h; coincidence drops to once a day. The
+              # app reads AUTO_FORGET_INTERVAL_MS (confirmed in 0.9.29
+              # dist/index.mjs). TTL-expired memories linger up to 24 h
+              # instead of 1 h; both observed runs reclaimed nothing and
+              # the store has been flat at 461 MiB for a week.
+              AUTO_FORGET_INTERVAL_MS: "86400000"
               # Phase 2b (2026-06-28): per-observation LLM compression RE-ENABLED.
               # Runs the LLM on EVERY observation for richer summaries. It was OFF
               # because the old local 35B (then treated as serial) made ~95% of compressions time
@@ -155,30 +165,29 @@ spec:
                   failureThreshold: 60
                   periodSeconds: 5
             resources:
-              # Measured via container_memory_working_set_bytes, 2026-08-08 to
-              # -22 (full Prometheus retention): baseline right after a cold
-              # start is already ~1.47-1.78Gi within a minute (loading the
-              # memory/embedding store into RAM, not a leak from zero), then
-              # climbs another ~250-560Mi over the following ~55-60 min until
-              # it hits the old 2Gi limit and gets OOMKilled - a cycle that
-              # repeats hourly, every day, for the full two-week retention
-              # window with the ceiling flat at ~2020-2045Mi each time.
-              # Every one of those cycles was cut off by the old 2Gi limit
-              # before the process could reveal whether growth would keep
-              # climbing or level off just above it, so this evidence alone
-              # cannot fully rule out an unbounded leak - it only shows
-              # growth well past 2Gi, not where it would actually plateau.
-              # Sized 3Gi as real headroom above the last observed (clipped)
-              # value rather than doubling blind; request raised from 256Mi
-              # (8x below the measured baseline, badly mis-scheduling the
-              # node) to match it. If OOMKills recur at 3Gi, that recurrence
-              # is itself the leak signal - this is a mitigation that buys
-              # headroom, not a proven cure.
+              # Not a leak. d42527ec's fallback ("if OOMKills recur at 3Gi,
+              # that recurrence is itself the leak signal") does not hold.
+              # Two process-start-anchored setInterval timers -
+              # mem::auto-forget (60 min) and mem::consolidate-pipeline
+              # (120 min) - coincide every 120 min. The coincident tick
+              # allocates +647 MiB of anon in 417 ms; the measured floor
+              # for that tick to complete is ~3588 MiB (~3.5 GiB):
+              #   2340 MiB stable pre-tick memory.current
+              # +  890 MiB iii address-space growth during the tick
+              # +  358 MiB Node growth during the tick
+              # Two kill modes: fast kernel OOM, and a 90s memcg reclaim
+              # stall that starves the liveness probe (exit 137, reason
+              # Error, no OOMKilled). AUTO_FORGET_INTERVAL_MS=86400000
+              # de-harmonises the timers; 4Gi (request 2Gi, same 1:2 ratio
+              # as 1536Mi/3Gi) clears the ~3.5 GiB floor with ~500 MiB
+              # margin. Watch container_memory_usage_bytes, not working_set:
+              # working_set hides ~548 MiB of this cgroup's page cache
+              # (mmap'd state_store.db).
               requests:
                 cpu: 100m
-                memory: 1536Mi
+                memory: 2Gi
               limits:
-                memory: 3Gi
+                memory: 4Gi
             securityContext:
               allowPrivilegeEscalation: false
               capabilities:


### PR DESCRIPTION
## Intent

Apply the captain's chosen agentmemory remediation - BOTH halves - exactly as diagnosed in /Users/coder/firstmate/data/homeops-agentmemory-oom-diagnosis/report.md (decision record: /Users/coder/firstmate/data/homeops-agentmemory-oom-diagnosis/decision-remediation-choice.md). There is no leak: the 60-minute auto-forget and 120-minute consolidation timers are anchored to process start and coincide every 120 minutes, allocating 647MiB of anon in 417ms past the 3Gi limit (measured coincident-tick floor ~3.5GiB); two kill modes were instrumented (fast kernel OOM, and a reclaim stall that starves the liveness probe).

The change is all in kubernetes/apps/ai/agentmemory/:
1. Set AUTO_FORGET_INTERVAL_MS=86400000 in the HelmRelease env so the timers de-harmonise (coincidence drops from every 2h to once a day). Verify against the report's appendix which env var name the app actually reads - the report documents the timer registration it observed; match reality, not a guessed name.
2. Raise the container memory limit to 4Gi (requests stay proportionate). Quote the measured floor in the PR body so the number is evidence-based, not a blind bump.
3. Correct the misleading comment block at the HelmRelease that frames recurrence-at-3Gi as a leak signal - the diagnosis disproved that inference; point the comment at the report's mechanism instead so nobody re-runs the leak hunt.
4. The report's "do regardless" item: any agentmemory dashboard/alert in this repo that reads container_memory_working_set_bytes for this workload should use container_memory_usage_bytes (working_set hides ~548 MiB of its page cache). Fix only agentmemory-scoped panels/rules; do not rework general dashboards.

After merge the pod restarts with the new env/limit - that is Flux's normal reconcile, nothing manual. Keep the diff tight; everything else about the workload stays as it is.

Decisions made while implementing:
- Env var name confirmed as AUTO_FORGET_INTERVAL_MS from the 0.9.29 dist/index.mjs dump in the diagnosis report (parseInt(process.env.AUTO_FORGET_INTERVAL_MS || "3600000")).
- Memory request scaled 1536Mi -> 2Gi to keep the same 1:2 request:limit ratio as 1536Mi/3Gi.
- Measured coincident-tick floor quoted as ~3588 MiB (~3.5 GiB): 2340 MiB stable pre-tick memory.current + 890 MiB iii address-space growth + 358 MiB Node growth; 4Gi clears that with ~500 MiB margin.
- Repo search found no agentmemory-scoped dashboard or PrometheusRule reading container_memory_working_set_bytes; the metric trap is documented on the resources comment instead. General dashboards (coder, cert-manager, rook-ceph, agentgateway, surrealdb) were left untouched.

## What Changed

- Added `AUTO_FORGET_INTERVAL_MS: "86400000"` to the agentmemory HelmRelease env, de-harmonising the 60-minute auto-forget timer from the 120-minute consolidation timer (both anchored to process start) so their coincidence drops from every 2 hours to once a day.
- Raised the container memory limit from 3Gi to 4Gi and scaled the request from 1536Mi to 2Gi (keeping the same 1:2 request:limit ratio), clearing the measured coincident-tick floor of ~3588 MiB (~3.5 GiB) with ~500 MiB of margin.
- Rewrote the `resources` comment block: it no longer frames OOMKill recurrence at the old 3Gi limit as a leak signal, and instead documents the diagnosed timer-coincidence mechanism, the two observed kill modes (fast kernel OOM and a liveness-starving reclaim stall), and that `container_memory_usage_bytes` should be watched instead of `working_set_bytes` (which hides ~548 MiB of page cache from the mmap'd state store).

## Risk Assessment

✅ Low: Single-file, tightly-scoped config change that implements exactly the captain's authorized two-part remediation (env var de-harmonisation + evidence-based limit bump) plus the corrected comment and verified no-op on the dashboard/alert item; numbers in the new comment match the diagnosis report and decision record precisely, and no reachable gap in the fix was found.

## Testing

This is a GitOps-only YAML change (no app code, no tests to run), so I cross-checked every diagnosed fact against /Users/coder/firstmate/data/homeops-agentmemory-oom-diagnosis/{report.md,decision-remediation-choice.md}: the env var name AUTO_FORGET_INTERVAL_MS matches the report's 0.9.29 dist/index.mjs excerpt (line 211), the 647 MiB/417 ms burst and ~3588 MiB coincident-tick floor figures in the new resources comment match the report verbatim, the two-kill-mode description (kernel OOM vs. liveness-starving reclaim stall) matches report section 12, and the request:limit ratio (2Gi:4Gi) preserves the prior 1536Mi:3Gi 1:2 ratio. I also grepped the whole kubernetes/ tree for container_memory_working_set_bytes and confirmed no agentmemory-scoped dashboard or PrometheusRule exists (only surrealdb, cert-manager, rook-ceph, coder use it, all explicitly left untouched per the decision record - satisfying the 'fix only agentmemory-scoped panels, do not rework general dashboards' constraint by having nothing in-scope to change). Finally I ran `kubectl kustomize kubernetes/apps/ai/agentmemory/app --load-restrictor LoadRestrictionsNone`, the same manifest-rendering path flux-local/Flux itself uses, and confirmed it builds cleanly with AUTO_FORGET_INTERVAL_MS: \"86400000\", limits.memory: 4Gi, and requests.memory: 2Gi present in the exact output Flux would apply to the cluster - the closest available end-to-end evidence without a live cluster to reconcile against. No issues found.

<details>
<summary>Evidence: kustomize-rendered agentmemory HelmRelease (env + resources)</summary>

<code>AUTO_FORGET_INTERVAL_MS: &#34;86400000&#34;&#10;...&#10;limits:&#10;memory: 4Gi&#10;requests:&#10;cpu: 100m&#10;memory: 2Gi</code>

```text
apiVersion: external-secrets.io/v1
kind: ExternalSecret
metadata:
  name: agentmemory
  namespace: ai
spec:
  dataFrom:
  - extract:
      key: agentmemory
  refreshInterval: 1h
  secretStoreRef:
    kind: ClusterSecretStore
    name: onepassword
  target:
    name: agentmemory
    template:
      data:
        AGENTMEMORY_SECRET: '{{ .AGENTMEMORY_SECRET }}'
---
apiVersion: helm.toolkit.fluxcd.io/v2
kind: HelmRelease
metadata:
  name: agentmemory
  namespace: ai
spec:
  chartRef:
    kind: OCIRepository
    name: app-template
  install:
    remediation:
      retries: -1
  interval: 1h
  upgrade:
    cleanupOnFail: true
    remediation:
      retries: 3
  values:
    controllers:
      agentmemory:
        annotations:
          reloader.stakater.com/auto: "true"
        containers:
          app:
            command:
            - /usr/bin/catatonit
            - --
            - /bin/sh
            - -c
            - |
              PREFS_HOME="${HOME:-/home/node}"
              mkdir -p "$PREFS_HOME/.agentmemory"
              if [ ! -s "$PREFS_HOME/.agentmemory/preferences.json" ]; then
                printf '%s\n' '{"schemaVersion":1,"lastAgent":null,"lastAgents":[],"lastProvider":null,"skipSplash":true,"skipNpxHint":true,"skipGlobalInstall":true,"skipConsoleInstall":true,"firstRunAt":"1970-01-01T00:00:00.000Z"}' > "$PREFS_HOME/.agentmemory/preferences.json"
              fi
              exec /entrypoint.sh
            env:
              AGENTMEMORY_AUTO_COMPRESS: "true"
              AGENTMEMORY_DROP_STALE_INDEX: "true"
              AGENTMEMORY_LLM_TIMEOUT_MS: "120000"
              AGENTMEMORY_REFLECT: "true"
              AGENTMEMORY_TOOLS: all
              AGENTMEMORY_VIEWER_HOST: 0.0.0.0
              AUTO_FORGET_INTERVAL_MS: "86400000"
              CONSOLIDATION_DECAY_DAYS: "60"
              CONSOLIDATION_ENABLED: "true"
              EMBEDDING_PROVIDER: openai
              GRAPH_EXTRACTION_ENABLED: "true"
              III_REST_PORT: "3111"
              OPENAI_API_KEY: local
              OPENAI_API_KEY_FOR_LLM: "true"
              OPENAI_BASE_URL: http://internal-noauth.ai.svc.cluster.local/v1
              OPENAI_EMBEDDING_DIMENSIONS: "1536"
              OPENAI_EMBEDDING_MODEL: openai/text-embedding-3-small
              OPENAI_MODEL: deepseek/deepseek-v4-flash
              RUST_LOG: warn
              SNAPSHOT_ENABLED: "false"
              SUMMARIZE_CHUNK_CONCURRENCY: "2"
              TZ: ${CONFIG_TIMEZONE}
              VIEWER_ALLOWED_HOSTS: agentmemory.${SECRET_DOMAIN}
              VIEWER_ALLOWED_ORIGINS: https://agentmemory.${SECRET_DOMAIN}
            envFrom:
            - secretRef:
                name: agentmemory
            image:
              repository: ghcr.io/joryirving/agentmemory
              tag: 0.9.29@sha256:74f1175c9ed75e1a00cdedab60560926d941f4dd6624efa0ebf7a7b27f071e72
            probes:
              liveness:
                custom: true
                enabled: true
                spec:
                  failureThreshold: 3
                  httpGet:
                    path: /agentmemory/livez
                    port: 3111
                  initialDelaySeconds: 0
                  periodSeconds: 30
                  timeoutSeconds: 5
              readiness:
                custom: true
                enabled: true
                spec:
                  failureThreshold: 3
                  httpGet:
                    path: /agentmemory/livez
                    port: 3111
                  initialDelaySeconds: 0
                  periodSeconds: 30
                  timeoutSeconds: 5
              startup:
                custom: true
                enabled: true
                spec:
                  failureThreshold: 60
                  httpGet:
                    path: /agentmemory/livez
                    port: 3111
                  periodSeconds: 5
            resources:
              limits:
                memory: 4Gi
              requests:
                cpu: 100m
                memory: 2Gi
            securityContext:
              allowPrivilegeEscalation: false
              capabilities:
                drop:
                - ALL
        replicas: 1
        strategy: Recreate
    defaultPodOptions:
      securityContext:
        fsGroup: 1000
        fsGroupChangePolicy: OnRootMismatch
        runAsGroup: 1000
        runAsNonRoot: true
        runAsUser: 1000
        seccompProfile:
          type: RuntimeDefault
    persistence:
      data:
        existingClaim: agentmemory
        globalMounts:
        - path: /data
        - path: /home/node
      tmp:
        globalMounts:
        - path: /tmp
        type: emptyDir
    route:
      app:
        hostnames:
        - '{{ .Release.Name }}.${SECRET_DOMAIN}'
        parentRefs:
        - name: envoy-internal
          namespace: network
          sectionName: https
        rules:
        - backendRefs:
          - name: agentmemory
            port: 3111
          matches:
          - path:
              type: PathPrefix
              value: /agentmemory
        - backendRefs:
          - name: agentmemory
            port: 3112
          matches:
          - path:
              type: PathPrefix
              value: /stream
        - backendRefs:
          - name: agentmemory
            port: 3112
          matches:
          - headers:
            - name: Upgrade
              value: websocket
            path:
              type: PathPrefix
              value: /
        - backendRefs:
          - name: agentmemory
            port: 3113
    service:
      app:
        ports:
          api:
            port: 3111
          streams:
            port: 3112
          viewer:
            port: 3113
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"a3fc5c7437b7da1c252c9cf525f893dc58aefff3","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `git diff efa0c5c3 a3fc5c74 -- kubernetes/apps/ai/agentmemory/app/helmrelease.yaml (reviewed full diff)`
- `grep -n "AUTO_FORGET_INTERVAL_MS|CONSOLIDATION_INTERVAL_MS|process.env.AUTO_FORGET" against report.md to confirm env var name evidence`
- `grep -n "3588|647 MiB|417 ms|548 MiB|kernel OOM|reclaim stall" against report.md to confirm resources-comment figures are accurate quotes, not fabricated`
- `grep -rln container_memory_working_set_bytes kubernetes/ to confirm no agentmemory-scoped dashboard/alert needed changing`
- <code>`kubectl kustomize kubernetes/apps/ai/agentmemory/app --load-restrictor LoadRestrictionsNone` to render the real manifest Flux would apply and confirm exact env/resource values</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
