### PR TITLE
fix(talos): allow os:operator alongside os:admin in Talos API access

### DIFF
--- a/talos/machineconfig.yaml.j2
+++ b/talos/machineconfig.yaml.j2
@@ -17,8 +17,13 @@ machine:
   features:
     kubernetesTalosAPIAccess:
       enabled: true
+      # Both roles allowed: os:operator is the actions-runner ServiceAccount's
+      # least-privilege role (kubernetes/apps/actions-runner-system/gha-runner-scale-set/app/rbac.yaml)
+      # and must stay reissuable; os:admin stays for existing/manual use and is
+      # out of scope to remove here.
       allowedRoles:
         - os:admin
+        - os:operator
       allowedKubernetesNamespaces:
         - actions-runner-system
         - system-upgrade


### PR DESCRIPTION
## Intent

Durable fix for the runner-credential role mismatch (captain decision "E1 A", 2026-08-23). The runner's Talos ServiceAccount (kubernetes/apps/actions-runner-system/gha-runner-scale-set/app/rbac.yaml) requests os:operator (the least-privilege choice from the runner-privilege reduction #1395), but talos/machineconfig.yaml.j2's features.kubernetesTalosAPIAccess.allowedRoles has been [os:admin] only since #877 - reissue was impossible, and when the old admin-era cert expired, CI died.

Scope of THIS PR (PR 1 of 2, strictly sequenced - PR 2 is a separate later task gated on firstmate confirming all three Talos nodes carry the new allowedRoles): add "os:operator" to allowedRoles in talos/machineconfig.yaml.j2, KEEPING os:admin (removing it is out of scope), plus a concise comment in the file explaining why both are allowed. Validate through the talos render/validate gates that exist in CI (.github/workflows/validate.yaml, schema-only render/validate). Do not modify the actions-runner ServiceAccount manifest or any other file - that is PR 2, which happens only after node rollout is confirmed. Do not apply this config to any node (no just talos apply-node / talosctl apply-config) - that is a manual, human-driven step after merge.

## What Changed

- Added `os:operator` to `features.kubernetesTalosAPIAccess.allowedRoles` in `talos/machineconfig.yaml.j2`, alongside the existing `os:admin` entry.
- Added a comment explaining why both roles are allowed: `os:operator` is required for the actions-runner ServiceAccount's least-privilege role to remain reissuable, while `os:admin` is retained for existing/manual use.

## Risk Assessment

✅ Low: Single-file, additive-only change to a Jinja2 template (adds os:operator to allowedRoles, keeps os:admin, adds an accurate explanatory comment); it is not applied to any node and does not modify the actions-runner ServiceAccount or any other file, exactly matching the stated PR-1-of-2 scope.

## Testing

Ran the two real CI gate scripts that this talos/-only change triggers (talos-validate.sh and version-consistency.sh from .github/workflows/validate.yaml), both passing for all 3 nodes with the pinned toolchain (minijinja-cli, yq, talosctl 1.13.2 via mise), and additionally rendered the actual machine-config template to directly confirm the produced config carries both os:admin and os:operator under allowedRoles plus the required explanatory comment - matching the PR's stated scope exactly (single-file diff, no node applied, no other files touched).

<details>
<summary>Evidence: talos-validate.sh output (CI &#39;talos&#39; job)</summary>

```text
/var/folders/.../talos-1.yaml is valid for metal mode
/var/folders/.../talos-2.yaml is valid for metal mode
/var/folders/.../talos-3.yaml is valid for metal mode
OK: 3 node config(s) render and validate; schematic renders
```
</details>
<details>
<summary>Evidence: version-consistency.sh output (CI &#39;versions&#39; job)</summary>

```text
OK: 6 machineconfig version pin(s) match the tuppr CRs (Talos v1.13.9, Kubernetes v1.36.3)
```
</details>
<details>
<summary>Evidence: Rendered machineconfig.yaml.j2 output (controlplane), showing allowedRoles with both os:admin and os:operator plus the explanatory comment</summary>

```text
---
version: v1alpha1
debug: false
persist: true
machine:
  # machine.type is provided by the per-node overlay (nodes/<node>.yaml.j2)
  token: ZHVtbXk=
  ca:
    crt: ZHVtbXk=
    key: ZHVtbXk=
  certSANs:
    - 127.0.0.1
    - 10.10.10.10
    - talos.sklab.dev
  features:
    kubernetesTalosAPIAccess:
      enabled: true
      # Both roles allowed: os:operator is the actions-runner ServiceAccount's
      # least-privilege role (kubernetes/apps/actions-runner-system/gha-runner-scale-set/app/rbac.yaml)
      # and must stay reissuable; os:admin stays for existing/manual use and is
      # out of scope to remove here.
      allowedRoles:
        - os:admin
        - os:operator
      allowedKubernetesNamespaces:
        - actions-runner-system
        - system-upgrade
    diskQuotaSupport: true
    kubePrism:
      enabled: true
      port: 7445
    hostDNS:
      enabled: true
      forwardKubeDNSToHost: true # Requires Cilium socketLB hostNamespaceOnly
      resolveMemberNames: true
  files:
    # Needed by spegel: https://spegel.dev/docs/getting-started/#talos
    - op: create
      path: /etc/cri/conf.d/20-customization.part
      permissions: 0o644
      content: |-
        [plugins."io.containerd.cri.v1.images"]
          discard_unpacked_layers = false
    - op: overwrite
      path: /etc/nfsmount.conf
      permissions: 0o644
      content: |
        [ NFSMount_Global_Options ]
        nfsvers=4.2
        hard=True
        nconnect=16
        noatime=True
  install:
    # renovate: datasource=docker depName=ghcr.io/siderolabs/installer
    image: factory.talos.dev/installer/0000000000000000000000000000000000000000000000000000000000000000:v1.13.9
    wipe: false
    grubUseUKICmdline: true
  kubelet:
    # renovate: datasource=docker depName=ghcr.io/siderolabs/kubelet
    image: ghcr.io/siderolabs/kubelet:v1.36.3
    defaultRuntimeSeccompProfileEnabled: true
    disableManifestsDirectory: true
    extraMounts:
      # Local Hostpath (openebs)
      - destination: /var/openebs/local
        type: bind
        source: /var/openebs/local
        options:
          - rbind
          - rshared
          - rw
    extraConfig:
      serializeImagePulls: false
      maxPods: 250
      # Reclaim accumulated container-image layers. The kubelet prunes unused
      # images when the imagefs (/var) hits 60% full, down to 45%. Default is
      # 85/80, which let ~600G of old image versions pile up on this
      # image-churn-heavy cluster (Renovate bumps + redeploys); a first
      # tightening pass to 70/55 (2026-06) wasn't enough headroom on its own -
      # as of 2026-08-20 talos-1 (the busiest node) already sits at 42%
      # imagefs / 51% total disk, well above the other two nodes (~29-30%
      # imagefs), with the same Renovate-churn trend that forced both prior
      # interventions still ongoing. 60/45 keeps the prior pair's 15-point
      # high/low gap but moves the ceiling down another 10 points (~100G on
      # a 997G disk): meaningful headroom above today's 42% high-water mark
      # without sitting so close to it that GC thrashes against Spegel's
      # kept-layer cache, and a lower low-water mark so each GC pass reclaims
      # down to a deeper floor, keeping normal reclaim events smaller and
      # more frequent instead of one large, IO-heavy purge - a factor in the
      # 2026-06-14 mon-corruption incident on this same disk (PR #979's
      # ~370G GC delete under a firmware bug that has since been fixed by an
      # SN770M firmware update, but heavy, bursty /var IO is still worth
      # avoiding on general principle). This also lets standing kubelet GC
      # reclaim the ~173G of verified cluster-wide-orphaned image digests
      # identified in the 2026-08-20 image audit, without a one-off manual
      # `talosctl image remove` pass.
      imageGCHighThresholdPercent: 60
      imageGCLowThresholdPercent: 45
      featureGates:
        ImageVolume: true
    nodeIP:
      validSubnets:
        - 10.10.10.0/24
  network:
    disableSearchDomain: true
    nameservers:
      - 10.10.10.1
      - 1.1.1.1
      - 1.0.0.1
  time:
    disabled: false
    servers:
      - 162.159.200.1
      - 162.159.200.123
  sysctls:
    fs.aio-max-nr: "1048576"
    fs.file-max: "1048576"
    fs.inotify.max_user_instances: "8192"
    fs.inotify.max_user_watches: "1048576"
    net.core.default_qdisc: fq
    net.core.netdev_max_backlog: "5000"
    net.core.rmem_default: "262144"
    net.core.rmem_max: "134217728"
    net.core.wmem_default: "262144"
    net.core.wmem_max: "134217728"
    net.ipv4.neigh.default.gc_thresh1: "4096"
    net.ipv4.neigh.default.gc_thresh2: "8192"
    net.ipv4.neigh.default.gc_thresh3: "16384"
    net.ipv4.tcp_congestion_control: bbr
    net.ipv4.tcp_rmem: 4096 87380 134217728
    net.ipv4.tcp_timestamps: "1"
    net.ipv4.tcp_window_scaling: "1"
    net.ipv4.tcp_wmem: 4096 65536 134217728
    vm.dirty_background_ratio: "5"
    vm.dirty_expire_centisecs: "12000"
    vm.dirty_ratio: "15"
    vm.dirty_writeback_centisecs: "1500"
    vm.nr_hugepages: "1024"
    vm.swappiness: "1"
    vm.vfs_cache_pressure: "50"
  sysfs:
    # Disable MGLRU (multi-gen LRU). On kernel 6.18 the MGLRU reclaim path fails to
    # reclaim page cache fast enough under heavy file I/O on these no-swap nodes, so
    # the OOM-killer / Talos runtime.OOMController fires during transcode/backup/model
    # bursts and SIGKILLs burstable pods even with reclaimable memory (talos-3 node-wide
    # OOM on 2026-06-27 took out sabnzbd + vllm + tdarr). Writing 0 reverts to the
    # classic active/inactive LRU. There is NO kernel cmdline arg for MGLRU — sysfs is
    # the control; Talos applies machine.sysfs immediately (no reboot). See
    # docs/hardware-incidents.md and reference_ceph_cascade_rootcause.
    kernel/mm/lru_gen/enabled: "0"
  udev:
    rules:
      # NVMe scheduler optimization (none scheduler for NVMe)
      - SUBSYSTEM=="block", KERNEL=="nvme*", ACTION=="add|change", ATTR{queue/scheduler}="none"
      - SUBSYSTEM=="block", KERNEL=="nvme*", ACTION=="add|change", ATTR{queue/nr_requests}="1024"
      - SUBSYSTEM=="block", KERNEL=="nvme*", ACTION=="add|change", ATTR{queue/read_ahead_kb}="256"
      - SUBSYSTEM=="block", KERNEL=="nvme*", ACTION=="add|change", ATTR{queue/rq_affinity}="2"
  nodeLabels:
    intel.feature.node.kubernetes.io/gpu: "true"
    topology.kubernetes.io/region: kubernetes
    topology.kubernetes.io/zone: m
cluster:
  id: ZHVtbXk=
  secret: ZHVtbXk=
  clusterName: kubernetes
  controlPlane:
    endpoint: https://10.10.10.10:6443
  network:
    cni:
      name: none
    dnsDomain: cluster.local
    podSubnets:
      - 10.42.0.0/16
    serviceSubnets:
      - 10.43.0.0/16
  token: ZHVtbXk=
  ca:
    crt: ZHVtbXk=
    key: ZHVtbXk=
  discovery:
    enabled: true
    registries:
      kubernetes:
        disabled: true
      service: {}
  secretboxEncryptionSecret: ZHVtbXk=
  aggregatorCA:
    crt: ZHVtbXk=
    key: ZHVtbXk=
  serviceAccount:
    key: ZHVtbXk=
  apiServer:
    # renovate: datasource=docker depName=registry.k8s.io/kube-apiserver
    image: registry.k8s.io/kube-apiserver:v1.36.3
    extraArgs:
      default-watch-cache-size: "1500"
      enable-aggregator-routing: "true"
      etcd-compaction-interval: 5m
      etcd-count-metric-poll-period: 1m
      etcd-servers-overrides: /events#https://127.0.0.1:2379
      feature-gates: ImageVolume=true,MutatingAdmissionPolicy=true
      runtime-config: admissionregistration.k8s.io/v1beta1=true
      watch-cache-sizes: persistentvolumeclaims#1000,persistentvolumes#1000
    certSANs:
      - 127.0.0.1
      - 10.10.10.10
      - talos.sklab.dev
    admissionControl:
      - name: PodSecurity
        configuration:
          apiVersion: pod-security.admission.config.k8s.io/v1alpha1
          kind: PodSecurityConfiguration
          defaults:
            audit: privileged
            audit-version: latest
            enforce: privileged
            enforce-version: latest
            warn: privileged
            warn-version: latest
          exemptions:
            namespaces:
              - kube-system
            runtimeClasses: []
            usernames: []
    auditPolicy:
      apiVersion: audit.k8s.io/v1
      kind: Policy
      rules:
        - level: Metadata
  controllerManager:
    # renovate: datasource=docker depName=registry.k8s.io/kube-controller-manager
    image: registry.k8s.io/kube-controller-manager:v1.36.3
    extraArgs:
      bind-address: 0.0.0.0
  proxy:
    disabled: true
    # renovate: datasource=docker depName=registry.k8s.io/kube-proxy
    image: registry.k8s.io/kube-proxy:v1.36.3
  scheduler:
    # renovate: datasource=docker depName=registry.k8s.io/kube-scheduler
    image: registry.k8s.io/kube-scheduler:v1.36.3
    extraArgs:
      bind-address: 0.0.0.0
  etcd:
    ca:
      crt: ZHVtbXk=
      key: ZHVtbXk=
    extraArgs:
      auto-compaction-mode: periodic
      auto-compaction-retention: 1h
      election-timeout: "1500"
      heartbeat-interval: "150"
      listen-metrics-urls: http://0.0.0.0:2381
      snapshot-count: "10000"
    advertisedSubnets:
      - 10.10.10.0/24
  coreDNS:
    disabled: true
  allowSchedulingOnControlPlanes: true
---
# Raise the Talos runtime.OOMController PSI trigger. The default
# (memory_full_avg10 > 12.0 && ... time_since_trigger > 500ms) is far too
# aggressive for a Ceph-hosting cluster: memory-PSI spikes are NORMAL here
# (OSD peering/backfill, BlueStore cache churn, recovery I/O) and the
# controller answered them by SIGKILLing the heaviest *burstable* cgroups —
# cilium-agent, ceph-osd pods, kube-apiserver, mon pods — causing the
# 2026-06-30 4-OSD outage (100% PGs inactive for ~2 days) and repeated
# cilium/mon kills through 2026-07-03. Note the victim ranking never selects
# Guaranteed-QoS cgroups, so critical pods with requests==limits are safe
# regardless of this trigger. Codifies the imperative patch applied live on
# all 3 nodes on 2026-07-03 (~15:04 UTC); see docs/hardware-incidents.md.
apiVersion: v1alpha1
kind: OOMConfig
triggerExpression: memory_full_avg10 > 50.0 && d_memory_full_avg10 > 0.0 && time_since_trigger > duration("30s")
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"1876c40f1519f2456c8d940509b3aea6a987f119","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `git diff --stat 0fc150e9..1876c40f (confirmed only talos/machineconfig.yaml.j2 changed, 5 lines added, no other files touched)`
- <code>mise exec -- bash ./scripts/ci/talos-validate.sh (the exact CI &#39;talos&#39; job command from .github/workflows/validate.yaml) - all 3 node configs (talos-1/2/3) rendered via minijinja-cli, patched, and passed `talosctl validate -m metal`; schematic rendered</code>
- `mise exec -- bash ./scripts/ci/version-consistency.sh (the exact CI 'versions' job command) - all 6 machineconfig version pins still match the tuppr CRs`
- `Manual render: minijinja-cli talos/machineconfig.yaml.j2 with CONTROLPLANE=true, inspected via yq - confirmed rendered .machine.features.kubernetesTalosAPIAccess.allowedRoles contains both os:admin and os:operator, with the explanatory comment present in the rendered YAML`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
