### PR TITLE
fix: split B70 onto devic.es/b70 and force-probe a7a0 iGPUs

### DIFF
--- a/docs/ai-gpu-changelog.md
+++ b/docs/ai-gpu-changelog.md
@@ -18,24 +18,27 @@ recently, and why?" without spelunking git.
 
 ---
 
-## Current baseline (2026-08-21)
+## Current baseline (2026-08-25)
 
 | Layer | Value |
 |-------|-------|
-| **GPU** | 1× Intel Arc Pro B70 (Battlemage G31, 32 GiB / 32656 MiB reported), on talos-3 via OCuLink |
-| **Device plugin** | `gpu.intel.com/xe: 99` shared units - a **scheduling token only, no VRAM fencing** |
-| **On the card** | chat (`vllm`) only. `vllm-embed` and `comfyui` are pinned `replicas: 0` |
+| **GPU (discrete)** | 1× Intel Arc Pro B70 (Battlemage G31, 32 GiB / 32656 MiB reported), talos-3 OCuLink PCI `0000:03:00.0` |
+| **GPU (iGPU)** | Raptor Lake `8086:a7a0` on all three nodes. Schematic carries `xe.force_probe=a7a0` + `i915.force_probe=!a7a0` (captain applies via `just talos apply-node`; not Flux) |
+| **B70 resource** | `devic.es/b70: 99` via generic-device-plugin (`--domain=devic.es`, DRM by-path at `0000:03:00.0`) - **scheduling identity only, no VRAM fencing** |
+| **xe pool** | `gpu.intel.com/xe: 99` via Intel GpuDevicePlugin - light QSV/browser (jellyfin/plex/playwright). B70 still included until iGPUs are confirmed after force_probe; follow-up `allowIDs: "0xa7a0"` drops B70 from xe |
+| **On the B70** | chat (`vllm`) + optional `tdarr-node`. `vllm-embed` and `comfyui` are pinned `replicas: 0` |
 | **Chat image** | `ghcr.io/ggml-org/llama.cpp:server-intel-b9592` (pin is load-bearing; do not float to `server-intel`) |
 | **Chat window** | `--ctx-size 262144` (native max, no yarn), auto `n_parallel=4` + `kv_unified=true` |
 | **Chat KV / FA** | `--flash-attn on`, `--cache-type-k/-v q8_0` (accepted on this pin; see 2026-08-21) |
 
-### Workloads on the B70
+### Workloads on the B70 (`devic.es/b70`)
 
 | Pod | Image | Role | VRAM |
 |-----|-------|------|------|
 | `vllm` | `ghcr.io/ggml-org/llama.cpp:server-intel-b9592` | Chat - **llama.cpp SYCL**, `Qwen3.6-35B-A3B UD-Q4_K_M`. Keeps the `vllm` name so the service + gateway backend stay stable; real vLLM OOMs the MoE warmup (intel/llm-scaler#382). | ~21.4 GiB weights + ~5.2 GiB KV @262k q8_0 |
 | `vllm-embed` | `intel/llm-scaler-vllm` | Embeddings - `Qwen3-VL-Embedding-2B`. **Default off** (`replicas: 0`); agentmemory moved to OpenRouter 2026-06-28. | (not resident) |
 | `comfyui` | `intel/llm-scaler-omni` | Image generation. **Default off** (`replicas: 0`). | (not resident) |
+| `tdarr-node` | tdarr (media ns) | QSV AV1 worker; codec needs the discrete card | light |
 
 ### SYCL / Battlemage constraints
 
@@ -53,6 +56,28 @@ When you merge an AI / GPU config change, prepend an entry (newest first):
 ## [YYYY-MM-DD] Short title  (PR #NNN)
 Change · Why · Evidence · Risk/rollback · Verify
 ```
+
+---
+
+## [2026-08-25] Split B70 onto `devic.es/b70`; force-probe a7a0 iGPUs
+
+**Change:**
+- `talos/schematic.yaml.j2`: `xe.force_probe=a7a0` + `i915.force_probe=!a7a0` (unquoted, same style as `module_blacklist=igc`). New factory ID `6b46d2c00a2295d31fef568ead1420f3088ac6adadc78abe1ff1c7ea8c1a6ef9` (was `ae2cb5793c9f8e61d2493f652b0e9251b2ffa525c5c17f3e4718b30d19940715`).
+- `generic-device-plugin`: advertise discrete B70 as `devic.es/b70` (count 99, DRM by-path `0000:03:00.0` → in-container `card0`/`renderD128`, `--domain=devic.es`).
+- Consumers moved off `gpu.intel.com/xe` onto `devic.es/b70`: `vllm`, `vllm-embed`, `comfyui`, `tdarr-node`. Placement is the extended resource, not hostname affinity.
+- Intel GpuDevicePlugin keeps B70 in the `gpu.intel.com/xe` pool for now (jellyfin/plex/playwright). Follow-up once iGPUs advertise xe: `allowIDs: "0xa7a0"`.
+
+**Why:** After the i915→xe migration, xe skips Raptor Lake `a7a0` by default, so only the B70 on talos-3 advertised `gpu.intel.com/xe`. When the B70 dropped off the PCIe bus, five GPU pods could not schedule. Restoring iGPUs as xe providers needs force_probe, but `gpu.intel.com/xe` is a bare share-count token with no VRAM fencing - once talos-1/2 advertise xe, the scheduler could place the ~21.4 GiB chat server on an iGPU. A dedicated `devic.es/b70` identity pins discrete consumers to the card without hostname affinity.
+
+**Evidence:** Rendered schematic registered at factory.talos.dev under the new ID; `talosctl validate -m metal` clean on all three node configs; installer v1.13.9 and Kubernetes pins v1.36.3 match live (no downgrade risk). B70 recovered via ordered cold cycle and enumerates as Battlemage G31 at `0000:03:00.0`.
+
+**Risk / rollback:** Schematic/kernel-arg changes are **not** Flux-applied - captain rolls `just talos apply-node` one node at a time. Revert the two force_probe args and re-apply to undo iGPU bind; move consumers back to `gpu.intel.com/xe` and drop the `b70` generic-device-plugin entry to undo the resource split. Do not set `allowIDs: "0xa7a0"` until every node advertises xe from its iGPU, or jellyfin/plex/playwright lose their only xe provider.
+
+**Verify:** After each `apply-node`, confirm iGPU xe allocatable and B70 identity:
+```sh
+kubectl get nodes -o json | jq -r '.items[] | "\(.metadata.name): xe=\(.status.allocatable."gpu.intel.com/xe" // "0") b70=\(.status.allocatable."devic.es/b70" // "0")"'
+```
+Expect `devic.es/b70=99` only on talos-3; after force_probe, `gpu.intel.com/xe` on all three.
 
 ---
 

--- a/docs/ai/b70-llm-serving-tuning.md
+++ b/docs/ai/b70-llm-serving-tuning.md
@@ -159,20 +159,24 @@ second card.
 
 ## 4. Single-card workload isolation (B70 time-slice contention)
 
-`talos-3` has **one** B70 via the Intel GPU device plugin. **As of 2026-06-28 / 2026-07-08,
-only chat is on the card by default.** `vllm-embed` is `replicas: 0` (agentmemory moved to
-OpenRouter). `comfyui` stays `replicas: 0` except during a deliberate image session. The B70
-has **no hardware compute partition** (no MIG, no SR-IOV compute slicing), so any second
-consumer **time-slices** the GPU and starves chat.
+`talos-3` has **one** B70. Discrete consumers (`vllm`, `vllm-embed`, `comfyui`, `tdarr-node`)
+request `devic.es/b70` from generic-device-plugin (DRM by-path at `0000:03:00.0`) - placement
+is that extended resource, not hostname affinity. **As of 2026-06-28 / 2026-07-08, only chat
+is on the card by default** among AI workloads. `vllm-embed` is `replicas: 0` (agentmemory
+moved to OpenRouter). `comfyui` stays `replicas: 0` except during a deliberate image session.
+`tdarr-node` may still co-schedule for light QSV. The B70 has **no hardware compute
+partition** (no MIG, no SR-IOV compute slicing), so any second consumer **time-slices** the
+GPU and starves chat.
 
 The 2026-06-26 measurements below were taken while embeddings could still be co-resident.
 They remain valid as the contention mechanism; they are not today's default inventory.
 
-> ⚠️ `--gpu-memory-utilization` and the device plugin's `sharedDevNum: 99`
-> (`kubernetes/apps/base/system/intel-device-plugin-operator/gpu/`) only divide **VRAM /
-> device-count** - neither isolates **compute**. The plugin advertises the one card as 99
-> schedulable slots. Chat vs ComfyUI is the remaining heavy pair; do not start ComfyUI
-> while `vllm` is up. Re-enabling `vllm-embed` would restore the three-consumer problem.
+> ⚠️ `--gpu-memory-utilization`, Intel `sharedDevNum: 99`, and generic-device-plugin
+> `count: 99` only divide **VRAM / device-count** - none isolate **compute**. `devic.es/b70`
+> is a scheduling identity (share-count token), not VRAM fencing. Chat vs ComfyUI is the
+> remaining heavy pair; do not start ComfyUI while `vllm` is up. Re-enabling `vllm-embed`
+> would restore the three-consumer problem. Light media (jellyfin/plex/playwright) stays on
+> `gpu.intel.com/xe` - see [`../ai-gpu-changelog.md`](../ai-gpu-changelog.md).
 
 ### Symptom & measured penalty
 
@@ -184,7 +188,7 @@ They remain valid as the contention mechanism; they are not today's default inve
 
 ### Mechanism (why no knob fixes it)
 
-- `sharedDevNum`: multiplexes device *count* only — leave it (cluster-wide; transcoders depend on it).
+- `sharedDevNum` / `devic.es/b70` count: multiplex device *count* only — leave both (xe pool for light media; b70 identity for discrete consumers).
 - vLLM `--gpu-memory-utilization`: VRAM cap only, zero effect on compute scheduling.
 - PriorityClass / in-cluster hooks: govern scheduling/preemption, not GPU time-slice
   arbitration, and would fight Flux — **not used.**

--- a/docs/ai/b70-second-card-decision.md
+++ b/docs/ai/b70-second-card-decision.md
@@ -31,16 +31,24 @@ OCuLink/M.2 adapter).
 > above for 2026-06-28 / 2026-07-08. Chat decode cited here (≈54.7 t/s) is PMZFX's
 > published figure, not this cluster's later ~61 / 68.4 t/s measurements.
 
-`talos-3` ran **three GPU workloads contending for one 32 GB B70**. Those AI
-workloads now request the dedicated `devic.es/b70` extended resource (generic-device-plugin
-on the B70 DRM by-path at `0000:03:00.0`); `gpu.intel.com/xe` is reserved for iGPU
-share-tokens (media/browser) via the Intel plugin's `allowIDs: "0xa7a0"`:
+`talos-3` ran **three GPU workloads contending for one 32 GB B70**. Discrete-GPU
+workloads now request the dedicated `devic.es/b70` extended resource
+(generic-device-plugin on the B70 DRM by-path at `0000:03:00.0`, advertised with
+`--domain=devic.es`). Consumers: vllm, vllm-embed, comfyui, and tdarr-node.
+`gpu.intel.com/xe` stays the Intel plugin pool for jellyfin/plex/playwright
+(light QSV/browser). The B70 remains in that xe pool for now so those media
+pods stay schedulable until `xe.force_probe=a7a0` is applied node-by-node and
+the iGPUs are confirmed advertising xe; a follow-up will set
+`allowIDs: "0xa7a0"` to drop the B70 from xe once that window is closed.
+`devic.es/b70` is a scheduling identity only (share count 99) — not VRAM
+fencing — so concurrent B70 holders still contend for the card's memory.
 
 | Workload | Engine | VRAM appetite | Notes |
 | --- | --- | --- | --- |
-| Chat (Qwen3.6-35B-A3B MoE, UD-Q4_K_M) | `llama.cpp:server-intel` (SYCL) | ~22–24 GB (weights + 128k KV q8_0) | Single-stream, ≈54.7 t/s |
-| Embeddings | `intel/llm-scaler-vllm:0.14.0-b8.3.1` | a few GB (pooling) | |
-| ComfyUI | `intel/llm-scaler-omni` | bursty, multi-GB images | Forced to ceph-block RWO, pinned talos-3 |
+| Chat (Qwen3.6-35B-A3B MoE, UD-Q4_K_M) | `llama.cpp:server-intel` (SYCL) | ~22–24 GB (weights + 128k KV q8_0) | Single-stream, ≈54.7 t/s; `devic.es/b70` |
+| Embeddings | `intel/llm-scaler-vllm:0.14.0-b8.3.1` | a few GB (pooling) | `devic.es/b70`; often `replicas: 0` |
+| ComfyUI | `intel/llm-scaler-omni` | bursty, multi-GB images | `devic.es/b70`; ceph-block RWO |
+| Tdarr node | tdarr_node (QSV) | light transcode | `devic.es/b70`; codec needs discrete card |
 
 These coexist via VRAM partitioning runbooks (e.g. scale vllm→0 for big ComfyUI jobs),
 i.e. **contention is managed manually, not eliminated**. A second card is fundamentally a

--- a/docs/ai/b70-second-card-decision.md
+++ b/docs/ai/b70-second-card-decision.md
@@ -31,8 +31,10 @@ OCuLink/M.2 adapter).
 > above for 2026-06-28 / 2026-07-08. Chat decode cited here (≈54.7 t/s) is PMZFX's
 > published figure, not this cluster's later ~61 / 68.4 t/s measurements.
 
-`talos-3` ran **three GPU workloads contending for one 32 GB B70** via the Intel GPU
-device plugin (`gpu.intel.com/xe`):
+`talos-3` ran **three GPU workloads contending for one 32 GB B70**. Those AI
+workloads now request the dedicated `devic.es/b70` extended resource (generic-device-plugin
+on the B70 DRM by-path at `0000:03:00.0`); `gpu.intel.com/xe` is reserved for iGPU
+share-tokens (media/browser) via the Intel plugin's `allowIDs: "0xa7a0"`:
 
 | Workload | Engine | VRAM appetite | Notes |
 | --- | --- | --- | --- |
@@ -62,8 +64,10 @@ three-workloads-on-one-card contention and gives **full single-card performance 
 workload simultaneously** (no more "scale vllm→0 to run ComfyUI" dance).
 
 - **Pro:** Simplest, lowest-risk, no new software stack. Each workload keeps the perf it
-  has today but stops fighting for VRAM/compute. Device selection is trivial — the device
-  plugin hands each pod its own `renderD12X` and SYCL/Level-Zero device index.
+  has today but stops fighting for VRAM/compute. Device selection is trivial on a dual-B70
+  node once each card has its own extended resource (same split used today for B70 vs
+  iGPU: dedicated resource identity, not a pooled `gpu.intel.com/xe` share-token). The
+  plugin then hands each pod only that card's `renderD12X` / Level-Zero device.
 - **Con:** Buys *isolation*, not *more capability*. Does not make chat faster, does not
   enable >32 GB models, does not fix prefill throughput. Pure quality-of-life.
 - **Verdict:** The safest reason to buy, but the weakest ROI — it solves a problem we are

--- a/docs/media-stack.md
+++ b/docs/media-stack.md
@@ -175,14 +175,17 @@ Autobrr is deployed (`kubernetes/apps/main/downloads/kustomization.yaml`). Cross
 
 **Namespace:** `media` | **Hostname:** `tdarr.${SECRET_DOMAIN}`
 
-Not a DaemonSet. After the i915 -> xe migration, only talos-3 advertises GPU
-(`gpu.intel.com/xe: 99` on the B70; talos-1/2 report 0). See
-[`ai-gpu-changelog.md`](ai-gpu-changelog.md).
+Not a DaemonSet. The worker requests `devic.es/b70` (generic-device-plugin on the
+discrete Arc Pro B70 at talos-3 PCI `0000:03:00.0`) because the AV1 QSV codec path
+needs that card; iGPUs restored by `xe.force_probe=a7a0` are not enough. Still a
+single replica (server `internalNode=false`), not a DaemonSet - a DaemonSet would
+strand Pending pods on nodes without the B70. Resource split and force_probe
+detail: [`ai-gpu-changelog.md`](ai-gpu-changelog.md).
 
 | Controller | Type | Purpose | GPU |
 |-----------|------|---------|-----|
 | `tdarr` | Deployment (1 pod) | Web UI, orchestrator, database | No |
-| `tdarr-node` | Deployment (`replicas: 1`) | Transcode worker on the xe node (talos-3 / B70) | `gpu.intel.com/xe: 1` |
+| `tdarr-node` | Deployment (`replicas: 1`) | Transcode worker on the B70 (talos-3) | `devic.es/b70: 1` |
 
 Optional external Windows node via Service `tdarr-node-lb` (`10.50.0.54:8266`,
 `tdarr/app/externalservice.yaml`). Live UI (2026-08-21): k8s node `talos-3`
@@ -331,11 +334,14 @@ Expect 1 `tdarr-*` server pod + 1 `tdarr-tdarr-node-*` worker on talos-3. The Td
 ### Monitoring GPU usage
 
 ```sh
-kubectl get nodes -o json | jq -r '.items[] | "\(.metadata.name): gpu.intel.com/xe=\(.status.allocatable."gpu.intel.com/xe" // "0")"'
+kubectl get nodes -o json | jq -r '.items[] | "\(.metadata.name): xe=\(.status.allocatable."gpu.intel.com/xe" // "0") b70=\(.status.allocatable."devic.es/b70" // "0")"'
 ```
 
-Only the B70 node (talos-3) reports `99`. `gpu.intel.com/i915` is 0 on every node
-after the xe migration.
+`devic.es/b70` is `99` only on talos-3 (tdarr-node / AI discrete consumers).
+`gpu.intel.com/xe` is the Intel plugin pool for jellyfin/plex/playwright; after
+`xe.force_probe=a7a0` is applied node-by-node it should appear on all three
+nodes (iGPUs). Until then the B70 remains in the xe pool so those media pods
+stay schedulable. `gpu.intel.com/i915` stays 0 after the xe migration.
 
 ### Finding which *arr app is failing imports
 

--- a/kubernetes/apps/base/ai/comfyui/app/helmrelease.yaml
+++ b/kubernetes/apps/base/ai/comfyui/app/helmrelease.yaml
@@ -29,6 +29,21 @@ spec:
   uninstall:
     keepHistory: false
   values:
+    # Pin to the B70 node. The 32GiB Arc Pro B70 is a discrete card on talos-3
+    # only (via OCuLink); every node also has a Raptor Lake iGPU that advertises
+    # the same gpu.intel.com/xe once xe.force_probe=a7a0 is applied. That
+    # resource is a share-count token with no VRAM fencing, so on its own it
+    # cannot keep image generation off an iGPU with nowhere near the VRAM it needs.
+    defaultPodOptions:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/hostname
+                    operator: In
+                    values:
+                      - talos-3
     controllers:
       comfyui:
         # Single GPU + RWO model/input PVCs -> never run two pods at once.

--- a/kubernetes/apps/base/ai/comfyui/app/helmrelease.yaml
+++ b/kubernetes/apps/base/ai/comfyui/app/helmrelease.yaml
@@ -31,7 +31,7 @@ spec:
   values:
     # Placement is enforced by devic.es/b70 (generic-device-plugin on the
     # discrete Arc Pro B70 at talos-3 PCI 0000:03:00.0), not hostname affinity.
-    # gpu.intel.com/xe is reserved for iGPU share-tokens (QSV/browser).
+    # jellyfin/plex/playwright stay on gpu.intel.com/xe.
     controllers:
       comfyui:
         # Single GPU + RWO model/input PVCs -> never run two pods at once.

--- a/kubernetes/apps/base/ai/comfyui/app/helmrelease.yaml
+++ b/kubernetes/apps/base/ai/comfyui/app/helmrelease.yaml
@@ -29,21 +29,9 @@ spec:
   uninstall:
     keepHistory: false
   values:
-    # Pin to the B70 node. The 32GiB Arc Pro B70 is a discrete card on talos-3
-    # only (via OCuLink); every node also has a Raptor Lake iGPU that advertises
-    # the same gpu.intel.com/xe once xe.force_probe=a7a0 is applied. That
-    # resource is a share-count token with no VRAM fencing, so on its own it
-    # cannot keep image generation off an iGPU with nowhere near the VRAM it needs.
-    defaultPodOptions:
-      affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-              - matchExpressions:
-                  - key: kubernetes.io/hostname
-                    operator: In
-                    values:
-                      - talos-3
+    # Placement is enforced by devic.es/b70 (generic-device-plugin on the
+    # discrete Arc Pro B70 at talos-3 PCI 0000:03:00.0), not hostname affinity.
+    # gpu.intel.com/xe is reserved for iGPU share-tokens (QSV/browser).
     controllers:
       comfyui:
         # Single GPU + RWO model/input PVCs -> never run two pods at once.
@@ -80,10 +68,10 @@ spec:
               requests:
                 cpu: "1"
                 memory: 8Gi
-                gpu.intel.com/xe: 1
+                devic.es/b70: 1
               limits:
                 memory: 32Gi
-                gpu.intel.com/xe: 1
+                devic.es/b70: 1
             probes:
               # No model loads until a workflow runs; startup is just process boot.
               startup:

--- a/kubernetes/apps/base/ai/vllm/app/helmrelease.yaml
+++ b/kubernetes/apps/base/ai/vllm/app/helmrelease.yaml
@@ -20,6 +20,22 @@ spec:
   uninstall:
     keepHistory: false
   values:
+    # Pin to the B70 node. The 32GiB Arc Pro B70 is a discrete card on talos-3
+    # only (via OCuLink); every node also has a Raptor Lake iGPU that advertises
+    # the same gpu.intel.com/xe once xe.force_probe=a7a0 is applied. That
+    # resource is a share-count token with no VRAM fencing, so on its own it
+    # cannot keep the 35B chat model server (~21.4GiB weights + ~5.2GiB KV
+    # @262k q8_0) off an iGPU with nowhere near the VRAM it needs.
+    defaultPodOptions:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/hostname
+                    operator: In
+                    values:
+                      - talos-3
     controllers:
       # Main chat model runs on llama.cpp SYCL, not vLLM: Qwen3.6-35B-A3B GPTQ
       # cannot complete vLLM warmup on a single 32GB B70 (21.4GiB weights +

--- a/kubernetes/apps/base/ai/vllm/app/helmrelease.yaml
+++ b/kubernetes/apps/base/ai/vllm/app/helmrelease.yaml
@@ -22,8 +22,8 @@ spec:
   values:
     # Placement is enforced by devic.es/b70 (generic-device-plugin on the
     # discrete Arc Pro B70 at talos-3 PCI 0000:03:00.0), not hostname affinity.
-    # gpu.intel.com/xe is reserved for iGPU share-tokens (QSV/browser); the 35B
-    # chat server (~21.4GiB weights + ~5.2GiB KV @262k q8_0) must not consume it.
+    # jellyfin/plex/playwright stay on gpu.intel.com/xe; the 35B chat server
+    # (~21.4GiB weights + ~5.2GiB KV @262k q8_0) must not consume that pool.
     controllers:
       # Main chat model runs on llama.cpp SYCL, not vLLM: Qwen3.6-35B-A3B GPTQ
       # cannot complete vLLM warmup on a single 32GB B70 (21.4GiB weights +

--- a/kubernetes/apps/base/ai/vllm/app/helmrelease.yaml
+++ b/kubernetes/apps/base/ai/vllm/app/helmrelease.yaml
@@ -20,22 +20,10 @@ spec:
   uninstall:
     keepHistory: false
   values:
-    # Pin to the B70 node. The 32GiB Arc Pro B70 is a discrete card on talos-3
-    # only (via OCuLink); every node also has a Raptor Lake iGPU that advertises
-    # the same gpu.intel.com/xe once xe.force_probe=a7a0 is applied. That
-    # resource is a share-count token with no VRAM fencing, so on its own it
-    # cannot keep the 35B chat model server (~21.4GiB weights + ~5.2GiB KV
-    # @262k q8_0) off an iGPU with nowhere near the VRAM it needs.
-    defaultPodOptions:
-      affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-              - matchExpressions:
-                  - key: kubernetes.io/hostname
-                    operator: In
-                    values:
-                      - talos-3
+    # Placement is enforced by devic.es/b70 (generic-device-plugin on the
+    # discrete Arc Pro B70 at talos-3 PCI 0000:03:00.0), not hostname affinity.
+    # gpu.intel.com/xe is reserved for iGPU share-tokens (QSV/browser); the 35B
+    # chat server (~21.4GiB weights + ~5.2GiB KV @262k q8_0) must not consume it.
     controllers:
       # Main chat model runs on llama.cpp SYCL, not vLLM: Qwen3.6-35B-A3B GPTQ
       # cannot complete vLLM warmup on a single 32GB B70 (21.4GiB weights +
@@ -101,10 +89,10 @@ spec:
               requests:
                 cpu: "2"
                 memory: 16Gi
-                gpu.intel.com/xe: 1
+                devic.es/b70: 1
               limits:
                 memory: 48Gi
-                gpu.intel.com/xe: 1
+                devic.es/b70: 1
             probes:
               # First boot downloads ~21GB GGUF; allow 30 min
               startup:
@@ -132,7 +120,7 @@ spec:
       vllm-embed:
         # Scaled to 0: agentmemory (its only consumer) moved to OpenRouter
         # embeddings (text-embedding-3-small, 1536-dim) on 2026-06-28, freeing
-        # this B70 gpu.intel.com/xe slot + ~5GB VRAM. Controller + PVC kept so
+        # this B70 devic.es/b70 slot + ~5GB VRAM. Controller + PVC kept so
         # restoring local embeddings is a one-line revert (replicas: 0 -> 1).
         replicas: 0
         strategy: Recreate
@@ -166,10 +154,10 @@ spec:
               requests:
                 cpu: "1"
                 memory: 4Gi
-                gpu.intel.com/xe: 1
+                devic.es/b70: 1
               limits:
                 memory: 16Gi
-                gpu.intel.com/xe: 1
+                devic.es/b70: 1
             probes:
               startup:
                 enabled: true

--- a/kubernetes/apps/base/media/tdarr/app/helmrelease.yaml
+++ b/kubernetes/apps/base/media/tdarr/app/helmrelease.yaml
@@ -85,14 +85,12 @@ spec:
               limits:
                 memory: 2Gi
 
-      # Worker: single replica, placed by its gpu.intel.com/xe request rather
-      # than by any affinity. The iGPUs on talos-1/2 stopped being advertised
-      # at the i915 -> xe driver migration, leaving talos-3 (Arc Pro B70) as
-      # the only node offering that resource; xe.force_probe=a7a0 in the
-      # factory schematic brings the iGPUs back, so this worker may then land
-      # on any node - fine for QSV transcoding. Still a single replica, not a
-      # DaemonSet: the server runs internalNode=false so one worker is enough,
-      # and a DaemonSet would strand Pending pods whenever a node lacks a GPU.
+      # Worker: single replica, placed by its devic.es/b70 request (discrete
+      # Arc Pro B70 on talos-3). Codec requirement needs the discrete card;
+      # the Raptor Lake iGPUs restored by xe.force_probe=a7a0 are not enough.
+      # Still a single replica, not a DaemonSet: the server runs
+      # internalNode=false so one worker is enough, and a DaemonSet would
+      # strand Pending pods whenever a node lacks the B70.
       tdarr-node:
         replicas: 1
         containers:
@@ -150,7 +148,7 @@ spec:
                 cpu: 100m
                 memory: 512Mi
               limits:
-                gpu.intel.com/xe: 1
+                devic.es/b70: 1
                 memory: 4Gi
 
     service:

--- a/kubernetes/apps/base/media/tdarr/app/helmrelease.yaml
+++ b/kubernetes/apps/base/media/tdarr/app/helmrelease.yaml
@@ -85,10 +85,14 @@ spec:
               limits:
                 memory: 2Gi
 
-      # Worker: single replica scheduled onto the node exposing gpu.intel.com/xe
-      # (the Arc B70 Pro on talos-3). The iGPUs on talos-1/2 are no longer
-      # advertised since the i915 -> xe driver migration, so a DaemonSet would
-      # leave permanently-Pending pods on GPU-less nodes.
+      # Worker: single replica, placed by its gpu.intel.com/xe request rather
+      # than by any affinity. The iGPUs on talos-1/2 stopped being advertised
+      # at the i915 -> xe driver migration, leaving talos-3 (Arc Pro B70) as
+      # the only node offering that resource; xe.force_probe=a7a0 in the
+      # factory schematic brings the iGPUs back, so this worker may then land
+      # on any node - fine for QSV transcoding. Still a single replica, not a
+      # DaemonSet: the server runs internalNode=false so one worker is enough,
+      # and a DaemonSet would strand Pending pods whenever a node lacks a GPU.
       tdarr-node:
         replicas: 1
         containers:

--- a/kubernetes/apps/base/system/generic-device-plugin/app/config/config.yaml
+++ b/kubernetes/apps/base/system/generic-device-plugin/app/config/config.yaml
@@ -5,3 +5,18 @@ devices:
       - count: 1000
         paths:
           - path: /dev/net/tun
+  # Discrete Arc Pro B70 on talos-3 (Battlemage G31, PCI 8086:e223 @ 0000:03:00.0).
+  # Intel GpuDevicePlugin cannot split xe KMD devices into distinct extended
+  # resources (both iGPU and B70 would be gpu.intel.com/xe), so this plugin
+  # owns the B70 under its own name. Discover via stable DRM by-path nodes and
+  # re-expose them at the conventional card0/renderD128 paths Level Zero expects
+  # inside the container. count matches the former sharedDevNum share-token model
+  # so vllm/vllm-embed/comfyui can still co-schedule when deliberately scaled up.
+  - name: b70
+    groups:
+      - count: 99
+        paths:
+          - path: /dev/dri/by-path/pci-0000:03:00.0-card
+            mountPath: /dev/dri/card0
+          - path: /dev/dri/by-path/pci-0000:03:00.0-render
+            mountPath: /dev/dri/renderD128

--- a/kubernetes/apps/base/system/generic-device-plugin/app/config/config.yaml
+++ b/kubernetes/apps/base/system/generic-device-plugin/app/config/config.yaml
@@ -11,7 +11,7 @@ devices:
   # owns the B70 under its own name. Discover via stable DRM by-path nodes and
   # re-expose them at the conventional card0/renderD128 paths Level Zero expects
   # inside the container. count matches the former sharedDevNum share-token model
-  # so vllm/vllm-embed/comfyui can still co-schedule when deliberately scaled up.
+  # so vllm/vllm-embed/comfyui/tdarr-node can still co-schedule concurrently.
   - name: b70
     groups:
       - count: 99

--- a/kubernetes/apps/base/system/generic-device-plugin/app/helmrelease.yaml
+++ b/kubernetes/apps/base/system/generic-device-plugin/app/helmrelease.yaml
@@ -28,6 +28,9 @@ spec:
               tag: 36bfc606bba2064de6ede0ff2764cbb52edff70d@sha256:ba6f0b4cf6c858d6ad29ba4d32e4da11638abbc7d96436bf04f582a97b2b8821
             args:
               - --log-level=info
+              # Pinned image defaults to squat.ai; force the documented domain
+              # so consumers requesting devic.es/b70 match allocatable capacity.
+              - --domain=devic.es
               - --config=/config/config.yaml
             resources:
               requests:

--- a/kubernetes/apps/base/system/intel-device-plugin-operator/gpu/helmrelease.yaml
+++ b/kubernetes/apps/base/system/intel-device-plugin-operator/gpu/helmrelease.yaml
@@ -34,10 +34,9 @@ spec:
     name: xe
     nodeFeatureRule: false
     sharedDevNum: 99
-    # Only the Raptor Lake iGPU (8086:a7a0). The discrete Arc Pro B70
-    # (8086:e223) is advertised separately as devic.es/b70 by
-    # generic-device-plugin — GpuDevicePlugin always registers xe-KMD devices
-    # under gpu.intel.com/xe, so a second instance cannot give the B70 its own
-    # resource name. Without this allow-list, force_probe would pool iGPU + B70
-    # shares on talos-3 and AI pods requesting xe could land on the iGPU.
-    allowIDs: "0xa7a0"
+    # Discrete B70 consumers (vllm/vllm-embed/comfyui/tdarr-node) request
+    # devic.es/b70 from generic-device-plugin, not this pool. keep B70 in
+    # gpu.intel.com/xe for now so jellyfin/plex/playwright stay schedulable
+    # until xe.force_probe=a7a0 is applied node-by-node and the iGPUs are
+    # confirmed advertising xe. Follow-up: allowIDs: "0xa7a0" to drop the B70
+    # from this pool once that window is closed.

--- a/kubernetes/apps/base/system/intel-device-plugin-operator/gpu/helmrelease.yaml
+++ b/kubernetes/apps/base/system/intel-device-plugin-operator/gpu/helmrelease.yaml
@@ -34,3 +34,10 @@ spec:
     name: xe
     nodeFeatureRule: false
     sharedDevNum: 99
+    # Only the Raptor Lake iGPU (8086:a7a0). The discrete Arc Pro B70
+    # (8086:e223) is advertised separately as devic.es/b70 by
+    # generic-device-plugin — GpuDevicePlugin always registers xe-KMD devices
+    # under gpu.intel.com/xe, so a second instance cannot give the B70 its own
+    # resource name. Without this allow-list, force_probe would pool iGPU + B70
+    # shares on talos-3 and AI pods requesting xe could land on the iGPU.
+    allowIDs: "0xa7a0"

--- a/talos/schematic.yaml.j2
+++ b/talos/schematic.yaml.j2
@@ -18,6 +18,8 @@ customization:
     - pcie_aspm=off # Disable PCIe Active State Power Management to prevent link state transitions
     - pci=realloc # Reallocate PCIe resource windows for the Arc B70 Pro OCuLink switch
     - pci=assign-busses # BIOS leaves the B70's e2ff switch at [bus 00-00] with no spare bus numbers behind 00:01.0; kernel must renumber all buses (NIC renames are safe: bonds select members via LinkAliasConfig)
+    - xe.force_probe=a7a0 # Bind xe to the Raptor Lake i9-13900H iGPU (8086:a7a0), which xe skips by default
+    - i915.force_probe=!a7a0 # Keep i915 off the iGPU so xe owns it (inert today: no siderolabs/i915 extension)
     - talos.auditd.disabled=1 # Less security, faster puter
     # Bond interface kernel parameters for early network initialization
     # - bond=bond0:enp2s0f0np0,enp2s0f1np1:mode=802.3ad:miimon=100:lacp_rate=1:xmit_hash_policy=layer3+4:updelay=200:downdelay=200


### PR DESCRIPTION
## Intent

Fix the live GPU incident where five pods (vllm, jellyfin, plex, tdarr-node, playwright) could not schedule because no node advertised gpu.intel.com/xe.

Root cause (corrected from the original brief during investigation): device a7a0 is the Raptor Lake iGPU present on ALL three nodes, NOT the discrete Arc Pro B70. The xe driver skips a7a0 by default, so since the i915->xe migration the iGPUs stopped being advertised, leaving the B70 on talos-3 as the only xe provider. The incident itself was caused by the B70 dropping off talos-3's PCIe bus; that has since been recovered by the captain via a correctly-ordered cold cycle (B70 now enumerates as Battlemage G31 at 0000:03:00.0, xe allocatable 99, all five pods Running).

Changes on this branch (3 commits):
1. talos/schematic.yaml.j2 - add two extraKernelArgs, unquoted to match the existing module_blacklist=igc style: xe.force_probe=a7a0 (bind xe to the a7a0 iGPU) and i915.force_probe=!a7a0 (keep i915 off it; inert today since no siderolabs/i915 extension is installed). This restores the iGPUs on all three nodes as xe providers so GPU workloads are no longer single-homed on the B70.
2. kubernetes/apps/base/ai/vllm/app/helmrelease.yaml and kubernetes/apps/base/ai/comfyui/app/helmrelease.yaml - pin vllm, vllm-embed and comfyui to talos-3 via nodeAffinity (kubernetes.io/hostname matchExpressions, same shape as downloads/sabnzbd). Required safety measure: gpu.intel.com/xe is a bare share-count token with no VRAM fencing, and these pods request only 'gpu.intel.com/xe: 1'. Once force_probe makes talos-1/2 advertise xe from their iGPUs, the scheduler could otherwise place the 35B chat model server (~21.4GiB weights + ~5.2GiB KV @262k q8_0) onto an iGPU with nowhere near the VRAM it needs.
3. kubernetes/apps/base/media/tdarr/app/helmrelease.yaml - correct the worker placement comment to reflect that force_probe brings the iGPUs back, so the tdarr worker may then land on any node, which is fine for QSV transcoding. Deliberately NOT pinned: jellyfin, plex, tdarr-node and playwright do light transcode/browser work that an iGPU handles well, and letting them spread is the point of force_probe plus it reduces B70 VRAM contention.

Verification already performed: rendered schematic produces a NEW factory ID 6b46d2c00a2295d31fef568ead1420f3088ac6adadc78abe1ff1c7ea8c1a6ef9 (was ae2cb5793c9f8e61d2493f652b0e9251b2ffa525c5c17f3e4718b30d19940715), confirmed registered at factory.talos.dev and baked into the installer image; talosctl validate -m metal clean on all three rendered node configs; installer v1.13.9 and all Kubernetes pins v1.36.3 match the live cluster exactly, so no downgrade risk.

Scope constraints: do NOT touch the TalosUpgrade/KubernetesUpgrade tuppr CRs, the Kubernetes version, or the installer version pin. Do not modify talos/machineconfig.yaml.j2. talos/*.j2 changes are not applied by Flux; the captain applies them node-by-node with just talos apply-node, and this worker must not apply anything to live nodes.

## What Changed

- Add `xe.force_probe=a7a0` and `i915.force_probe=!a7a0` to `talos/schematic.yaml.j2` so the Raptor Lake iGPU on every node is bound by xe again after the i915→xe migration.
- Advertise the discrete Arc Pro B70 as `devic.es/b70` via generic-device-plugin (DRM by-path at `0000:03:00.0`, `--domain=devic.es`) and move `vllm`, `vllm-embed`, `comfyui`, and `tdarr-node` off `gpu.intel.com/xe` onto that resource so heavy discrete consumers cannot land on iGPUs once they reappear.
- Leave jellyfin/plex/playwright on the Intel `gpu.intel.com/xe` pool (B70 still included until iGPUs are confirmed) and update AI/media GPU docs to match the B70 vs xe split.

## Risk Assessment

⚠️ Medium: Authorized split-resource design closes the iGPU scheduling hole for AI/tdarr, but production GPU injection for the 35B server moves from the Intel plugin to generic-device-plugin DRM by-path mounts with accepted temporary B70 dual-advertisement and VRAM contention until the allowIDs follow-up.

## Testing

Offline Talos validate passed for all three nodes; factory accepted the new schematic ID with both force_probe kernel args; kustomize/helm consumers emit devic.es/b70 for vllm/vllm-embed/comfyui/tdarr-node and gpu.intel.com/xe for jellyfin/plex/playwright with no hostname pins; tuppr and installer pins stayed frozen. Live cluster apply/iGPU xe advertisement was out of scope and not exercised (no kubeconfig).

<details>
<summary>Evidence: End-to-end verification transcript</summary>

```text
GPU force_probe + B70 resource split — local verification transcript
========================================================================

1) Talos schematic (factory.talos.dev consumer)
   previous factory id: ae2cb5793c9f8e61d2493f652b0e9251b2ffa525c5c17f3e4718b30d19940715
   new factory id:      {"id":"6b46d2c00a2295d31fef568ead1420f3088ac6adadc78abe1ff1c7ea8c1a6ef9","schematic":"customization:\n    extraKernelArgs:\n        - -init_on_alloc\n        - -init_on_free\n        - -selinux\n        - apparmor=0\n        - init_on_alloc=0\n        - init_on_free=0\n        - intel_iommu=on\n        - iommu=pt\n        - mitigations=off\n        - module_blacklist=igc\n        - security=none\n        - sysctl.kernel.kexec_load_disabled=1\n        - nvme_core.default_ps_max_latency_us=0\n        - pcie_aspm=off\n        - pci=realloc\n        - pci=assign-busses\n        - xe.force_probe=a7a0\n        - i915.force_probe=!a7a0\n        - talos.auditd.disabled=1\n    systemExtensions:\n        officialExtensions:\n            - siderolabs/xe\n            - siderolabs/intel-ucode\n            - siderolabs/mei\n            - siderolabs/nfsrahead\n            - siderolabs/thunderbolt\n"}
   force_probe args in rendered extraKernelArgs:
      - xe.force_probe=a7a0
      - i915.force_probe=!a7a0
   talosctl validate -m metal: all 3 node configs OK (see talos-validate.txt)
   installer image available: factory .../v1.13.9/installer-amd64.tar HTTP 200

2) generic-device-plugin advertises discrete B70 as extended resource devic.es/b70
   kustomize ConfigMap device b70 -> PCI 0000:03:00.0 by-path, count 99
   DaemonSet args include --domain=devic.es (matches consumer resource domain)

3) helm template (app-template 5.1.0) rendered pod resources:
   - Deployment/vllm: devic.es/b70 req=1 lim=1
   - Deployment/vllm-vllm-embed: devic.es/b70 req=1 lim=1
   - Deployment/comfyui: devic.es/b70 req=1 lim=1
   - Deployment/tdarr-tdarr-node: devic.es/b70 req=None lim=1
   - Deployment/jellyfin: gpu.intel.com/xe req=None lim=1
   - Deployment/plex: gpu.intel.com/xe req=None lim=1
   - Deployment/playwright: gpu.intel.com/xe req=None lim=1
   - DaemonSet/generic-device-plugin: (none) args=['--log-level=info', '--domain=devic.es', '--config=/config/config.yaml']

4) Safety split check
   heavy (vllm, vllm-embed, comfyui, tdarr-node): devic.es/b70 only
   light (jellyfin, plex, playwright): gpu.intel.com/xe only
   no hostname nodeAffinity pins on these workloads
   intel GpuDevicePlugin still name=xe sharedDevNum=99, allowIDs unset (B70 remains in xe until iGPUs confirmed)

5) Scope gates
   talos/machineconfig.yaml.j2 unchanged; installer v1.13.9; kubelet v1.36.3
   tuppr TalosUpgrade/KubernetesUpgrade manifests unchanged
   no live apply-node performed (out of worker scope)

RESULT: declarative contracts verified via real consumers (talosctl, factory, kustomize, helm).
Live iGPU xe advertisement after force_probe requires captain node apply — not exercised here.
```
</details>
<details>
<summary>Evidence: talosctl validate (3 nodes)</summary>

<code>/var/.../talos-1.yaml is valid for metal mode&#10;/var/.../talos-2.yaml is valid for metal mode&#10;/var/.../talos-3.yaml is valid for metal mode&#10;OK: 3 node config(s) render and validate; schematic renders</code>

```text
/var/folders/yr/h20mxtv56yj1c1pt9tr1_kbc0000gn/T/tmp.HuEJdzeE49/talos-1.yaml is valid for metal mode
/var/folders/yr/h20mxtv56yj1c1pt9tr1_kbc0000gn/T/tmp.HuEJdzeE49/talos-2.yaml is valid for metal mode
/var/folders/yr/h20mxtv56yj1c1pt9tr1_kbc0000gn/T/tmp.HuEJdzeE49/talos-3.yaml is valid for metal mode
OK: 3 node config(s) render and validate; schematic renders
```
</details>
<details>
<summary>Evidence: Factory schematic ID (new)</summary>

<code>{&#10;&#34;id&#34;: &#34;6b46d2c00a2295d31fef568ead1420f3088ac6adadc78abe1ff1c7ea8c1a6ef9&#34;&#10;}</code>

```text
{
  "id": "6b46d2c00a2295d31fef568ead1420f3088ac6adadc78abe1ff1c7ea8c1a6ef9"
}
```
</details>
<details>
<summary>Evidence: Rendered extraKernelArgs (force_probe)</summary>

<code>xe.force_probe=a7a0&#10;i915.force_probe=!a7a0</code>

```text
[
  "-init_on_alloc",
  "-init_on_free",
  "-selinux",
  "apparmor=0",
  "init_on_alloc=0",
  "init_on_free=0",
  "intel_iommu=on",
  "iommu=pt",
  "mitigations=off",
  "module_blacklist=igc",
  "security=none",
  "sysctl.kernel.kexec_load_disabled=1",
  "nvme_core.default_ps_max_latency_us=0",
  "pcie_aspm=off",
  "pci=realloc",
  "pci=assign-busses",
  "xe.force_probe=a7a0",
  "i915.force_probe=!a7a0",
  "talos.auditd.disabled=1"
]
```
</details>
<details>
<summary>Evidence: helm template resource summary</summary>

```text
{
  "vllm": {
    "release": "vllm",
    "resources": [
      {
        "kind": "Deployment",
        "name": "vllm",
        "container": "app",
        "gpu": {
          "devic.es/b70": {
            "req": 1,
            "lim": 1
          }
        }
      },
      {
        "kind": "Deployment",
        "name": "vllm-vllm-embed",
        "container": "app",
        "gpu": {
          "devic.es/b70": {
            "req": 1,
            "lim": 1
          }
        }
      }
    ]
  },
  "comfyui": {
    "release": "comfyui",
    "resources": [
      {
        "kind": "Deployment",
        "name": "comfyui",
        "container": "app",
        "gpu": {
          "devic.es/b70": {
            "req": 1,
            "lim": 1
          }
        }
      }
    ]
  },
  "tdarr": {
    "release": "tdarr",
    "resources": [
      {
        "kind": "Deployment",
        "name": "tdarr-tdarr-node",
        "container": "app",
        "gpu": {
          "devic.es/b70": {
            "req": null,
            "lim": 1
          }
        }
      }
    ]
  },
  "jellyfin": {
    "release": "jellyfin",
    "resources": [
      {
        "kind": "Deployment",
        "name": "jellyfin",
        "container": "app",
        "gpu": {
          "gpu.intel.com/xe": {
            "req": null,
            "lim": 1
          }
        }
      }
    ]
  },
  "plex": {
    "release": "plex",
    "resources": [
      {
        "kind": "Deployment",
        "name": "plex",
        "container": "app",
        "gpu": {
          "gpu.intel.com/xe": {
            "req": null,
            "lim": 1
          }
        }
      }
    ]
  },
  "playwright": {
    "release": "playwright",
    "resources": [
      {
        "kind": "Deployment",
        "name": "playwright",
        "container": "app",
        "gpu": {
          "gpu.intel.com/xe": {
            "req": null,
            "lim": 1
          }
        }
      }
    ]
  },
  "generic-device-plugin": {
    "release": "generic-device-plugin",
    "resources": [
      {
        "kind": "DaemonSet",
        "name": "generic-device-plugin",
        "container": "app",
        "gpu": {},
        "args": [
          "--log-level=info",
          "--domain=devic.es",
          "--config=/config/config.yaml"
        ]
      }
    ]
  }
}
```
</details>
<details>
<summary>Evidence: Rendered workload GPU resources (vllm/comfyui/tdarr/jellyfin/plugin)</summary>

```text
[
  {
    "file": "vllm.helm-template.yaml",
    "kind": "Deployment",
    "name": "vllm",
    "container": "app",
    "resources": {
      "limits": {
        "devic.es/b70": 1,
        "memory": "48Gi"
      },
      "requests": {
        "cpu": "2",
        "devic.es/b70": 1,
        "memory": "16Gi"
      }
    },
    "args": [
      "-hf",
      "unsloth/Qwen3.6-35B-A3B-GGUF:UD-Q4_K_M",
      "--alias",
      "qwen3.6-35b-a3b",
      "--host",
      "0.0.0.0",
      "--port",
      "8000",
      "--ctx-size",
      "262144",
      "-ngl",
      "99",
      "--jinja",
      "--metrics",
      "--flash-attn",
      "on",
      "--cache-type-k",
      "q8_0",
      "--cache-type-v",
      "q8_0",
      "--cache-reuse",
      "256",
      "--no-mmap"
    ]
  },
  {
    "file": "vllm.helm-template.yaml",
    "kind": "Deployment",
    "name": "vllm-vllm-embed",
    "container": "app",
    "resources": {
      "limits": {
        "devic.es/b70": 1,
        "memory": "16Gi"
      },
      "requests": {
        "cpu": "1",
        "devic.es/b70": 1,
        "memory": "4Gi"
      }
    },
    "args": null
  },
  {
    "file": "comfyui.helm-template.yaml",
    "kind": "Deployment",
    "name": "comfyui",
    "container": "app",
    "resources": {
      "limits": {
        "devic.es/b70": 1,
        "memory": "32Gi"
      },
      "requests": {
        "cpu": "1",
        "devic.es/b70": 1,
        "memory": "8Gi"
      }
    },
    "args": [
      "cd /llm/ComfyUI && exec python3 main.py --listen 0.0.0.0 --port 8188\n"
    ]
  },
  {
    "file": "tdarr.helm-template.yaml",
    "kind": "Deployment",
    "name": "tdarr",
    "container": "app",
    "resources": {
      "limits": {
        "memory": "2Gi"
      },
      "requests": {
        "cpu": "100m",
        "memory": "512Mi"
      }
    },
    "args": null
  },
  {
    "file": "tdarr.helm-template.yaml",
    "kind": "Deployment",
    "name": "tdarr-tdarr-node",
    "container": "app",
    "resources": {
      "limits": {
        "devic.es/b70": 1,
        "memory": "4Gi"
      },
      "requests": {
        "cpu": "100m",
        "memory": "512Mi"
      }
    },
    "args": null
  },
  {
    "file": "jellyfin.helm-template.yaml",
    "kind": "Deployment",
    "name": "jellyfin",
    "container": "app",
    "resources": {
      "limits": {
        "gpu.intel.com/xe": 1,
        "memory": "8Gi"
      },
      "requests": {
        "cpu": "100m"
      }
    },
    "args": null
  },
  {
    "file": "generic-device-plugin.helm-template.yaml",
    "kind": "DaemonSet",
    "name": "generic-device-plugin",
    "container": "app",
    "resources": {
      "limits": {
        "memory": "64Mi"
      },
      "requests": {
        "cpu": "10m"
      }
    },
    "args": [
      "--log-level=info",
      "--domain=devic.es",
      "--config=/config/config.yaml"
    ]
  }
]
```
</details>
<details>
<summary>Evidence: generic-device-plugin kustomize output</summary>

```text
apiVersion: v1
data:
  config.yaml: |
    ---
    devices:
      - name: tun
        groups:
          - count: 1000
            paths:
              - path: /dev/net/tun
      # Discrete Arc Pro B70 on talos-3 (Battlemage G31, PCI 8086:e223 @ 0000:03:00.0).
      # Intel GpuDevicePlugin cannot split xe KMD devices into distinct extended
      # resources (both iGPU and B70 would be gpu.intel.com/xe), so this plugin
      # owns the B70 under its own name. Discover via stable DRM by-path nodes and
      # re-expose them at the conventional card0/renderD128 paths Level Zero expects
      # inside the container. count matches the former sharedDevNum share-token model
      # so vllm/vllm-embed/comfyui/tdarr-node can still co-schedule concurrently.
      - name: b70
        groups:
          - count: 99
            paths:
              - path: /dev/dri/by-path/pci-0000:03:00.0-card
                mountPath: /dev/dri/card0
              - path: /dev/dri/by-path/pci-0000:03:00.0-render
                mountPath: /dev/dri/renderD128
kind: ConfigMap
metadata:
  name: generic-device-plugin
---
apiVersion: helm.toolkit.fluxcd.io/v2
kind: HelmRelease
metadata:
  name: generic-device-plugin
spec:
  chartRef:
    kind: OCIRepository
    name: app-template
    namespace: flux-system
  driftDetection:
    mode: enabled
  interval: 30m
  values:
    controllers:
      generic-device-plugin:
        containers:
          app:
            args:
            - --log-level=info
            - --domain=devic.es
            - --config=/config/config.yaml
            image:
              repository: ghcr.io/squat/generic-device-plugin
              tag: 36bfc606bba2064de6ede0ff2764cbb52edff70d@sha256:ba6f0b4cf6c858d6ad29ba4d32e4da11638abbc7d96436bf04f582a97b2b8821
            resources:
              limits:
                memory: 64Mi
              requests:
                cpu: 10m
            securityContext:
              allowPrivilegeEscalation: false
              capabilities:
                drop:
                - ALL
              readOnlyRootFilesystem: true
        strategy: RollingUpdate
        type: daemonset
    defaultPodOptions:
      priorityClassName: system-node-critical
    persistence:
      config:
        globalMounts:
        - path: /config/config.yaml
          readOnly: true
          subPath: config.yaml
        name: generic-device-plugin
        type: configMap
      dev:
        globalMounts:
        - readOnly: true
        hostPath: /dev
        type: hostPath
      sys:
        globalMounts:
        - readOnly: true
        hostPath: /sys
        type: hostPath
      var-lib-kubelet-device-plugins:
        hostPath: /var/lib/kubelet/device-plugins
        type: hostPath
```
</details>
<details>
<summary>Evidence: Scope pin check (machineconfig + tuppr unchanged)</summary>

```text
{
  "talos/machineconfig.yaml.j2": {
    "changed": false,
    "installer_pin_old": [
      "version: v1"
    ],
    "installer_pin_new": [
      "version: v1"
    ]
  },
  "kubernetes/apps/base/system-upgrade/tuppr/upgrades/talosupgrade.yaml": {
    "changed": false,
    "installer_pin_old": [
      "version: v1.13.9"
    ],
    "installer_pin_new": [
      "version: v1.13.9"
    ]
  },
  "kubernetes/apps/base/system-upgrade/tuppr/upgrades/kubernetesupgrade.yaml": {
    "changed": false,
    "installer_pin_old": [
      "version: v1.36.3"
    ],
    "installer_pin_new": [
      "version: v1.36.3"
    ]
  },
  "machineconfig_pins": {
    "installer": "v1.13.9",
    "kubelet": "v1.36.3"
  }
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"e63924b98f765b4bc6111f1ce9c6833c5a2d5036","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed (2) ✅</summary>

- 🚨 `kubernetes/apps/base/ai/vllm/app/helmrelease.yaml:29` - Claimed durable invariant is &#39;vllm/vllm-embed/comfyui must not run on an iGPU&#39; (35B + KV cannot fit; host-RAM OOM risk). This branch only adds nodeAffinity to hostname talos-3 while still requesting the undifferentiated share-token gpu.intel.com/xe: 1 (see also comfyui helmrelease defaultPodOptions and resources). After xe.force_probe=a7a0, talos-3 has two xe DRM devices (Raptor Lake iGPU a7a0 + Arc Pro B70). intel-device-plugin-gpu uses a single resource name with sharedDevNum: 99, so capacity becomes one pooled token space across both cards; Allocate hands the pod one physical render node (repo docs/ai/b70-second-card-decision.md: each pod gets its own renderD12X). Reachable failure: scheduler satisfies In [talos-3], plugin assigns the iGPU share, ONEAPI_DEVICE_SELECTOR=level_zero:0 binds that only visible device, model load fails or OOMs host RAM — same class of failure the pin was meant to close for talos-1/2. nodeAffinity is necessary but not sufficient. ONEAPI/ZE filters cannot fix it once the plugin already mounted the wrong card. Earliest shared boundary: split schedulable identity so discrete B70 is a different extended resource than iGPU xe (e.g. second GPU plugin instance / allow-id filter / generic-device-plugin on the B70 PCI path) and have vllm/vllm-embed/comfyui request that resource; keep gpu.intel.com/xe for jellyfin/plex/tdarr/playwright. Per-node skipping force_probe on talos-3 would also work but needs node-specific kernel args outside the shared schematic, and machineconfig changes are out of this change&#39;s scope.

🔧 Fix: Split B70 onto dedicated devic.es/b70 resource
2 issues (1 error, 1 warning) still open:
- 🚨 `kubernetes/apps/base/system/generic-device-plugin/app/helmrelease.yaml:29` - vllm/vllm-embed/comfyui request devic.es/b70, but the pinned generic-device-plugin image (ghcr.io/squat/generic-device-plugin@36bfc606…, 2024-03-14) hard-codes defaultDomain = &#34;squat.ai&#34; and this HelmRelease only passes --log-level/--config — no --domain. Resource construction is path.Join(domain, name), so the plugin will advertise squat.ai/b70 (and only on nodes where the by-path nodes exist). Pods requesting devic.es/b70 never match any allocatable resource and stay Pending. The default only became devic.es in upstream 9eae799 (2026-04-14), after this pin. Earliest fix: add --domain=devic.es to the plugin args (preferred; keeps the documented resource name and is stable across image bumps), or change every consumer to squat.ai/b70.
- ⚠️ `kubernetes/apps/base/system/intel-device-plugin-operator/gpu/helmrelease.yaml:43` - allowIDs: &#34;0xa7a0&#34; removes the B70 from gpu.intel.com/xe as soon as Flux reconciles the Intel GPU plugin, while xe.force_probe=a7a0 only takes effect after the captain applies the new schematic node-by-node (out of Flux). Until at least one node has a bound a7a0 DRM device, jellyfin/plex/tdarr-node/playwright (still on gpu.intel.com/xe) lose every xe provider — the same class of unschedulable outage this branch set out to close. AI pods are insulated only after the domain fix above. Coordinate apply order (schematic/force_probe on nodes before or immediately with allowIDs) or temporarily keep B70 in the xe pool until iGPUs are confirmed advertised.

🔧 Fix: Fix B70 domain, drop allowIDs, move tdarr
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash scripts/ci/talos-validate.sh` (3 nodes metal validate + schematic render)</code>
- <code>`minijinja-cli talos/schematic.yaml.j2` then YAML-parse `extraKernelArgs` for `xe.force_probe=a7a0` and `i915.force_probe=!a7a0`</code>
- <code>`curl -X POST https://factory.talos.dev/schematics` base vs HEAD (IDs ae2cb579… → 6b46d2c0…); installer-amd64.tar v1.13.9 HTTP 200</code>
- <code>`kustomize build kubernetes/apps/base/system/generic-device-plugin/app` semantic check of b70 by-path ConfigMap + `--domain=devic.es`</code>
- <code>`helm template` app-template 5.1.0 for vllm, comfyui, tdarr, jellyfin, plex, playwright, generic-device-plugin resource identities</code>
- `Scope gate: machineconfig.yaml.j2 and tuppr TalosUpgrade/KubernetesUpgrade unchanged; installer v1.13.9 / kubelet v1.36.3`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
