### PR TITLE
feat(renovate): deploy in-cluster dry-run CronJob alongside GitHub Actions

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -55,11 +55,11 @@ Pre-pulls new container images to Talos nodes before PRs are merged, reducing de
 
 **File:** `renovate.yaml`
 
-Runs [Renovate](https://github.com/renovatebot/renovate) for automated dependency updates.
+Runs [Renovate](https://github.com/renovatebot/renovate) for automated dependency updates. This workflow is still the live write path; the in-cluster CronJob is dry-run observation until cutover (`kubernetes/apps/base/renovate/README.md`).
 
 **Triggers:**
 - Push to `.renovaterc.json5` or `.renovate/**`
-- Hourly schedule
+- Every 4 hours (`0 */4 * * *`)
 - Manual dispatch with options for dry-run and log level
 
 **Configuration:** Uses repository's `.renovaterc.json5` for Renovate settings.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@ Gatus is an app under `kubernetes/apps/base/monitoring/gatus`, not a component. 
 | Task commands | `Taskfile.yaml` + `.taskfiles/{domain}/` | `task --list-all`. Split with `just`: see UNIQUE STYLES |
 | CI workflows | `.github/workflows/` | flux-local, renovate, codeql, image-pull, label-sync, validate, plus build-talosctl-busybox, labeler, tag, test-runner |
 | Branch protection | GitHub ruleset on `main`, applied via `gh api` (not in Git) | `docs/branch-protection.md`. Only `Labeler - Labeler` is a required status check today - flux-local/image-pull/validate all path-filter at the `on: pull_request:` trigger level, so they never post a check outside their paths and are unsafe to require as-is (see doc for the live-measured proof and the follow-up needed to close the gap) |
-| Renovate config | `.renovaterc.json5` + `.renovate/` | Extends from Aviator-Coding/mortyops + local presets, incl. `.renovate/talos.json5` (Talos-scoped datasource + managers) |
+| Renovate config | `.renovaterc.json5` + `.renovate/` | Presets/config (extends Aviator-Coding/mortyops + local, incl. `.renovate/talos.json5`). Runtime is dual-path until cutover: GHA `.github/workflows/renovate.yaml` still does live writes; in-cluster CronJob is dry-run observation — owner: `kubernetes/apps/base/renovate/README.md` |
 | Tool versions | `.mise.toml` | kubectl, flux, talos, helm, vals, 1password-cli, just, minijinja, etc. |
 | AI stack | `kubernetes/apps/main/ai/` (Flux Kustomizations) + `kubernetes/apps/base/ai/` (manifests) | Hermes + ToolHive (`toolhive.stacklok.dev/v1alpha1` `MCPServer`) + agentgateway. kagent/kmcp tombstones: `docs/ai-system/{kagent,kmcp}`. Retired 2026-08-22: `docs/ai-system/retired-2026-08-22.md` |
 

--- a/README.md
+++ b/README.md
@@ -81,4 +81,4 @@ Flux reconciles from Git. After a merge, `task reconcile` forces a sync.
 
 ## Renovate
 
-Renovate opens PRs for container images, Helm charts, GitHub Actions, and mise tools. Config is [`.renovaterc.json5`](.renovaterc.json5).
+Renovate opens PRs for container images, Helm charts, GitHub Actions, and mise tools. Config is [`.renovaterc.json5`](.renovaterc.json5). Live writes still come from [`.github/workflows/renovate.yaml`](.github/workflows/renovate.yaml); an in-cluster dry-run CronJob ships in parallel until cutover — see [`kubernetes/apps/base/renovate/README.md`](kubernetes/apps/base/renovate/README.md).

--- a/kubernetes/apps/base/renovate/README.md
+++ b/kubernetes/apps/base/renovate/README.md
@@ -1,0 +1,31 @@
+# renovate
+
+In-cluster Renovate via the official helm chart (`oci://ghcr.io/renovatebot/charts/renovate`), a CronJob every 4 hours matching `.github/workflows/renovate.yaml`. Community operators (mogenius / thegeeklab / secustor) are not used.
+
+This path ships in **observation / dry-run** (`RENOVATE_DRY_RUN=full`). The GitHub Actions workflow stays enabled until a follow-up PR proves the CronJob and flips writes on.
+
+## 1Password item (captain)
+
+The ExternalSecret expects a Homelab vault item that does not exist yet:
+
+| Vault | Item | Field | Source |
+| --- | --- | --- | --- |
+| Homelab | `renovate` | `BOT_APP_ID` | GitHub Actions secret `BOT_APP_ID` |
+| Homelab | `renovate` | `BOT_APP_PRIVATE_KEY` | GitHub Actions secret `BOT_APP_PRIVATE_KEY` (PEM) |
+
+Same GitHub App the hosted workflow already uses via `actions/create-github-app-token`. The CronJob mints a one-hour installation token at start (`app/resources/github-app-token.js`). The app must keep access to `Aviator-Coding/home-ops` and `Aviator-Coding/mortyops` (preset `extends`).
+
+Until that item exists, the ExternalSecret will stay non-ready and the first CronJob will fail token minting. The `RenovateRunMissing` alert is the tripwire.
+
+## Cutover (follow-up PR, not this one)
+
+1. Confirm a dry-run Job completes (`kubectl -n renovate get jobs`) and logs show the repo was processed.
+2. Remove `env.RENOVATE_DRY_RUN` from `app/helmrelease.yaml` entirely. Do not set it to `"false"`.
+3. After a live write run looks healthy, suspend or delete `.github/workflows/renovate.yaml`.
+
+## Alerts
+
+The chart has no metrics Service, so there is no ServiceMonitor. `app/prometheusrule.yaml` watches kube-state-metrics CronJob timestamps:
+
+- `RenovateJobFailed` - last schedule did not succeed within 40m
+- `RenovateRunMissing` - no successful run in 8h (two missed cycles)

--- a/kubernetes/apps/base/renovate/README.md
+++ b/kubernetes/apps/base/renovate/README.md
@@ -15,7 +15,7 @@ The ExternalSecret expects a Homelab vault item that does not exist yet:
 
 Same GitHub App the hosted workflow already uses via `actions/create-github-app-token`. The CronJob mints a one-hour installation token at start (`app/resources/github-app-token.js`). The app must keep access to `Aviator-Coding/home-ops` and `Aviator-Coding/mortyops` (preset `extends`).
 
-Until that item exists, the ExternalSecret will stay non-ready and the first CronJob will fail token minting. The `RenovateRunMissing` alert is the tripwire.
+Until that item exists, the ExternalSecret will stay non-ready and the first CronJob will fail token minting. The `RenovateNeverSucceeded` alert is the tripwire on first deploy (no prior success). `RenovateRunMissing` only applies after at least one successful run.
 
 ## Cutover (follow-up PR, not this one)
 
@@ -28,4 +28,6 @@ Until that item exists, the ExternalSecret will stay non-ready and the first Cro
 The chart has no metrics Service, so there is no ServiceMonitor. `app/prometheusrule.yaml` watches kube-state-metrics CronJob timestamps:
 
 - `RenovateJobFailed` - last schedule did not succeed within 40m
-- `RenovateRunMissing` - no successful run in 8h (two missed cycles)
+- `RenovateRunMissing` - no successful run in 8h after at least one prior success (two missed cycles)
+- `RenovateNeverSucceeded` - CronJob exists but has never succeeded (8h); first-deploy / missing-secret tripwire
+- `RenovateCronJobAbsent` - CronJob missing for 1h

--- a/kubernetes/apps/base/renovate/app/externalsecret.yaml
+++ b/kubernetes/apps/base/renovate/app/externalsecret.yaml
@@ -1,0 +1,27 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+# 1Password item the captain must create (does not exist in-repo today):
+#   vault: Homelab
+#   item: renovate
+#   fields: BOT_APP_ID, BOT_APP_PRIVATE_KEY
+# Copy from the live GitHub Actions secrets of the same names used by
+# .github/workflows/renovate.yaml (actions/create-github-app-token).
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: renovate
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: renovate-secret
+    template:
+      engineVersion: v2
+      data:
+        GITHUB_APP_ID: "{{ .BOT_APP_ID }}"
+        GITHUB_APP_PRIVATE_KEY: "{{ .BOT_APP_PRIVATE_KEY }}"
+  dataFrom:
+    - extract:
+        key: renovate

--- a/kubernetes/apps/base/renovate/app/helmrelease.yaml
+++ b/kubernetes/apps/base/renovate/app/helmrelease.yaml
@@ -1,0 +1,76 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app renovate
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: renovate
+  values:
+    fullnameOverride: *app
+    image:
+      tag: 44.40.0
+    cronjob:
+      schedule: "0 */4 * * *"
+      concurrencyPolicy: Forbid
+      failedJobsHistoryLimit: 5
+      successfulJobsHistoryLimit: 3
+      startingDeadlineSeconds: 600
+      jobBackoffLimit: "0"
+      jobRestartPolicy: Never
+      ttlSecondsAfterFinished: 86400
+      activeDeadlineSeconds: 1800
+      preCommand: |
+        export RENOVATE_TOKEN="$(node /opt/github-app-token/github-app-token.js)"
+    existingSecret: renovate-secret
+    extraVolumes:
+      - name: github-app-token
+        configMap:
+          name: renovate-github-app-token
+    extraVolumeMounts:
+      - name: github-app-token
+        mountPath: /opt/github-app-token
+        readOnly: true
+    env:
+      LOG_LEVEL: info
+      # Observation mode: logs proposed PRs without writing. Remove this env
+      # entirely (do not set it to "false") in the follow-up cutover PR.
+      RENOVATE_DRY_RUN: full
+    renovate:
+      config: |
+        {
+          "platform": "github",
+          "autodiscover": true,
+          "autodiscoverFilter": ["Aviator-Coding/home-ops"],
+          "onboarding": false,
+          "requireConfig": "required",
+          "internalChecksFilter": "strict",
+          "platformCommit": true,
+          "configValidationError": true,
+          "binarySource": "install",
+          "gitNoVerify": ["commit", "push"]
+        }
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+    securityContext:
+      runAsNonRoot: true
+      runAsUser: 12021
+      runAsGroup: 12021
+      fsGroup: 12021
+      seccompProfile:
+        type: RuntimeDefault
+    resources:
+      requests:
+        cpu: 100m
+        memory: 512Mi
+      limits:
+        memory: 2Gi
+    pod:
+      annotations:
+        secret.reloader.stakater.com/reload: renovate-secret

--- a/kubernetes/apps/base/renovate/app/kustomization.yaml
+++ b/kubernetes/apps/base/renovate/app/kustomization.yaml
@@ -1,0 +1,17 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml
+  - ./prometheusrule.yaml
+configMapGenerator:
+  - name: renovate-github-app-token
+    files:
+      - github-app-token.js=./resources/github-app-token.js
+generatorOptions:
+  disableNameSuffixHash: true
+  annotations:
+    kustomize.toolkit.fluxcd.io/substitute: disabled

--- a/kubernetes/apps/base/renovate/app/ocirepository.yaml
+++ b/kubernetes/apps/base/renovate/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: renovate
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 46.255.0
+  url: oci://ghcr.io/renovatebot/charts/renovate

--- a/kubernetes/apps/base/renovate/app/prometheusrule.yaml
+++ b/kubernetes/apps/base/renovate/app/prometheusrule.yaml
@@ -1,0 +1,63 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/monitoring.coreos.com/prometheusrule_v1.json
+# The official renovate helm chart is a CronJob with no metrics endpoint, so
+# there is no ServiceMonitor. Failed/missing runs are detected from
+# kube-state-metrics CronJob timestamps.
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: renovate-rules
+spec:
+  groups:
+    - name: renovate.rules
+      rules:
+        - alert: RenovateJobFailed
+          expr: |-
+            (
+              kube_cronjob_status_last_schedule_time{namespace="renovate", cronjob="renovate"}
+              - kube_cronjob_status_last_successful_time{namespace="renovate", cronjob="renovate"}
+            ) > 60
+          for: 40m
+          annotations:
+            summary: >-
+              In-cluster Renovate's last scheduled run did not succeed
+              (schedule minus last success is {{ $value | humanizeDuration }}).
+              Check the latest Job logs in the renovate namespace.
+          labels:
+            severity: warning
+        - alert: RenovateRunMissing
+          expr: |-
+            kube_cronjob_status_last_successful_time{namespace="renovate", cronjob="renovate"} > 1
+            and
+            (time() - kube_cronjob_status_last_successful_time{namespace="renovate", cronjob="renovate"}) > 28800
+          for: 15m
+          annotations:
+            summary: >-
+              In-cluster Renovate has not completed a successful run in over 8h
+              (two missed 4-hour cycles). Confirm the CronJob is not suspended
+              and that the renovate 1Password item exists so the GitHub App
+              token can be minted.
+          labels:
+            severity: critical
+        - alert: RenovateNeverSucceeded
+          expr: |-
+            kube_cronjob_info{namespace="renovate", cronjob="renovate"} == 1
+            unless on(namespace, cronjob)
+              kube_cronjob_status_last_successful_time{namespace="renovate", cronjob="renovate"} > 1
+          for: 8h
+          annotations:
+            summary: >-
+              In-cluster Renovate has never completed a successful run. The
+              first likely cause is a missing Homelab/renovate 1Password item
+              (BOT_APP_ID, BOT_APP_PRIVATE_KEY).
+          labels:
+            severity: critical
+        - alert: RenovateCronJobAbsent
+          expr: absent(kube_cronjob_info{namespace="renovate", cronjob="renovate"})
+          for: 1h
+          annotations:
+            summary: >-
+              The in-cluster Renovate CronJob is missing. Flux may have failed
+              to reconcile kubernetes/apps/base/renovate.
+          labels:
+            severity: critical

--- a/kubernetes/apps/base/renovate/app/resources/github-app-token.js
+++ b/kubernetes/apps/base/renovate/app/resources/github-app-token.js
@@ -1,0 +1,113 @@
+"use strict";
+
+const crypto = require("crypto");
+const https = require("https");
+
+const APP_ID = process.env.GITHUB_APP_ID;
+const RAW_KEY = process.env.GITHUB_APP_PRIVATE_KEY;
+const ACCOUNT = process.env.GITHUB_APP_ACCOUNT || "Aviator-Coding";
+
+if (!APP_ID || !RAW_KEY) {
+  console.error("GITHUB_APP_ID and GITHUB_APP_PRIVATE_KEY must be set");
+  process.exit(1);
+}
+
+const privateKey = RAW_KEY.replace(/\\n/g, "\n");
+
+function b64url(input) {
+  const buf = Buffer.isBuffer(input) ? input : Buffer.from(input);
+  return buf.toString("base64url");
+}
+
+function mintJwt() {
+  const now = Math.floor(Date.now() / 1000);
+  const header = b64url(JSON.stringify({ alg: "RS256", typ: "JWT" }));
+  const payload = b64url(
+    JSON.stringify({ iat: now - 60, exp: now + 540, iss: APP_ID }),
+  );
+  const signer = crypto.createSign("RSA-SHA256");
+  signer.update(`${header}.${payload}`);
+  const signature = signer.sign(privateKey, "base64url");
+  return `${header}.${payload}.${signature}`;
+}
+
+function githubRequest(method, path, jwt) {
+  return new Promise((resolve, reject) => {
+    const req = https.request(
+      {
+        hostname: "api.github.com",
+        path,
+        method,
+        headers: {
+          Accept: "application/vnd.github+json",
+          Authorization: `Bearer ${jwt}`,
+          "User-Agent": "home-ops-renovate",
+          "X-GitHub-Api-Version": "2022-11-28",
+        },
+      },
+      (res) => {
+        let body = "";
+        res.on("data", (chunk) => {
+          body += chunk;
+        });
+        res.on("end", () => {
+          let parsed = {};
+          if (body) {
+            try {
+              parsed = JSON.parse(body);
+            } catch (err) {
+              reject(
+                new Error(
+                  `GitHub ${method} ${path} returned non-JSON (${res.statusCode}): ${body.slice(0, 200)}`,
+                ),
+              );
+              return;
+            }
+          }
+          if (res.statusCode < 200 || res.statusCode >= 300) {
+            reject(
+              new Error(
+                `GitHub ${method} ${path} failed (${res.statusCode}): ${body.slice(0, 500)}`,
+              ),
+            );
+            return;
+          }
+          resolve(parsed);
+        });
+      },
+    );
+    req.on("error", reject);
+    req.end();
+  });
+}
+
+(async () => {
+  const jwt = mintJwt();
+  const installations = await githubRequest("GET", "/app/installations", jwt);
+  if (!Array.isArray(installations) || installations.length === 0) {
+    throw new Error("GitHub App has no installations");
+  }
+  const installation =
+    installations.find((item) => item.account && item.account.login === ACCOUNT) ||
+    (installations.length === 1 ? installations[0] : null);
+  if (!installation) {
+    const logins = installations
+      .map((item) => (item.account && item.account.login) || "?")
+      .join(", ");
+    throw new Error(
+      `No GitHub App installation for ${ACCOUNT}; found: ${logins}`,
+    );
+  }
+  const token = await githubRequest(
+    "POST",
+    `/app/installations/${installation.id}/access_tokens`,
+    jwt,
+  );
+  if (!token.token) {
+    throw new Error("GitHub App installation token response missing token");
+  }
+  process.stdout.write(token.token);
+})().catch((err) => {
+  console.error(err.message || err);
+  process.exit(1);
+});

--- a/kubernetes/apps/main/kustomization.yaml
+++ b/kubernetes/apps/main/kustomization.yaml
@@ -16,6 +16,7 @@ resources:
   - ./media
   - ./monitoring
   - ./network
+  - ./renovate
   - ./rook-ceph
   - ./security
   - ./selfhosted

--- a/kubernetes/apps/main/renovate/kustomization.yaml
+++ b/kubernetes/apps/main/renovate/kustomization.yaml
@@ -1,0 +1,12 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: renovate
+
+components:
+  - ../../../components/common
+  - ../../../components/alerts
+
+resources:
+  - ./renovate.yaml

--- a/kubernetes/apps/main/renovate/renovate.yaml
+++ b/kubernetes/apps/main/renovate/renovate.yaml
@@ -1,0 +1,30 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app renovate
+  namespace: &namespace renovate
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: onepassword-store
+      namespace: security
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: *app
+      namespace: *namespace
+  interval: 1h
+  path: ./kubernetes/apps/base/renovate/app
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  timeout: 5m
+  wait: false


### PR DESCRIPTION
## Intent

Move Renovate from its current hosted GitHub Actions workflow to an in-cluster GitOps deployment, and add failed-run alerting the reference setups do not ship.

Current state (verified before building): Renovate today is .github/workflows/renovate.yaml on hosted ubuntu-latest, cron 0 */4 * * *, plus push-on-config-change and workflow_dispatch. Auth is a GitHub App via actions/create-github-app-token using GitHub Actions secrets BOT_APP_ID and BOT_APP_PRIVATE_KEY (not a PAT). Repo config is .renovaterc.json5 plus .renovate/ presets. There was no in-cluster Renovate. Upstream-recommended in-cluster pattern from current docs is the official helm chart oci://ghcr.io/renovatebot/charts/renovate (CronJob); community operators (mogenius / thegeeklab / secustor) are unofficial and were not used.

Scope:
- Deploy Renovate in-cluster in its OWN NEW dedicated namespace named renovate, following the post-split structure: kubernetes/apps/base/renovate (manifests) + kubernetes/apps/main/renovate (Flux overlay) + a single wiring entry in kubernetes/apps/main/kustomization.yaml. Copy a freshly migrated namespace as the template.
- Schedule-driven runs via the chart's CronJob (0 */4 * * *, matching the existing workflow), resource limits set, GitHub credential via External Secrets / 1Password (ClusterSecretStore onepassword). Never a plaintext token.
- The needed 1Password item does not already exist; build everything around the ExternalSecret reference anyway. Captain must create Homelab vault item "renovate" with fields BOT_APP_ID and BOT_APP_PRIVATE_KEY copied from the live GitHub Actions secrets of those names. The CronJob mints a one-hour GitHub App installation token at start from those fields (app/resources/github-app-token.js). Do not block early on the missing item.
- Alerting: PrometheusRule wired into the existing kube-prometheus-stack / Alertmanager path. The official chart exposes no metrics Service, so do not add a ServiceMonitor. Failed/missing/never-succeeded/absent CronJob alerts use kube-state-metrics timestamps.
- Cutover safety: do NOT disable or delete the currently working GitHub Actions Renovate path in this same PR. This PR deploys the in-cluster instance in dry-run/observation config (RENOVATE_DRY_RUN=full; remove that env entirely in a follow-up, do not set it to "false") alongside the existing path. Real cutover (enabling writes + retiring .github/workflows/renovate.yaml) is an explicitly separate follow-up PR. State the cutover plan in the PR description.

HARD FENCES (a structural restructuring is finishing in parallel):
- Touch ONLY the new namespace's paths plus the single overlay wiring entry required to include it.
- Do NOT touch kube-system, cert-manager, flux-system, bootstrap, or anything under kubernetes/flux/.
- Expect main to move under this work; rebase forward as needed, never force.

Acceptance criteria: in-cluster Renovate deployed via GitOps in its own namespace with checks green; secret via ExternalSecret; failed-run alert rule present and syntactically validated; existing Renovate path untouched and still functional; cutover plan stated in the PR.

## What Changed

- Add a dedicated `renovate` namespace via the post-split layout (`kubernetes/apps/base/renovate` + `kubernetes/apps/main/renovate`), wiring the official Renovate Helm chart CronJob (`0 */4 * * *`) with resource limits, GitHub App auth through ExternalSecret/`onepassword`, and a startup token mint script.
- Ship observation-only mode with `RENOVATE_DRY_RUN=full` and leave `.github/workflows/renovate.yaml` untouched as the live write path; document dual-path ownership and captain 1Password setup in the app README plus root/`AGENTS.md` notes.
- Add kube-state-metrics-based PrometheusRules (`RenovateJobFailed`, `RenovateRunMissing`, `RenovateNeverSucceeded`, `RenovateCronJobAbsent`) instead of a ServiceMonitor, since the chart exposes no metrics Service.

## Cutover (follow-up PR)

1. Confirm a dry-run Job completes and logs show the repo was processed.
2. Remove `env.RENOVATE_DRY_RUN` from `app/helmrelease.yaml` entirely (do not set it to `"false"`).
3. After a healthy live write run, suspend or delete `.github/workflows/renovate.yaml`.

## Risk Assessment

✅ Low: Bounded new renovate namespace in dry-run observation mode with ExternalSecret auth, CronJob alerts, and the existing GitHub Actions path left untouched; prior doc tripwire issue is corrected and no remaining source defects were found.

## Testing

Rendered the new renovate base/main Kustomizations and the official chart CronJob end-state, confirmed dry-run observation, 1Password ExternalSecret wiring, 4h schedule parity with the untouched GHA workflow, promtool-valid kube-state-metrics alerts, and token-script fail-closed/JWT behavior; no intent gaps found.

<details>
<summary>Evidence: End-user rendered experience transcript</summary>

```text
IN-CLUSTER RENOVATE — RENDERED END-USER SURFACE
============================================================
Namespace: renovate
Flux Kustomization path: ./kubernetes/apps/base/renovate/app
Flux targetNamespace: renovate
dependsOn: [{'name': 'onepassword-store', 'namespace': 'security'}]

Secret wiring (ExternalSecret → renovate-secret):
  store: {'kind': 'ClusterSecretStore', 'name': 'onepassword'}
  1P item key: renovate
  template keys: ['GITHUB_APP_ID', 'GITHUB_APP_PRIVATE_KEY']

CronJob (official helm chart render):
  name: renovate
  schedule: 0 */4 * * *
  image: ghcr.io/renovatebot/renovate:44.40.0
  env: {'RENOVATE_CONFIG_FILE': '/usr/src/app/config.json', 'LOG_LEVEL': 'info', 'RENOVATE_DRY_RUN': 'full'}
  envFrom: [{'secretRef': {'name': 'renovate-secret'}}]
  resources: {'limits': {'memory': '2Gi'}, 'requests': {'cpu': '100m', 'memory': '512Mi'}}
  entrypoint args:
    set -e;
    export RENOVATE_TOKEN="$(node /opt/github-app-token/github-app-token.js)"

    renovate


Alerts (PrometheusRule via kube-state-metrics, no ServiceMonitor):
  - RenovateJobFailed [warning] for=40m
  - RenovateRunMissing [critical] for=15m
  - RenovateNeverSucceeded [critical] for=8h
  - RenovateCronJobAbsent [critical] for=1h

Dry-run observation mode: RENOVATE_DRY_RUN=full (writes disabled)
GitHub Actions path: .github/workflows/renovate.yaml LEFT INTACT
Cutover: documented in kubernetes/apps/base/renovate/README.md
============================================================
E2E_RENDER_OK
```
</details>
<details>
<summary>Evidence: Helm-templated CronJob (pretty)</summary>

```text
apiVersion: v1
kind: ConfigMap
metadata:
  name: renovate-config
  namespace: renovate
  labels:
    helm.sh/chart: renovate-46.255.0
    app.kubernetes.io/name: renovate
    app.kubernetes.io/instance: renovate
    app.kubernetes.io/version: 44.40.0
    app.kubernetes.io/managed-by: Helm
data:
  config.json: "{\n  \"platform\": \"github\",\n  \"autodiscover\": true,\n  \"autodiscoverFilter\"\
    : [\"Aviator-Coding/home-ops\"],\n  \"onboarding\": false,\n  \"requireConfig\"\
    : \"required\",\n  \"internalChecksFilter\": \"strict\",\n  \"platformCommit\"\
    : true,\n  \"configValidationError\": true,\n  \"binarySource\": \"install\",\n\
    \  \"gitNoVerify\": [\"commit\", \"push\"]\n}"
---
apiVersion: batch/v1
kind: CronJob
metadata:
  name: renovate
  namespace: renovate
  labels:
    helm.sh/chart: renovate-46.255.0
    app.kubernetes.io/name: renovate
    app.kubernetes.io/instance: renovate
    app.kubernetes.io/version: 44.40.0
    app.kubernetes.io/managed-by: Helm
spec:
  schedule: 0 */4 * * *
  concurrencyPolicy: Forbid
  failedJobsHistoryLimit: 5
  successfulJobsHistoryLimit: 3
  startingDeadlineSeconds: 600
  jobTemplate:
    metadata:
      labels:
        app.kubernetes.io/name: renovate
        app.kubernetes.io/instance: renovate
    spec:
      ttlSecondsAfterFinished: 86400
      activeDeadlineSeconds: 1800
      backoffLimit: 0
      template:
        metadata:
          labels:
            app.kubernetes.io/name: renovate
            app.kubernetes.io/instance: renovate
          annotations:
            secret.reloader.stakater.com/reload: renovate-secret
        spec:
          serviceAccountName: default
          restartPolicy: Never
          containers:
          - name: renovate
            image: ghcr.io/renovatebot/renovate:44.40.0
            imagePullPolicy: IfNotPresent
            command:
            - /bin/bash
            - -c
            args:
            - 'set -e;

              export RENOVATE_TOKEN="$(node /opt/github-app-token/github-app-token.js)"


              renovate

              '
            volumeMounts:
            - name: config-volume
              mountPath: /usr/src/app/config.json
              subPath: config.json
            - mountPath: /opt/github-app-token
              name: github-app-token
              readOnly: true
            env:
            - name: RENOVATE_CONFIG_FILE
              value: /usr/src/app/config.json
            - name: LOG_LEVEL
              value: info
            - name: RENOVATE_DRY_RUN
              value: full
            envFrom:
            - secretRef:
                name: renovate-secret
            securityContext:
              allowPrivilegeEscalation: false
              capabilities:
                drop:
                - ALL
            resources:
              limits:
                memory: 2Gi
              requests:
                cpu: 100m
                memory: 512Mi
          volumes:
          - name: config-volume
            configMap:
              name: renovate-config
          - configMap:
              name: renovate-github-app-token
            name: github-app-token
          securityContext:
            fsGroup: 12021
            runAsGroup: 12021
            runAsNonRoot: true
            runAsUser: 12021
            seccompProfile:
              type: RuntimeDefault
```
</details>
<details>
<summary>Evidence: CronJob semantic extract</summary>

```text
kind: CronJob
name: renovate
schedule: 0 */4 * * *
concurrencyPolicy: Forbid
failedJobsHistoryLimit: 5
successfulJobsHistoryLimit: 3
startingDeadlineSeconds: 600
container: renovate
image: ghcr.io/renovatebot/renovate:44.40.0
env:
  RENOVATE_CONFIG_FILE: /usr/src/app/config.json
  LOG_LEVEL: info
  RENOVATE_DRY_RUN: full
envFrom:
- secretRef:
    name: renovate-secret
volumeMounts:
- name: config-volume
  mountPath: /usr/src/app/config.json
  subPath: config.json
- mountPath: /opt/github-app-token
  name: github-app-token
  readOnly: true
volumes:
- name: config-volume
  keys:
  - name
  - configMap
- name: github-app-token
  keys:
  - configMap
  - name
resources:
  limits:
    memory: 2Gi
  requests:
    cpu: 100m
    memory: 512Mi
securityContext_pod:
  fsGroup: 12021
  runAsGroup: 12021
  runAsNonRoot: true
  runAsUser: 12021
  seccompProfile:
    type: RuntimeDefault
securityContext_container:
  allowPrivilegeEscalation: false
  capabilities:
    drop:
    - ALL
command:
- /bin/bash
- -c
args:
- 'set -e;

  export RENOVATE_TOKEN="$(node /opt/github-app-token/github-app-token.js)"


  renovate

  '
restartPolicy: Never
activeDeadlineSeconds: 1800
backoffLimit: 0

---CONFIGMAP KEYS---
['config.json']
--- config.json (first 800 chars) ---
{
  "platform": "github",
  "autodiscover": true,
  "autodiscoverFilter": ["Aviator-Coding/home-ops"],
  "onboarding": false,
  "requireConfig": "required",
  "internalChecksFilter": "strict",
  "platformCommit": true,
  "configValidationError": true,
  "binarySource": "install",
  "gitNoVerify": ["commit", "push"]
}
```
</details>
<details>
<summary>Evidence: Acceptance checks (all true)</summary>

```text
{
  "checks": {
    "namespace_renovate": true,
    "eso_store": true,
    "eso_target": true,
    "eso_template_keys": true,
    "eso_extract_key": true,
    "no_plaintext_token_in_base": true,
    "no_private_key_pem_in_git": true,
    "no_pem_in_renovate_tree": true,
    "schedule": true,
    "dry_run_full": true,
    "existing_secret": true,
    "resources_set": true,
    "oci_url": true,
    "chart_not_operator": true,
    "rendered_schedule": true,
    "rendered_dry_run": true,
    "rendered_secretRef": true,
    "rendered_precommand_token_mint": true,
    "no_servicemonitor_rendered": true,
    "flux_path": true,
    "flux_target_ns": true,
    "flux_depends_on_op": true,
    "wired_in_main": true,
    "gha_workflow_untouched": true,
    "gha_workflow_exists": true,
    "gha_still_has_schedule": true,
    "gha_still_create_app_token": true,
    "fence_only_allowed_paths": true,
    "forbidden_paths_absent": true,
    "cutover_plan_in_readme": true,
    "cutover_says_remove_env_not_false": true,
    "token_script_configmap": true,
    "token_script_has_mint": true
  },
  "failed": [],
  "changed_files": [
    "kubernetes/apps/base/renovate/README.md",
    "kubernetes/apps/base/renovate/app/externalsecret.yaml",
    "kubernetes/apps/base/renovate/app/helmrelease.yaml",
    "kubernetes/apps/base/renovate/app/kustomization.yaml",
    "kubernetes/apps/base/renovate/app/ocirepository.yaml",
    "kubernetes/apps/base/renovate/app/prometheusrule.yaml",
    "kubernetes/apps/base/renovate/app/resources/github-app-token.js",
    "kubernetes/apps/main/kustomization.yaml",
    "kubernetes/apps/main/renovate/kustomization.yaml",
    "kubernetes/apps/main/renovate/renovate.yaml"
  ],
  "bad_paths": []
}
ACCEPTANCE_ALL_OK
```
</details>
<details>
<summary>Evidence: promtool check rules SUCCESS</summary>

<code>Checking /tmp/renovate-rules.yaml&#10;SUCCESS: 4 rules found</code>

```text
Checking /tmp/renovate-rules.yaml
  SUCCESS: 4 rules found
```
</details>
<details>
<summary>Evidence: kustomize base render</summary>

```text
apiVersion: v1
data:
  github-app-token.js: |
    "use strict";

    const crypto = require("crypto");
    const https = require("https");

    const APP_ID = process.env.GITHUB_APP_ID;
    const RAW_KEY = process.env.GITHUB_APP_PRIVATE_KEY;
    const ACCOUNT = process.env.GITHUB_APP_ACCOUNT || "Aviator-Coding";

    if (!APP_ID || !RAW_KEY) {
      console.error("GITHUB_APP_ID and GITHUB_APP_PRIVATE_KEY must be set");
      process.exit(1);
    }

    const privateKey = RAW_KEY.replace(/\\n/g, "\n");

    function b64url(input) {
      const buf = Buffer.isBuffer(input) ? input : Buffer.from(input);
      return buf.toString("base64url");
    }

    function mintJwt() {
      const now = Math.floor(Date.now() / 1000);
      const header = b64url(JSON.stringify({ alg: "RS256", typ: "JWT" }));
      const payload = b64url(
        JSON.stringify({ iat: now - 60, exp: now + 540, iss: APP_ID }),
      );
      const signer = crypto.createSign("RSA-SHA256");
      signer.update(`${header}.${payload}`);
      const signature = signer.sign(privateKey, "base64url");
      return `${header}.${payload}.${signature}`;
    }

    function githubRequest(method, path, jwt) {
      return new Promise((resolve, reject) => {
        const req = https.request(
          {
            hostname: "api.github.com",
            path,
            method,
            headers: {
              Accept: "application/vnd.github+json",
              Authorization: `Bearer ${jwt}`,
              "User-Agent": "home-ops-renovate",
              "X-GitHub-Api-Version": "2022-11-28",
            },
          },
          (res) => {
            let body = "";
            res.on("data", (chunk) => {
              body += chunk;
            });
            res.on("end", () => {
              let parsed = {};
              if (body) {
                try {
                  parsed = JSON.parse(body);
                } catch (err) {
                  reject(
                    new Error(
                      `GitHub ${method} ${path} returned non-JSON (${res.statusCode}): ${body.slice(0, 200)}`,
                    ),
                  );
                  return;
                }
              }
              if (res.statusCode < 200 || res.statusCode >= 300) {
                reject(
                  new Error(
                    `GitHub ${method} ${path} failed (${res.statusCode}): ${body.slice(0, 500)}`,
                  ),
                );
                return;
              }
              resolve(parsed);
            });
          },
        );
        req.on("error", reject);
        req.end();
      });
    }

    (async () => {
      const jwt = mintJwt();
      const installations = await githubRequest("GET", "/app/installations", jwt);
      if (!Array.isArray(installations) || installations.length === 0) {
        throw new Error("GitHub App has no installations");
      }
      const installation =
        installations.find((item) => item.account && item.account.login === ACCOUNT) ||
        (installations.length === 1 ? installations[0] : null);
      if (!installation) {
        const logins = installations
          .map((item) => (item.account && item.account.login) || "?")
          .join(", ");
        throw new Error(
          `No GitHub App installation for ${ACCOUNT}; found: ${logins}`,
        );
      }
      const token = await githubRequest(
        "POST",
        `/app/installations/${installation.id}/access_tokens`,
        jwt,
      );
      if (!token.token) {
        throw new Error("GitHub App installation token response missing token");
      }
      process.stdout.write(token.token);
    })().catch((err) => {
      console.error(err.message || err);
      process.exit(1);
    });
kind: ConfigMap
metadata:
  annotations:
    kustomize.toolkit.fluxcd.io/substitute: disabled
  name: renovate-github-app-token
---
apiVersion: external-secrets.io/v1
kind: ExternalSecret
metadata:
  name: renovate
spec:
  dataFrom:
  - extract:
      key: renovate
  refreshInterval: 1h
  secretStoreRef:
    kind: ClusterSecretStore
    name: onepassword
  target:
    name: renovate-secret
    template:
      data:
        GITHUB_APP_ID: '{{ .BOT_APP_ID }}'
        GITHUB_APP_PRIVATE_KEY: '{{ .BOT_APP_PRIVATE_KEY }}'
      engineVersion: v2
---
apiVersion: helm.toolkit.fluxcd.io/v2
kind: HelmRelease
metadata:
  name: renovate
spec:
  chartRef:
    kind: OCIRepository
    name: renovate
  interval: 1h
  values:
    cronjob:
      activeDeadlineSeconds: 1800
      concurrencyPolicy: Forbid
      failedJobsHistoryLimit: 5
      jobBackoffLimit: "0"
      jobRestartPolicy: Never
      preCommand: |
        export RENOVATE_TOKEN="$(node /opt/github-app-token/github-app-token.js)"
      schedule: 0 */4 * * *
      startingDeadlineSeconds: 600
      successfulJobsHistoryLimit: 3
      ttlSecondsAfterFinished: 86400
    env:
      LOG_LEVEL: info
      RENOVATE_DRY_RUN: full
    existingSecret: renovate-secret
    extraVolumeMounts:
    - mountPath: /opt/github-app-token
      name: github-app-token
      readOnly: true
    extraVolumes:
    - configMap:
        name: renovate-github-app-token
      name: github-app-token
    fullnameOverride: renovate
    image:
      tag: 44.40.0
    pod:
      annotations:
        secret.reloader.stakater.com/reload: renovate-secret
    renovate:
      config: |
        {
          "platform": "github",
          "autodiscover": true,
          "autodiscoverFilter": ["Aviator-Coding/home-ops"],
          "onboarding": false,
          "requireConfig": "required",
          "internalChecksFilter": "strict",
          "platformCommit": true,
          "configValidationError": true,
          "binarySource": "install",
          "gitNoVerify": ["commit", "push"]
        }
      securityContext:
        allowPrivilegeEscalation: false
        capabilities:
          drop:
          - ALL
    resources:
      limits:
        memory: 2Gi
      requests:
        cpu: 100m
        memory: 512Mi
    securityContext:
      fsGroup: 12021
      runAsGroup: 12021
      runAsNonRoot: true
      runAsUser: 12021
      seccompProfile:
        type: RuntimeDefault
---
apiVersion: monitoring.coreos.com/v1
kind: PrometheusRule
metadata:
  name: renovate-rules
spec:
  groups:
  - name: renovate.rules
    rules:
    - alert: RenovateJobFailed
      annotations:
        summary: In-cluster Renovate's last scheduled run did not succeed (schedule
          minus last success is {{ $value | humanizeDuration }}). Check the latest
          Job logs in the renovate namespace.
      expr: |-
        (
          kube_cronjob_status_last_schedule_time{namespace="renovate", cronjob="renovate"}
          - kube_cronjob_status_last_successful_time{namespace="renovate", cronjob="renovate"}
        ) > 60
      for: 40m
      labels:
        severity: warning
    - alert: RenovateRunMissing
      annotations:
        summary: In-cluster Renovate has not completed a successful run in over 8h
          (two missed 4-hour cycles). Confirm the CronJob is not suspended and that
          the renovate 1Password item exists so the GitHub App token can be minted.
      expr: |-
        kube_cronjob_status_last_successful_time{namespace="renovate", cronjob="renovate"} > 1
        and
        (time() - kube_cronjob_status_last_successful_time{namespace="renovate", cronjob="renovate"}) > 28800
      for: 15m
      labels:
        severity: critical
    - alert: RenovateNeverSucceeded
      annotations:
        summary: In-cluster Renovate has never completed a successful run. The first
          likely cause is a missing Homelab/renovate 1Password item (BOT_APP_ID, BOT_APP_PRIVATE_KEY).
      expr: |-
        kube_cronjob_info{namespace="renovate", cronjob="renovate"} == 1
        unless on(namespace, cronjob)
          kube_cronjob_status_last_successful_time{namespace="renovate", cronjob="renovate"} > 1
      for: 8h
      labels:
        severity: critical
    - alert: RenovateCronJobAbsent
      annotations:
        summary: The in-cluster Renovate CronJob is missing. Flux may have failed
          to reconcile kubernetes/apps/base/renovate.
      expr: absent(kube_cronjob_info{namespace="renovate", cronjob="renovate"})
      for: 1h
      labels:
        severity: critical
---
apiVersion: source.toolkit.fluxcd.io/v1
kind: OCIRepository
metadata:
  name: renovate
spec:
  interval: 15m
  layerSelector:
    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
    operation: copy
  ref:
    tag: 46.255.0
  url: oci://ghcr.io/renovatebot/charts/renovate
```
</details>
<details>
<summary>Evidence: kustomize main overlay render</summary>

```text
apiVersion: v1
kind: Namespace
metadata:
  annotations:
    kustomize.toolkit.fluxcd.io/prune: disabled
  name: renovate
---
apiVersion: external-secrets.io/v1
kind: ExternalSecret
metadata:
  name: cluster-secrets
  namespace: renovate
spec:
  dataFrom:
  - extract:
      key: cluster
  secretStoreRef:
    kind: ClusterSecretStore
    name: onepassword
  target:
    name: cluster-secrets
    template:
      data:
        SECRET_DOMAIN: '{{ .SECRET_DOMAIN }}'
---
apiVersion: external-secrets.io/v1
kind: ExternalSecret
metadata:
  name: github-status-token
  namespace: renovate
spec:
  dataFrom:
  - extract:
      key: flux
  secretStoreRef:
    kind: ClusterSecretStore
    name: onepassword
  target:
    name: github-status-token-secret
    template:
      data:
        token: '{{ .FLUX_GITHUB_TOKEN }}'
---
apiVersion: kustomize.toolkit.fluxcd.io/v1
kind: Kustomization
metadata:
  name: renovate
  namespace: renovate
spec:
  commonMetadata:
    labels:
      app.kubernetes.io/name: renovate
  dependsOn:
  - name: onepassword-store
    namespace: security
  healthChecks:
  - apiVersion: helm.toolkit.fluxcd.io/v2
    kind: HelmRelease
    name: renovate
    namespace: renovate
  interval: 1h
  path: ./kubernetes/apps/base/renovate/app
  prune: true
  retryInterval: 2m
  sourceRef:
    kind: GitRepository
    name: flux-system
    namespace: flux-system
  targetNamespace: renovate
  timeout: 5m
  wait: false
---
apiVersion: notification.toolkit.fluxcd.io/v1beta3
kind: Alert
metadata:
  name: alertmanager
  namespace: renovate
spec:
  eventSeverity: error
  eventSources:
  - kind: FluxInstance
    name: '*'
  - kind: GitRepository
    name: '*'
  - kind: HelmRelease
    name: '*'
  - kind: HelmRepository
    name: '*'
  - kind: Kustomization
    name: '*'
  - kind: OCIRepository
    name: '*'
  exclusionList:
  - error.*lookup.*github
  - dial.*tcp.*timeout
  - waiting.*socket
  providerRef:
    name: alertmanager
  suspend: false
---
apiVersion: notification.toolkit.fluxcd.io/v1beta3
kind: Alert
metadata:
  name: github-status
  namespace: renovate
spec:
  eventSeverity: error
  eventSources:
  - kind: Kustomization
    name: '*'
  exclusionList:
  - error.*lookup.*github
  - dial.*tcp.*timeout
  - waiting.*socket
  providerRef:
    name: github-status
  suspend: false
---
apiVersion: notification.toolkit.fluxcd.io/v1beta3
kind: Provider
metadata:
  name: alertmanager
  namespace: renovate
spec:
  address: http://alertmanager-operated.monitoring.svc.cluster.local:9093/api/v2/alerts/
  type: alertmanager
---
apiVersion: notification.toolkit.fluxcd.io/v1beta3
kind: Provider
metadata:
  name: github-status
  namespace: renovate
spec:
  address: https://github.com/Aviator-Coding/home-ops
  secretRef:
    name: github-status-token-secret
  type: github
---
apiVersion: source.toolkit.fluxcd.io/v1
kind: OCIRepository
metadata:
  name: app-template
  namespace: renovate
spec:
  interval: 5m
  layerSelector:
    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
    operation: copy
  ref:
    tag: 5.1.0
  url: oci://ghcr.io/bjw-s-labs/helm/app-template
```
</details>
<details>
<summary>Evidence: Schedule parity GHA vs CronJob</summary>

<code>gha_cron=0 */4 * * *&#10;in_cluster_cron=0 */4 * * *&#10;parity=True&#10;SCHEDULE_PARITY_OK</code>

```text
gha_cron=0 */4 * * *
in_cluster_cron=0 */4 * * *
parity=True
SCHEDULE_PARITY_OK
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"1cb04084d7e6316921c5bce8f8e06f485b788a47","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `kubernetes/apps/base/renovate/README.md:18` - README says RenovateRunMissing is the tripwire while the Homelab/renovate 1Password item is missing, but that alert&#39;s expr requires kube_cronjob_status_last_successful_time to exist (a prior success). On first deploy with no secret/success, only RenovateNeverSucceeded can fire. Update the bootstrap guidance to name RenovateNeverSucceeded (and note RenovateRunMissing only applies after at least one success).

🔧 Fix: Fix Renovate bootstrap tripwire alert docs
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`kustomize build kubernetes/apps/base/renovate/app` and `kubernetes/apps/main/renovate`</code>
- <code>`helm pull oci://ghcr.io/renovatebot/charts/renovate --version 46.255.0` + `helm template` with HelmRelease values</code>
- `Semantic acceptance checks on rendered Namespace/ExternalSecret/CronJob/Flux Kustomization (dry-run, schedule, secretRef, token preCommand, fences, GHA untouched)`
- <code>`promtool check rules` on PrometheusRule groups</code>
- <code>`node --check` + missing-env fail-closed + JWT mint behavior for `github-app-token.js`</code>
- <code>`kubeconform -ignore-missing-schemas` on rendered manifests</code>
- <code>GHA vs in-cluster cron schedule parity (`0 */4 * * *`)</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
