### PR TITLE
fix(network): re-enable prune on cloudflare Kustomizations

### DIFF
--- a/kubernetes/apps/network/cloudflare-dns/ks.yaml
+++ b/kubernetes/apps/network/cloudflare-dns/ks.yaml
@@ -15,7 +15,7 @@ spec:
     substituteFrom:
       - name: cluster-secrets
         kind: Secret
-  prune: false
+  prune: true
   retryInterval: 2m
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/network/cloudflare-tunnel/ks.yaml
+++ b/kubernetes/apps/network/cloudflare-tunnel/ks.yaml
@@ -18,7 +18,7 @@ spec:
   dependsOn:
     - name: onepassword-store
       namespace: security
-  prune: false
+  prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system


### PR DESCRIPTION
## Intent

Step 3 of 3, the final step of a deliberate 3-PR sequence that removed a self-deletion landmine from the Flux Kustomizations network/cloudflare-dns and network/cloudflare-tunnel. This PR must contain ONLY the two-line change setting spec.prune from false back to true on those two ks.yaml files - nothing else.

The full sequence, for context a reviewer cannot get from this diff alone:
Step 1 (PR #1415, merged, live-verified): prune true -> false on both.
Step 2 (PR #1420, merged, live-verified): spec.path ./kubernetes/apps/network/<app> -> ./kubernetes/apps/network/<app>/app.
Step 3 (this PR): prune false -> true, restoring the repo default.

The original defect: each Kustomization's spec.path pointed at its OWN directory, which also contains its ks.yaml, and that directory had no kustomization.yaml. Flux's kustomize-controller autodetects every yaml under the path, so it picked up ks.yaml itself and each Kustomization rendered and owned a copy of itself, carrying its own <ns>_<name>_kustomize.toolkit.fluxcd.io_Kustomization entry in status.inventory. These were the only two self-referencing objects in the entire cluster. Moving spec.path with prune enabled would have made each Kustomization garbage-collect ITSELF and cascade into the cloudflare tunnel Deployment, DNSEndpoint, PodDisruptionBudget, ExternalSecret and OCIRepository - i.e. all public ingress. Hence the three-step dance rather than one commit.

Why restoring prune is safe now, verified live against the cluster after step 2 merged:
- Both Kustomizations are Ready at the new app/ path at merge commit ae21e8d9.
- cloudflare-dns inventory went 5 -> 4 entries; cloudflare-tunnel 7 -> 6. In both cases the ONLY entry removed is the Kustomization's own self entry; every real resource (ExternalSecret, HelmRelease, OCIRepository, PrometheusRule / DNSEndpoint, GrafanaDashboard, PodDisruptionBudget) is retained.
- The cluster-wide self-inventory scan now returns nothing at all - the self-referencing class is eliminated, not merely mitigated.
- Public ingress never dropped: all 12 network pods Running with 0 restarts, and the cascade targets still carry their original ages (DNSEndpoint 346d, PDB 114d, OCIRepositories 308d), proving they were never deleted and recreated.

Because the live inventories already match exactly what the new path renders, turning prune back on produces no inventory diff and therefore collects nothing. prune: true is the repo default and the same posture as the six sibling Kustomizations in this namespace, so this PR returns the two objects to normal rather than introducing new behavior. The temporary prune: false from step 1 was always intended to be reverted here.

## What Changed

- Set `spec.prune` back to `true` on the `network/cloudflare-dns` and `network/cloudflare-tunnel` Flux Kustomizations (`kubernetes/apps/network/cloudflare-dns/ks.yaml`, `kubernetes/apps/network/cloudflare-tunnel/ks.yaml`), restoring the repo-default pruning behavior on both.

## Risk Assessment

✅ Low: The diff is exactly the two-line prune:false→prune:true change on both Kustomizations as required by the intent; the prerequisite path change (step 2) is already live and confirmed present on disk with app/ directories containing proper kustomization.yaml files, so re-enabling prune restores the repo default without reintroducing the self-referencing GC landmine.

## Testing

`Confirmed the PR is exactly the claimed two-line prune:false->true flip on both cloudflare-dns and cloudflare-tunnel ks.yaml with no other changes, then used flux-local (the same engine backing the repo's CI Flux-Local Test job) to actually build both Kustomizations at their spec.path - both built successfully and rendered precisely the owned-resource sets the intent says are the only surviving live inventory entries, with zero self-referencing Kustomization objects in either output, structurally proving the self-deletion landmine this PR re-enables prune against is gone. No cluster access was available to re-verify live reconciliation, but that was already done by the author per the PR description for steps 1-2, and this step introduces no new path/spec behavior beyond the prune flag - only a boolean field flip, which the build output confirms is inert against the current tree.`

<details>
<summary>Evidence: Diff + flux-local build verification summary</summary>

```text
=== git diff ae21e8d9..28e23111 (target vs base) ===
diff --git a/kubernetes/apps/network/cloudflare-dns/ks.yaml b/kubernetes/apps/network/cloudflare-dns/ks.yaml
index 7458c780..7d246f61 100644
--- a/kubernetes/apps/network/cloudflare-dns/ks.yaml
+++ b/kubernetes/apps/network/cloudflare-dns/ks.yaml
@@ -15,7 +15,7 @@ spec:
     substituteFrom:
       - name: cluster-secrets
         kind: Secret
-  prune: false
+  prune: true
   retryInterval: 2m
   sourceRef:
     kind: GitRepository
diff --git a/kubernetes/apps/network/cloudflare-tunnel/ks.yaml b/kubernetes/apps/network/cloudflare-tunnel/ks.yaml
index a0f3f1af..c54e4e46 100644
--- a/kubernetes/apps/network/cloudflare-tunnel/ks.yaml
+++ b/kubernetes/apps/network/cloudflare-tunnel/ks.yaml
@@ -18,7 +18,7 @@ spec:
   dependsOn:
     - name: onepassword-store
       namespace: security
-  prune: false
+  prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system

=== flux-local build kustomization cloudflare-dns (exit 0, kinds rendered) ===
   1 kind: ExternalSecret
   1 kind: HelmRelease
   1 kind: OCIRepository
   1 kind: PrometheusRule

=== flux-local build kustomization cloudflare-tunnel (exit 0, kinds rendered) ===
   1 kind: DNSEndpoint
   1 kind: ExternalSecret
   1 kind: GrafanaDashboard
   1 kind: HelmRelease
   1 kind: OCIRepository
   1 kind: PodDisruptionBudget

No 'kind: Kustomization' (self-reference) present in either build output: confirmed absent.
```
</details>
<details>
<summary>Evidence: flux-local rendered output for cloudflare-dns (no self-reference)</summary>

```text
---
apiVersion: external-secrets.io/v1
kind: ExternalSecret
metadata:
  labels:
    app.kubernetes.io/name: cloudflare-dns
    kustomize.toolkit.fluxcd.io/name: cloudflare-dns
    kustomize.toolkit.fluxcd.io/namespace: network
  name: cloudflare-dns
  namespace: network
  annotations:
    config.kubernetes.io/index: '0'
    internal.config.kubernetes.io/index: '0'
spec:
  dataFrom:
  - extract:
      key: cloudflare
  secretStoreRef:
    kind: ClusterSecretStore
    name: onepassword
  target:
    name: cloudflare-dns-secret
    template:
      data:
        CF_API_TOKEN: '{{ .CLOUDFLARE_DNS_TOKEN }}'
        CF_ZONE_ID: '{{ .CLOUDFLARE_ZONE_ID }}'
---
apiVersion: helm.toolkit.fluxcd.io/v2
kind: HelmRelease
metadata:
  labels:
    app.kubernetes.io/name: cloudflare-dns
    kustomize.toolkit.fluxcd.io/name: cloudflare-dns
    kustomize.toolkit.fluxcd.io/namespace: network
  name: cloudflare-dns
  namespace: network
  annotations:
    config.kubernetes.io/index: '1'
    internal.config.kubernetes.io/index: '1'
spec:
  chartRef:
    kind: OCIRepository
    name: cloudflare-dns
  install:
    crds: CreateReplace
    strategy:
      name: RetryOnFailure
  interval: 1h
  rollback:
    cleanupOnFail: true
    recreate: true
  upgrade:
    cleanupOnFail: true
    crds: CreateReplace
    remediation:
      remediateLastFailure: true
      retries: 2
    strategy:
      name: RemediateOnFailure
  values:
    domainFilters:
    - ${SECRET_DOMAIN}
    env:
    - name: CF_API_TOKEN
      valueFrom:
        secretKeyRef:
          key: CF_API_TOKEN
          name: cloudflare-dns-secret
    - name: CF_ZONE_ID
      valueFrom:
        secretKeyRef:
          key: CF_ZONE_ID
          name: cloudflare-dns-secret
    extraArgs:
    - --cloudflare-dns-records-per-page=1000
    - --cloudflare-proxied
    - --crd-source-apiversion=externaldns.k8s.io/v1alpha1
    - --crd-source-kind=DNSEndpoint
    - --gateway-name=envoy-external
    - --zone-id-filter=$(CF_ZONE_ID)
    fullnameOverride: cloudflare-dns
    podAnnotations:
      secret.reloader.stakater.com/reload: cloudflare-dns-secret
    policy: sync
    provider:
      name: cloudflare
    resources:
      limits:
        memory: 64Mi
      requests:
        cpu: 10m
        memory: 32Mi
    serviceMonitor:
      enabled: true
    sources:
    - crd
    - gateway-httproute
    triggerLoopOnEvent: true
    txtOwnerId: default
    txtPrefix: k8s.
---
apiVersion: source.toolkit.fluxcd.io/v1
kind: OCIRepository
metadata:
  labels:
    app.kubernetes.io/name: cloudflare-dns
    kustomize.toolkit.fluxcd.io/name: cloudflare-dns
    kustomize.toolkit.fluxcd.io/namespace: network
  name: cloudflare-dns
  namespace: network
  annotations:
    config.kubernetes.io/index: '2'
    internal.config.kubernetes.io/index: '2'
spec:
  interval: 15m
  layerSelector:
    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
    operation: copy
  ref:
    tag: 1.21.1
  url: oci://ghcr.io/home-operations/charts-mirror/external-dns
---
apiVersion: monitoring.coreos.com/v1
kind: PrometheusRule
metadata:
  labels:
    app.kubernetes.io/name: cloudflare-dns
    kustomize.toolkit.fluxcd.io/name: cloudflare-dns
    kustomize.toolkit.fluxcd.io/namespace: network
  name: external-dns-rules
  namespace: network
  annotations:
    config.kubernetes.io/index: '3'
    internal.config.kubernetes.io/index: '3'
spec:
  groups:
  - name: external-dns.rules
    rules:
    - alert: ExternalDNSStale
      annotations:
        summary: ExternalDNS ({{ $labels.job }}) has not synced successfully in the last five minutes
      expr: time() - external_dns_controller_last_sync_timestamp_seconds > 60
      for: 5m
      labels:
        severity: critical
```
</details>
<details>
<summary>Evidence: flux-local rendered output for cloudflare-tunnel (no self-reference)</summary>

```text
---
apiVersion: external-secrets.io/v1
kind: ExternalSecret
metadata:
  labels:
    app.kubernetes.io/name: cloudflare-tunnel
    kustomize.toolkit.fluxcd.io/name: cloudflare-tunnel
    kustomize.toolkit.fluxcd.io/namespace: network
  name: cloudflare-tunnel-secret
  namespace: network
  annotations:
    config.kubernetes.io/index: '0'
    internal.config.kubernetes.io/index: '0'
spec:
  dataFrom:
  - extract:
      key: cloudflare
  secretStoreRef:
    kind: ClusterSecretStore
    name: onepassword
  target:
    name: cloudflare-tunnel-secret
    template:
      data:
        TUNNEL_ID: '{{ .TALOS_CF_TUNNEL_ID }}'
        TUNNEL_TOKEN: '{{ .TALOS_CF_TUNNEL_TOKEN }}'
---
apiVersion: externaldns.k8s.io/v1alpha1
kind: DNSEndpoint
metadata:
  labels:
    app.kubernetes.io/name: cloudflare-tunnel
    kustomize.toolkit.fluxcd.io/name: cloudflare-tunnel
    kustomize.toolkit.fluxcd.io/namespace: network
  name: cloudflare-tunnel
  namespace: network
  annotations:
    config.kubernetes.io/index: '1'
    internal.config.kubernetes.io/index: '1'
spec:
  endpoints:
  - dnsName: external.${SECRET_DOMAIN}
    recordType: CNAME
    targets:
    - b1911192-e50d-4318-9730-f287e281c4c3.cfargotunnel.com
---
apiVersion: grafana.integreatly.org/v1beta1
kind: GrafanaDashboard
metadata:
  labels:
    app.kubernetes.io/name: cloudflare-tunnel
    kustomize.toolkit.fluxcd.io/name: cloudflare-tunnel
    kustomize.toolkit.fluxcd.io/namespace: network
  name: cloudflare-tunnels
  namespace: network
  annotations:
    config.kubernetes.io/index: '2'
    internal.config.kubernetes.io/index: '2'
spec:
  allowCrossNamespaceImport: true
  datasources:
  - datasourceName: prometheus
    inputName: DS_PROMETHEUS
  instanceSelector:
    matchLabels:
      grafana.internal/instance: grafana
  url: https://grafana.com/api/dashboards/17457/revisions/6/download
---
apiVersion: helm.toolkit.fluxcd.io/v2
kind: HelmRelease
metadata:
  labels:
    app.kubernetes.io/name: cloudflare-tunnel
    kustomize.toolkit.fluxcd.io/name: cloudflare-tunnel
    kustomize.toolkit.fluxcd.io/namespace: network
  name: cloudflare-tunnel
  namespace: network
  annotations:
    config.kubernetes.io/index: '3'
    internal.config.kubernetes.io/index: '3'
spec:
  chartRef:
    kind: OCIRepository
    name: cloudflare-tunnel
  install:
    crds: CreateReplace
    strategy:
      name: RetryOnFailure
  interval: 1h
  rollback:
    cleanupOnFail: true
    recreate: true
  upgrade:
    cleanupOnFail: true
    crds: CreateReplace
    remediation:
      remediateLastFailure: true
      retries: 2
    strategy:
      name: RemediateOnFailure
  values:
    configMaps:
      config:
        data:
          config.yaml: |-
            ingress:
              - hostname: "*.${SECRET_DOMAIN}"
                originRequest:
                  http2Origin: true
                  originServerName: "external.${SECRET_DOMAIN}"
                  tcpKeepAlive: 7200s
                service: &svc https://envoy-external.{{ .Release.Namespace }}.svc.cluster.local:443
              - service: http_status:404
    controllers:
      cloudflare-tunnel:
        annotations:
          reloader.stakater.com/auto: "true"
        containers:
          app:
            args:
            - tunnel
            - run
            env:
              NO_AUTOUPDATE: true
              TUNNEL_METRICS: 0.0.0.0:8080
              TUNNEL_POST_QUANTUM: true
              TUNNEL_TRANSPORT_PROTOCOL: quic
            envFrom:
            - secretRef:
                name: cloudflare-tunnel-secret
            image:
              repository: docker.io/cloudflare/cloudflared
              tag: 2026.8.2
            probes:
              liveness:
                custom: true
                enabled: true
                spec:
                  failureThreshold: 3
                  httpGet:
                    path: /ready
                    port: 8080
                  initialDelaySeconds: 0
                  periodSeconds: 10
                  timeoutSeconds: 1
              readiness:
                custom: true
                enabled: true
                spec:
                  failureThreshold: 3
                  httpGet:
                    path: /ready
                    port: 8080
                  initialDelaySeconds: 0
                  periodSeconds: 10
                  timeoutSeconds: 1
            resources:
              limits:
                memory: 256Mi
              requests:
                cpu: 10m
            securityContext:
              allowPrivilegeEscalation: false
              capabilities:
                drop:
                - ALL
              readOnlyRootFilesystem: true
        replicas: 2
        strategy: RollingUpdate
    defaultPodOptions:
      affinity:
        podAntiAffinity:
          preferredDuringSchedulingIgnoredDuringExecution:
          - podAffinityTerm:
              labelSelector:
                matchLabels:
                  app.kubernetes.io/name: cloudflare-tunnel
              topologyKey: kubernetes.io/hostname
            weight: 100
      securityContext:
        runAsGroup: 65534
        runAsNonRoot: true
        runAsUser: 65534
    persistence:
      config-file:
        globalMounts:
        - path: /etc/cloudflared/config.yaml
          subPath: config.yaml
        identifier: config
        type: configMap
    service:
      app:
        ports:
          http:
            port: 8080
    serviceMonitor:
      app:
        endpoints:
        - port: http
---
apiVersion: source.toolkit.fluxcd.io/v1
kind: OCIRepository
metadata:
  labels:
    app.kubernetes.io/name: cloudflare-tunnel
    kustomize.toolkit.fluxcd.io/name: cloudflare-tunnel
    kustomize.toolkit.fluxcd.io/namespace: network
  name: cloudflare-tunnel
  namespace: network
  annotations:
    config.kubernetes.io/index: '4'
    internal.config.kubernetes.io/index: '4'
spec:
  interval: 15m
  layerSelector:
    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
    operation: copy
  ref:
    tag: 5.1.0
  url: oci://ghcr.io/bjw-s-labs/helm/app-template
---
apiVersion: policy/v1
kind: PodDisruptionBudget
metadata:
  labels:
    app.kubernetes.io/name: cloudflare-tunnel
    kustomize.toolkit.fluxcd.io/name: cloudflare-tunnel
    kustomize.toolkit.fluxcd.io/namespace: network
  name: cloudflare-tunnel
  namespace: network
  annotations:
    config.kubernetes.io/index: '5'
    internal.config.kubernetes.io/index: '5'
spec:
  minAvailable: 1
  selector:
    matchLabels:
      app.kubernetes.io/instance: cloudflare-tunnel
      app.kubernetes.io/name: cloudflare-tunnel
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"28e231115c6214f008db5eb05796d826139d6182","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`git diff ae21e8d9..28e23111 -- .` to confirm the changeset touches only the two prune lines and nothing else</code>
- <code>`kustomize build ./app --load-restrictor LoadRestrictionsNone` for both kubernetes/apps/network/cloudflare-dns and kubernetes/apps/network/cloudflare-tunnel, confirming clean builds with no `kind: Kustomization` (self-reference) in the output</code>
- <code>`flux-local build kustomization cloudflare-dns --path kubernetes/flux/cluster --namespace network` (exit 0) - rendered exactly ExternalSecret, HelmRelease, OCIRepository, PrometheusRule (4 kinds), matching the intent&#39;s claimed 5-&gt;4 live inventory with only the self-entry removed</code>
- <code>`flux-local build kustomization cloudflare-tunnel --path kubernetes/flux/cluster --namespace network` (exit 0) - rendered exactly DNSEndpoint, ExternalSecret, GrafanaDashboard, HelmRelease, OCIRepository, PodDisruptionBudget (6 kinds), matching the intent&#39;s claimed 7-&gt;6 live inventory with only the self-entry removed</code>
- `Manually inspected both app/ directories to confirm neither contains a ks.yaml, i.e. the original self-reference landmine (kustomize-controller autodetecting the owning Kustomization's own manifest under spec.path) cannot recur regardless of the prune setting`
- <code>`git status --porcelain` after testing to confirm no stray artifacts were left in the worktree</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
