### PR TITLE
fix(talos): restore siderolabs/i915 for a7a0 iGPU firmware

### DIFF
--- a/docs/ai-gpu-changelog.md
+++ b/docs/ai-gpu-changelog.md
@@ -18,14 +18,14 @@ recently, and why?" without spelunking git.
 
 ---
 
-## Current baseline (2026-08-25)
+## Current baseline (2026-08-26)
 
 | Layer | Value |
 |-------|-------|
 | **GPU (discrete)** | 1× Intel Arc Pro B70 (Battlemage G31, 32 GiB / 32656 MiB reported), talos-3 OCuLink PCI `0000:03:00.0` |
-| **GPU (iGPU)** | Raptor Lake `8086:a7a0` on all three nodes. Schematic carries `xe.force_probe=a7a0` + `i915.force_probe=!a7a0` (captain applies via `just talos apply-node`; not Flux) |
+| **GPU (iGPU)** | Raptor Lake `8086:a7a0` on all three nodes. Schematic: `siderolabs/xe` + `siderolabs/i915` (i915/ firmware for xe; `i915.ko` kept off a7a0), `xe.force_probe=a7a0` + `i915.force_probe=!a7a0` (captain applies via `just talos apply-node`; not Flux) |
 | **B70 resource** | `devic.es/b70: 99` via generic-device-plugin (`--domain=devic.es`, DRM by-path at `0000:03:00.0`) - **scheduling identity only, no VRAM fencing** |
-| **xe pool** | `gpu.intel.com/xe: 99` via Intel GpuDevicePlugin - light QSV/browser (jellyfin/plex/playwright). B70 still included until iGPUs are confirmed after force_probe; follow-up `allowIDs: "0xa7a0"` drops B70 from xe |
+| **xe pool** | `gpu.intel.com/xe: 99` via Intel GpuDevicePlugin - light QSV/browser (jellyfin/plex/playwright). B70 still included until iGPUs are confirmed after force_probe + i915 firmware; follow-up `allowIDs: "0xa7a0"` drops B70 from xe |
 | **On the B70** | chat (`vllm`) + optional `tdarr-node`. `vllm-embed` and `comfyui` are pinned `replicas: 0` |
 | **Chat image** | `ghcr.io/ggml-org/llama.cpp:server-intel-b9592` (pin is load-bearing; do not float to `server-intel`) |
 | **Chat window** | `--ctx-size 262144` (native max, no yarn), auto `n_parallel=4` + `kv_unified=true` |
@@ -56,6 +56,29 @@ When you merge an AI / GPU config change, prepend an entry (newest first):
 ## [YYYY-MM-DD] Short title  (PR #NNN)
 Change · Why · Evidence · Risk/rollback · Verify
 ```
+
+---
+
+## [2026-08-26] Restore `siderolabs/i915` for a7a0 iGPU firmware
+
+**Change:**
+- `talos/schematic.yaml.j2`: re-add `siderolabs/i915` alongside (not replacing) `siderolabs/xe`. Factory ID `b1a6b2ffb73af6f3b9d1f10921a4f5d8ac76aefa10be4af317f73fce3d488d04` (was `6b46d2c00a2295d31fef568ead1420f3088ac6adadc78abe1ff1c7ea8c1a6ef9`).
+- Comment only on `i915.force_probe=!a7a0`: was inert without the extension; now load-bearing because `siderolabs/i915` ships `i915.ko`.
+
+**Why:** After #1443 force_probe, xe binds a7a0 on talos-1/2 but still loads firmware from the legacy `i915/` path (`adlp_dmc.bin`, `adlp_dmc_ver2_16.bin`, `adlp_guc_70.bin`). `siderolabs/xe` ships only `xe/` blobs (`bmg_*`, `lnl_*`), so probe fails `-ENOENT`. Commit `73c9e3da` dropped `siderolabs/i915` with the i915→xe migration; until force_probe, xe skipped a7a0 so the missing firmware was invisible. talos-3 B70 stays healthy on `xe/` firmware alone.
+
+**Evidence:** Unpacked `ghcr.io/siderolabs/i915:20260810-v1.13.9` (amd64) carries the three requested `usr/lib/firmware/i915/adlp_*` blobs and no `xe/` tree (no collision with `siderolabs/xe`); `i915.ko` matches kernel `6.18.44-talos`. Live dmesg on talos-1/2 showed the three `-ENOENT` fetches. New schematic registered at factory.talos.dev with `siderolabs/i915` in the extension list; `talosctl validate -m metal` clean on all three node configs at installer v1.13.9.
+
+**Risk / rollback:** Not Flux-applied — captain rolls `just talos apply-node` one node at a time after merge. Do not drop `i915.force_probe=!a7a0` while `siderolabs/i915` is present, or `i915.ko` can reclaim the iGPU from xe. Revert the extension and re-apply to undo (iGPUs fail firmware load again). Do not re-add `i915.enable_dc=0` / `i915.enable_guc=3` — xe still owns the device.
+
+**Verify:** After each `apply-node` on talos-1/2:
+```sh
+# firmware present
+talosctl -n <node> ls /usr/lib/firmware/i915 | grep -E 'adlp_(dmc|guc)'
+# xe bound, allocatable
+kubectl get node <node> -o jsonpath='{.status.allocatable.gpu\.intel\.com/xe}{"\n"}'
+```
+Expect non-empty `i915/adlp_*` listing and `gpu.intel.com/xe=99` on talos-1 and talos-2 (talos-3 already had xe via B70).
 
 ---
 

--- a/docs/hardware-incidents.md
+++ b/docs/hardware-incidents.md
@@ -370,7 +370,7 @@ PCIe:  pcie_aspm=off                             (fixed 2026-03-16)
 iGPU:  i915.enable_dc=0                          (fixed 2026-04-14; superseded)
 ```
 
-**Superseded 2026-06-09** (`73c9e3da`, `feat(talos): migrate Intel GPU driver from i915 to xe`): i915 kernel args (`i915.enable_guc=3`, `i915.enable_dc=0`) and the `siderolabs/i915` extension were removed because xe handles GuC automatically. Current schematic is `talos/schematic.yaml.j2` with `siderolabs/xe`. **Do not re-add `i915.enable_dc=0`.** Node upgrades are `just talos upgrade-node talos-N`, not `task talos:upgrade-node`.
+**Superseded 2026-06-09** (`73c9e3da`, `feat(talos): migrate Intel GPU driver from i915 to xe`): i915 kernel args (`i915.enable_guc=3`, `i915.enable_dc=0`) were removed because xe handles GuC/device PM; the driver path is xe, not i915. **Do not re-add `i915.enable_dc=0`.** `siderolabs/i915` later returned for firmware only (xe still loads a7a0 blobs from `i915/`) — current extensions and kernel args live in `talos/schematic.yaml.j2`; deliberate GPU changes are logged in [`ai-gpu-changelog.md`](./ai-gpu-changelog.md). Node upgrades are `just talos upgrade-node talos-N`, not `task talos:upgrade-node`.
 
 ### Pattern observation
 

--- a/talos/schematic.yaml.j2
+++ b/talos/schematic.yaml.j2
@@ -19,7 +19,7 @@ customization:
     - pci=realloc # Reallocate PCIe resource windows for the Arc B70 Pro OCuLink switch
     - pci=assign-busses # BIOS leaves the B70's e2ff switch at [bus 00-00] with no spare bus numbers behind 00:01.0; kernel must renumber all buses (NIC renames are safe: bonds select members via LinkAliasConfig)
     - xe.force_probe=a7a0 # Bind xe to the Raptor Lake i9-13900H iGPU (8086:a7a0), which xe skips by default
-    - i915.force_probe=!a7a0 # Keep i915 off the iGPU so xe owns it (inert today: no siderolabs/i915 extension)
+    - i915.force_probe=!a7a0 # Keep i915 off the iGPU so xe owns it (load-bearing: siderolabs/i915 ships i915.ko)
     - talos.auditd.disabled=1 # Less security, faster puter
     # Bond interface kernel parameters for early network initialization
     # - bond=bond0:enp2s0f0np0,enp2s0f1np1:mode=802.3ad:miimon=100:lacp_rate=1:xmit_hash_policy=layer3+4:updelay=200:downdelay=200
@@ -27,6 +27,12 @@ customization:
   systemExtensions:
     officialExtensions:
       - siderolabs/xe # Intel iGPU + Arc discrete GPU
+      # Firmware only, in practice: xe drives the a7a0 iGPU but still loads its
+      # blobs from i915/ (adlp_dmc.bin, adlp_guc_70.bin), which siderolabs/xe does
+      # not ship - it carries only xe/ (bmg_*, lnl_*). Dropping this in 73c9e3da
+      # left talos-1/2 probing -ENOENT. i915.ko rides along but is kept off the
+      # iGPU by i915.force_probe=!a7a0 above, so xe still owns it.
+      - siderolabs/i915 # Intel iGPU firmware (i915/adlp_*) for the xe driver
       - siderolabs/intel-ucode # Intel iGPU
       - siderolabs/mei # Intel iGPU
       - siderolabs/nfsrahead # NFS Performance


### PR DESCRIPTION
## Intent

Downstream fix after the #1443 rollout. The captain applied #1443 to all three nodes: kernel args are live and the B70 is healthy on talos-3 (gpu.intel.com/xe=99, devic.es/b70=99, all GPU pods Running). But talos-1 and talos-2 still advertise NO xe - xe.force_probe=a7a0 now makes the driver bind the iGPU, and the probe then fails -ENOENT on missing firmware.

Verified live on both nodes via talosctl dmesg:
xe 0000:00:02.0: [drm] Found alderlake_p/raptorlake_p (device ID a7a0) integrated display version 13.00 stepping E0
xe 0000:00:02.0: Direct firmware load for i915/adlp_dmc.bin failed with error -2
xe 0000:00:02.0: Direct firmware load for i915/adlp_dmc_ver2_16.bin failed with error -2
xe 0000:00:02.0: [drm] Tile0: GT0: GuC firmware i915/adlp_guc_70.bin: fetch failed with error -ENOENT

Root cause: the xe driver drives the a7a0 iGPU but still loads its firmware from the legacy i915/ path. siderolabs/xe ships only xe/ blobs (bmg_*, lnl_*) - confirmed live that /usr/lib/firmware/xe exists on talos-3 while /usr/lib/firmware/i915 exists on no node. Commit 73c9e3da ("migrate Intel GPU driver from i915 to xe", 2026-06-09) swapped siderolabs/i915 out for siderolabs/xe and took the adlp_* blobs with it; nobody noticed because until #1443 the xe driver skipped a7a0 entirely, so the iGPUs were simply absent rather than failing.

The change: add siderolabs/i915 back to talos/schematic.yaml.j2's officialExtensions, alongside (not replacing) siderolabs/xe, and update the i915.force_probe=!a7a0 comment which previously said the arg was inert.

Evidence gathered rather than assumed: I unpacked ghcr.io/siderolabs/i915:20260810-v1.13.9 (amd64 layer) from ghcr and confirmed it carries 127 files under usr/lib/firmware/i915/ including all three the kernel asks for (adlp_dmc.bin, adlp_dmc_ver2_16.bin, adlp_guc_70.bin), and that it ships NO xe/ firmware, so it cannot collide with siderolabs/xe. It also ships i915.ko built for 6.18.44-talos, which matches the running kernel. That module is kept off the iGPU by i915.force_probe=!a7a0, already present from #1443 - previously inert, now load-bearing, and its comment is updated to say so.

Verification already performed: rendered schematic ID changes 6b46d2c00a2295d31fef568ead1420f3088ac6adadc78abe1ff1c7ea8c1a6ef9 -> b1a6b2ffb73af6f3b9d1f10921a4f5d8ac76aefa10be4af317f73fce3d488d04, registered at factory.talos.dev with siderolabs/i915 present in the returned extension list; talosctl validate -m metal clean on all three rendered node configs, each carrying the new installer image at v1.13.9 (matching the live cluster, so no downgrade); task flux:test:all 217/217 passed.

Scope constraints: only talos/schematic.yaml.j2 changes. Do NOT touch the TalosUpgrade/KubernetesUpgrade tuppr CRs, the Kubernetes version, the installer version pin, or talos/machineconfig.yaml.j2, and do not alter the existing kernel args beyond the one comment. Talos templates are not Flux-managed, so this only takes effect once nodes are applied with just talos apply-node; the operator rolls the nodes after merge and this worker must not apply anything to live nodes.

## What Changed

- Re-add `siderolabs/i915` to `talos/schematic.yaml.j2` official extensions alongside `siderolabs/xe`, so xe can load the legacy `i915/adlp_*` firmware blobs required by the a7a0 iGPU after `xe.force_probe=a7a0`.
- Update the `i915.force_probe=!a7a0` kernel-arg comment to mark it load-bearing now that `siderolabs/i915` ships `i915.ko` again (still keeping i915 off the iGPU so xe owns it).
- Record the firmware restore, factory schematic ID change, and operator apply/verify notes in `docs/ai-gpu-changelog.md`, and clarify the post-migration extension status in `docs/hardware-incidents.md`.

## Risk Assessment

✅ Low: Single-file, intent-aligned restoration of siderolabs/i915 for the verified i915/ firmware -ENOENT path, with existing i915.force_probe=!a7a0 left intact as the ownership guard and no forbidden files or kernel-arg behavior changes.

## Testing

Re-registered the schematic at factory.talos.dev (IDs match the intent), confirmed i915 supplies the three dmesg-requested adlp_* blobs without colliding with xe firmware, rendered and metal-validated all three node configs onto installer b1a6b2ff…:v1.13.9, pulled that installer image, and re-ran the talos/version CI scripts successfully; live apply/dmesg was correctly skipped per scope.

<details>
<summary>Evidence: Verification summary (factory ID, extensions, firmware, validate)</summary>

```text
# Evidence: restore siderolabs/i915 for a7a0 iGPU firmware

## Intent
After #1443, `xe.force_probe=a7a0` binds the Raptor Lake iGPU; probe then fails `-ENOENT`
because xe still loads firmware from `i915/` and `siderolabs/xe` only ships `xe/` blobs.
Fix: add `siderolabs/i915` alongside `siderolabs/xe` in `talos/schematic.yaml.j2` only.

## Factory schematic ID (POST https://factory.talos.dev/schematics)
expected_old=6b46d2c00a2295d31fef568ead1420f3088ac6adadc78abe1ff1c7ea8c1a6ef9
actual_old=6b46d2c00a2295d31fef568ead1420f3088ac6adadc78abe1ff1c7ea8c1a6ef9
expected_new=b1a6b2ffb73af6f3b9d1f10921a4f5d8ac76aefa10be4af317f73fce3d488d04
actual_new=b1a6b2ffb73af6f3b9d1f10921a4f5d8ac76aefa10be4af317f73fce3d488d04
old_match=true
new_match=true

New schematic id `b1a6b2ffb73af6f3b9d1f10921a4f5d8ac76aefa10be4af317f73fce3d488d04` returned with officialExtensions including **siderolabs/i915** and **siderolabs/xe**.
Kernel arg *values* unchanged vs baseline (including `xe.force_probe=a7a0` and `i915.force_probe=!a7a0`).

`` `
customization:
    extraKernelArgs:
        - -init_on_alloc
        - -init_on_free
        - -selinux
        - apparmor=0
        - init_on_alloc=0
        - init_on_free=0
        - intel_iommu=on
        - iommu=pt
        - mitigations=off
        - module_blacklist=igc
        - security=none
        - sysctl.kernel.kexec_load_disabled=1
        - nvme_core.default_ps_max_latency_us=0
        - pcie_aspm=off
        - pci=realloc
        - pci=assign-busses
        - xe.force_probe=a7a0
        - i915.force_probe=!a7a0
        - talos.auditd.disabled=1
    systemExtensions:
        officialExtensions:
            - siderolabs/xe
            - siderolabs/i915
            - siderolabs/intel-ucode
            - siderolabs/mei
            - siderolabs/nfsrahead
            - siderolabs/thunderbolt

`` `

## Extension catalog v1.13.9
=== siderolabs/i915 hits=1 ===
{
  "name": "siderolabs/i915",
  "ref": "ghcr.io/siderolabs/i915:20260810-v1.13.9",
  "digest": "sha256:61d32612737af0c365136964f40aba9e551fe32736ed88d5e03a514386027b0c",
  "author": "Sidero Labs",
  "description": "[core] This system extension provides Intel GPU microcode binaries and kernel modules.\n"
}
=== siderolabs/xe hits=1 ===
{
  "name": "siderolabs/xe",
  "ref": "ghcr.io/siderolabs/xe:20260810-v1.13.9",
  "digest": "sha256:21397ba561925e74327598cd76a01898e795f100c2e8c8aadd82b46fa268367d",
  "author": "Sidero Labs",
  "description": "[core] This system extension provides Intel GPU microcode binaries and kernel modules.\n"
}
total extensions 83
has_i915 True
has_xe True

## Firmware content (podman export of extension images)
Required dmesg-requested blobs all present under `usr/lib/firmware/i915/`:
- adlp_dmc.bin
- adlp_dmc_ver2_16.bin
- adlp_guc_70.bin
- i915.ko for kernel `6.18.44-talos`
- i915 ships **no** `firmware/xe/*`; xe ships **no** `firmware/i915/*`
- path overlap is only extension metadata (`manifest.yaml`, modules.*), not firmware blobs

See `i915-firmware-listing.txt`, `xe-firmware-listing.txt`, `firmware-collision-check.txt`.

## Node config render + talosctl validate -m metal
With real schematic id embedded in `machine.install.image`:
SCHEMATIC=b1a6b2ffb73af6f3b9d1f10921a4f5d8ac76aefa10be4af317f73fce3d488d04
/var/folders/yr/h20mxtv56yj1c1pt9tr1_kbc0000gn/T/tmp.arLNUSqyYs/talos-1.yaml is valid for metal mode
VALID talos-1 image=factory.talos.dev/installer/b1a6b2ffb73af6f3b9d1f10921a4f5d8ac76aefa10be4af317f73fce3d488d04:v1.13.9
/var/folders/yr/h20mxtv56yj1c1pt9tr1_kbc0000gn/T/tmp.arLNUSqyYs/talos-2.yaml is valid for metal mode
VALID talos-2 image=factory.talos.dev/installer/b1a6b2ffb73af6f3b9d1f10921a4f5d8ac76aefa10be4af317f73fce3d488d04:v1.13.9
/var/folders/yr/h20mxtv56yj1c1pt9tr1_kbc0000gn/T/tmp.arLNUSqyYs/talos-3.yaml is valid for metal mode
VALID talos-3 image=factory.talos.dev/installer/b1a6b2ffb73af6f3b9d1f10921a4f5d8ac76aefa10be4af317f73fce3d488d04:v1.13.9
installer_embeds_new_schematic_and_v1.13.9=true

Installer image pull succeeded:
`` `
0c90612572b87f7e5504c20d5aabac58dabfc4b5d61d12ef54fea2edde9b3b63 amd64 222014738 factory.talos.dev/installer/b1a6b2ffb73af6f3b9d1f10921a4f5d8ac76aefa10be4af317f73fce3d488d04:v1.13.9
manifest_head=200
`` `

## Offline CI gates
`` `
/var/folders/yr/h20mxtv56yj1c1pt9tr1_kbc0000gn/T/tmp.4AwKMYnIat/talos-1.yaml is valid for metal mode
/var/folders/yr/h20mxtv56yj1c1pt9tr1_kbc0000gn/T/tmp.4AwKMYnIat/talos-2.yaml is valid for metal mode
/var/folders/yr/h20mxtv56yj1c1pt9tr1_kbc0000gn/T/tmp.4AwKMYnIat/talos-3.yaml is valid for metal mode
OK: 3 node config(s) render and validate; schematic renders
OK: 6 machineconfig version pin(s) match the tuppr CRs (Talos v1.13.9, Kubernetes v1.36.3)
`` `

## Scope constraints held
files_changed_vs_base:
talos/schematic.yaml.j2
only_schematic=true
machineconfig_unchanged=0
tuppr_unchanged=0
--- force_probe lines (source comments) ---
21:    - xe.force_probe=a7a0 # Bind xe to the Raptor Lake i9-13900H iGPU (8086:a7a0), which xe skips by default
22:    - i915.force_probe=!a7a0 # Keep i915 off the iGPU so xe owns it (load-bearing: siderolabs/i915 ships i915.ko)
34:      # iGPU by i915.force_probe=!a7a0 above, so xe still owns it.

## Intentionally not exercised
Live node apply/upgrade is operator-owned after merge (`just talos apply-node`); this worker did not touch live nodes. End-to-end dmesg clearance of `-ENOENT` therefore remains a post-merge operational check.
```
</details>
<details>
<summary>Evidence: Factory schematic ID match (baseline → new)</summary>

<code>expected_old=6b46d2c00a2295d31fef568ead1420f3088ac6adadc78abe1ff1c7ea8c1a6ef9&#10;actual_old=6b46d2c00a2295d31fef568ead1420f3088ac6adadc78abe1ff1c7ea8c1a6ef9&#10;expected_new=b1a6b2ffb73af6f3b9d1f10921a4f5d8ac76aefa10be4af317f73fce3d488d04&#10;actual_new=b1a6b2ffb73af6f3b9d1f10921a4f5d8ac76aefa10be4af317f73fce3d488d04&#10;old_match=true&#10;new_match=true</code>

```text
expected_old=6b46d2c00a2295d31fef568ead1420f3088ac6adadc78abe1ff1c7ea8c1a6ef9
actual_old=6b46d2c00a2295d31fef568ead1420f3088ac6adadc78abe1ff1c7ea8c1a6ef9
expected_new=b1a6b2ffb73af6f3b9d1f10921a4f5d8ac76aefa10be4af317f73fce3d488d04
actual_new=b1a6b2ffb73af6f3b9d1f10921a4f5d8ac76aefa10be4af317f73fce3d488d04
old_match=true
new_match=true
```
</details>
<details>
<summary>Evidence: Factory POST new schematic (includes siderolabs/i915)</summary>

```text
{"id":"b1a6b2ffb73af6f3b9d1f10921a4f5d8ac76aefa10be4af317f73fce3d488d04","schematic":"customization:\n    extraKernelArgs:\n        - -init_on_alloc\n        - -init_on_free\n        - -selinux\n        - apparmor=0\n        - init_on_alloc=0\n        - init_on_free=0\n        - intel_iommu=on\n        - iommu=pt\n        - mitigations=off\n        - module_blacklist=igc\n        - security=none\n        - sysctl.kernel.kexec_load_disabled=1\n        - nvme_core.default_ps_max_latency_us=0\n        - pcie_aspm=off\n        - pci=realloc\n        - pci=assign-busses\n        - xe.force_probe=a7a0\n        - i915.force_probe=!a7a0\n        - talos.auditd.disabled=1\n    systemExtensions:\n        officialExtensions:\n            - siderolabs/xe\n            - siderolabs/i915\n            - siderolabs/intel-ucode\n            - siderolabs/mei\n            - siderolabs/nfsrahead\n            - siderolabs/thunderbolt\n"}
```
</details>
<details>
<summary>Evidence: i915 extension firmware listing (required adlp_* blobs)</summary>

```text
=== i915 firmware tree ===
i915-root/manifest.yaml
i915-root/rootfs/usr/lib/firmware/i915/adlp_dmc.bin
i915-root/rootfs/usr/lib/firmware/i915/adlp_dmc_ver2_09.bin
i915-root/rootfs/usr/lib/firmware/i915/adlp_dmc_ver2_10.bin
i915-root/rootfs/usr/lib/firmware/i915/adlp_dmc_ver2_12.bin
i915-root/rootfs/usr/lib/firmware/i915/adlp_dmc_ver2_14.bin
i915-root/rootfs/usr/lib/firmware/i915/adlp_dmc_ver2_16.bin
i915-root/rootfs/usr/lib/firmware/i915/adlp_guc_62.0.3.bin
i915-root/rootfs/usr/lib/firmware/i915/adlp_guc_69.0.3.bin
i915-root/rootfs/usr/lib/firmware/i915/adlp_guc_70.1.1.bin
i915-root/rootfs/usr/lib/firmware/i915/adlp_guc_70.bin
i915-root/rootfs/usr/lib/firmware/i915/adls_dmc_ver2_01.bin
i915-root/rootfs/usr/lib/firmware/i915/bmg_dmc.bin
i915-root/rootfs/usr/lib/firmware/i915/bxt_dmc_ver1_07.bin
i915-root/rootfs/usr/lib/firmware/i915/bxt_guc_32.0.3.bin
i915-root/rootfs/usr/lib/firmware/i915/bxt_guc_33.0.0.bin
i915-root/rootfs/usr/lib/firmware/i915/bxt_guc_49.0.1.bin
i915-root/rootfs/usr/lib/firmware/i915/bxt_guc_62.0.0.bin
i915-root/rootfs/usr/lib/firmware/i915/bxt_guc_69.0.3.bin
i915-root/rootfs/usr/lib/firmware/i915/bxt_guc_70.1.1.bin
i915-root/rootfs/usr/lib/firmware/i915/bxt_guc_ver8_7.bin
i915-root/rootfs/usr/lib/firmware/i915/bxt_guc_ver9_29.bin
i915-root/rootfs/usr/lib/firmware/i915/bxt_huc_2.0.0.bin
i915-root/rootfs/usr/lib/firmware/i915/bxt_huc_ver01_07_1398.bin
i915-root/rootfs/usr/lib/firmware/i915/bxt_huc_ver01_8_2893.bin
i915-root/rootfs/usr/lib/firmware/i915/cml_guc_33.0.0.bin
i915-root/rootfs/usr/lib/firmware/i915/cml_guc_49.0.1.bin
i915-root/rootfs/usr/lib/firmware/i915/cml_guc_62.0.0.bin
i915-root/rootfs/usr/lib/firmware/i915/cml_guc_69.0.3.bin
i915-root/rootfs/usr/lib/firmware/i915/cml_guc_70.1.1.bin
i915-root/rootfs/usr/lib/firmware/i915/cml_huc_4.0.0.bin
i915-root/rootfs/usr/lib/firmware/i915/cnl_dmc_ver1_06.bin
i915-root/rootfs/usr/lib/firmware/i915/cnl_dmc_ver1_07.bin
i915-root/rootfs/usr/lib/firmware/i915/dg1_dmc_ver2_02.bin
i915-root/rootfs/usr/lib/firmware/i915/dg1_guc_49.0.1.bin
i915-root/rootfs/usr/lib/firmware/i915/dg1_guc_62.0.0.bin
i915-root/rootfs/usr/lib/firmware/i915/dg1_guc_69.0.3.bin
i915-root/rootfs/usr/lib/firmware/i915/dg1_guc_70.1.1.bin
i915-root/rootfs/usr/lib/firmware/i915/dg1_guc_70.bin
i915-root/rootfs/usr/lib/firmware/i915/dg1_huc.bin
i915-root/rootfs/usr/lib/firmware/i915/dg1_huc_7.7.1.bin
i915-root/rootfs/usr/lib/firmware/i915/dg1_huc_7.9.3.bin
i915-root/rootfs/usr/lib/firmware/i915/dg2_dmc_ver2_06.bin
i915-root/rootfs/usr/lib/firmware/i915/dg2_dmc_ver2_07.bin
i915-root/rootfs/usr/lib/firmware/i915/dg2_dmc_ver2_08.bin
i915-root/rootfs/usr/lib/firmware/i915/dg2_guc_70.1.2.bin
i915-root/rootfs/usr/lib/firmware/i915/dg2_guc_70.4.1.bin
i915-root/rootfs/usr/lib/firmware/i915/dg2_guc_70.bin
i915-root/rootfs/usr/lib/firmware/i915/dg2_huc_gsc.bin
i915-root/rootfs/usr/lib/firmware/i915/ehl_guc_33.0.4.bin
i915-root/rootfs/usr/lib/firmware/i915/ehl_guc_49.0.1.bin
i915-root/rootfs/usr/lib/firmware/i915/ehl_guc_62.0.0.bin
i915-root/rootfs/usr/lib/firmware/i915/ehl_guc_69.0.3.bin
i915-root/rootfs/usr/lib/firmware/i915/ehl_guc_70.1.1.bin
i915-root/rootfs/usr/lib/firmware/i915/ehl_huc_9.0.0.bin
i915-root/rootfs/usr/lib/firmware/i915/glk_dmc_ver1_04.bin
i915-root/rootfs/usr/lib/firmware/i915/glk_guc_32.0.3.bin
i915-root/rootfs/usr/lib/firmware/i915/glk_guc_33.0.0.bin
i915-root/rootfs/usr/lib/firmware/i915/glk_guc_49.0.1.bin
i915-root/rootfs/usr/lib/firmware/i915/glk_guc_62.0.0.bin
i915-root/rootfs/usr/lib/firmware/i915/glk_guc_69.0.3.bin
i915-root/rootfs/usr/lib/firmware/i915/glk_guc_70.1.1.bin
i915-root/rootfs/usr/lib/firmware/i915/glk_huc_4.0.0.bin
i915-root/rootfs/usr/lib/firmware/i915/glk_huc_ver03_01_2893.bin
i915-root/rootfs/usr/lib/firmware/i915/icl_dmc_ver1_07.bin
i915-root/rootfs/usr/lib/firmware/i915/icl_dmc_ver1_09.bin
i915-root/rootfs/usr/lib/firmware/i915/icl_guc_32.0.3.bin
i915-root/rootfs/usr/lib/firmware/i915/icl_guc_33.0.0.bin
i915-root/rootfs/usr/lib/firmware/i915/icl_guc_49.0.1.bin
i915-root/rootfs/usr/lib/firmware/i915/icl_guc_62.0.0.bin
i915-root/rootfs/usr/lib/firmware/i915/icl_guc_69.0.3.bin
i915-root/rootfs/usr/lib/firmware/i915/icl_guc_70.1.1.bin
i915-root/rootfs/usr/lib/firmware/i915/icl_huc_9.0.0.bin
i915-root/rootfs/usr/lib/firmware/i915/icl_huc_ver8_4_3238.bin
i915-root/rootfs/usr/lib/firmware/i915/kbl_dmc_ver1_01.bin
i915-root/rootfs/usr/lib/firmware/i915/kbl_dmc_ver1_04.bin
i915-root/rootfs/usr/lib/firmware/i915/kbl_guc_32.0.3.bin
i915-root/rootfs/usr/lib/firmware/i915/kbl_guc_33.0.0.bin
i915-root/rootfs/usr/lib/firmware/i915/kbl_guc_49.0.1.bin
i915-root/rootfs/usr/lib/firmware/i915/kbl_guc_62.0.0.bin
i915-root/rootfs/usr/lib/firmware/i915/kbl_guc_69.0.3.bin
i915-root/rootfs/usr/lib/firmware/i915/kbl_guc_70.1.1.bin
i915-root/rootfs/usr/lib/firmware/i915/kbl_guc_ver9_14.bin
i915-root/rootfs/usr/lib/firmware/i915/kbl_guc_ver9_39.bin
i915-root/rootfs/usr/lib/firmware/i915/kbl_huc_4.0.0.bin
i915-root/rootfs/usr/lib/firmware/i915/kbl_huc_ver02_00_1810.bin
i915-root/rootfs/usr/lib/firmware/i915/mtl_dmc.bin
i915-root/rootfs/usr/lib/firmware/i915/mtl_dmc_ver2_10.bin
i915-root/rootfs/usr/lib/firmware/i915/mtl_gsc_1.bin
i915-root/rootfs/usr/lib/firmware/i915/mtl_guc_70.bin
i915-root/rootfs/usr/lib/firmware/i915/mtl_huc_gsc.bin
i915-root/rootfs/usr/lib/firmware/i915/rkl_dmc_ver2_02.bin
i915-root/rootfs/usr/lib/firmware/i915/rkl_dmc_ver2_03.bin
i915-root/rootfs/usr/lib/firmware/i915/skl_dmc_ver1_23.bin
i915-root/rootfs/usr/lib/firmware/i915/skl_dmc_ver1_26.bin
i915-root/rootfs/usr/lib/firmware/i915/skl_dmc_ver1_27.bin
i915-root/rootfs/usr/lib/firmware/i915/skl_guc_32.0.3.bin
i915-root/rootfs/usr/lib/firmware/i915/skl_guc_33.0.0.bin
i915-root/rootfs/usr/lib/firmware/i915/skl_guc_49.0.1.bin
i915-root/rootfs/usr/lib/firmware/i915/skl_guc_62.0.0.bin
i915-root/rootfs/usr/lib/firmware/i915/skl_guc_69.0.3.bin
i915-root/rootfs/usr/lib/firmware/i915/skl_guc_70.1.1.bin
i915-root/rootfs/usr/lib/firmware/i915/skl_guc_ver1.bin
i915-root/rootfs/usr/lib/firmware/i915/skl_guc_ver4.bin
i915-root/rootfs/usr/lib/firmware/i915/skl_guc_ver6_1.bin
i915-root/rootfs/usr/lib/firmware/i915/skl_guc_ver9_33.bin
i915-root/rootfs/usr/lib/firmware/i915/skl_huc_2.0.0.bin
i915-root/rootfs/usr/lib/firmware/i915/skl_huc_ver01_07_1398.bin
i915-root/rootfs/usr/lib/firmware/i915/tgl_dmc_ver2_04.bin
i915-root/rootfs/usr/lib/firmware/i915/tgl_dmc_ver2_06.bin
i915-root/rootfs/usr/lib/firmware/i915/tgl_dmc_ver2_08.bin
i915-root/rootfs/usr/lib/firmware/i915/tgl_dmc_ver2_12.bin
i915-root/rootfs/usr/lib/firmware/i915/tgl_guc_35.2.0.bin
i915-root/rootfs/usr/lib/firmware/i915/tgl_guc_49.0.1.bin
i915-root/rootfs/usr/lib/firmware/i915/tgl_guc_62.0.0.bin
i915-root/rootfs/usr/lib/firmware/i915/tgl_guc_69.0.3.bin
i915-root/rootfs/usr/lib/firmware/i915/tgl_guc_70.1.1.bin
i915-root/rootfs/usr/lib/firmware/i915/tgl_guc_70.bin
i915-root/rootfs/usr/lib/firmware/i915/tgl_huc.bin
i915-root/rootfs/usr/lib/firmware/i915/tgl_huc_7.0.12.bin
i915-root/rootfs/usr/lib/firmware/i915/tgl_huc_7.0.3.bin
i915-root/rootfs/usr/lib/firmware/i915/tgl_huc_7.5.0.bin
i915-root/rootfs/usr/lib/firmware/i915/tgl_huc_7.9.3.bin
i915-root/rootfs/usr/lib/firmware/i915/xe2lpd_dmc.bin
i915-root/rootfs/usr/lib/firmware/i915/xe3lpd_3002_dmc.bin
i915-root/rootfs/usr/lib/firmware/i915/xe3lpd_dmc.bin
i915-root/rootfs/usr/lib/firmware/i915/xe3p_lpd_dmc.bin
i915-root/rootfs/usr/lib/modules/6.18.44-talos/kernel/drivers/gpu/drm/i915/i915.ko
i915-root/rootfs/usr/lib/modules/6.18.44-talos/modules.builtin
i915-root/rootfs/usr/lib/modules/6.18.44-talos/modules.builtin.modinfo
i915-root/rootfs/usr/lib/modules/6.18.44-talos/modules.order
=== required blobs present? ===
adlp_dmc.bin -> i915-root/rootfs/usr/lib/firmware/i915/adlp_dmc.bin
adlp_dmc_ver2_16.bin -> i915-root/rootfs/usr/lib/firmware/i915/adlp_dmc_ver2_16.bin
adlp_guc_70.bin -> i915-root/rootfs/usr/lib/firmware/i915/adlp_guc_70.bin
=== i915 has xe/ firmware? ===
=== i915.ko present? ===
i915-root/rootfs/usr/lib/modules/6.18.44-talos/kernel/drivers/gpu/drm/i915/i915.ko
i915_file_count=131
i915_firmware_count=126
```
</details>
<details>
<summary>Evidence: xe extension firmware listing (xe/ only)</summary>

```text
=== xe firmware tree (top) ===
xe-root/manifest.yaml
xe-root/rootfs/usr/lib/firmware/xe/bmg_guc_70.bin
xe-root/rootfs/usr/lib/firmware/xe/bmg_huc.bin
xe-root/rootfs/usr/lib/firmware/xe/fan_control_8086_e20b_8086_1100.bin
xe-root/rootfs/usr/lib/firmware/xe/lnl_gsc_1.bin
xe-root/rootfs/usr/lib/firmware/xe/lnl_guc_70.bin
xe-root/rootfs/usr/lib/firmware/xe/lnl_huc.bin
xe-root/rootfs/usr/lib/firmware/xe/nvl_guc_70.bin
xe-root/rootfs/usr/lib/firmware/xe/ptl_gsc_1.bin
xe-root/rootfs/usr/lib/firmware/xe/ptl_guc_70.bin
xe-root/rootfs/usr/lib/firmware/xe/ptl_huc.bin
xe-root/rootfs/usr/lib/modules/6.18.44-talos/kernel/drivers/gpu/drm/xe/xe.ko
xe-root/rootfs/usr/lib/modules/6.18.44-talos/modules.builtin
xe-root/rootfs/usr/lib/modules/6.18.44-talos/modules.builtin.modinfo
xe-root/rootfs/usr/lib/modules/6.18.44-talos/modules.order
=== xe has i915/ firmware? ===
```
</details>
<details>
<summary>Evidence: i915 vs xe path collision check</summary>

`overlap_count=4 (manifest.yaml + modules.* metadata only; no shared firmware blobs)`

```text
=== collision check: same relative paths? ===
./manifest.yaml
./rootfs/usr/lib/modules/6.18.44-talos/modules.builtin
./rootfs/usr/lib/modules/6.18.44-talos/modules.builtin.modinfo
./rootfs/usr/lib/modules/6.18.44-talos/modules.order
overlap_count=4
```
</details>
<details>
<summary>Evidence: Rendered node installer images + metal validate</summary>

`VALID talos-1/2/3 image=factory.talos.dev/installer/b1a6b2ffb73af6f3b9d1f10921a4f5d8ac76aefa10be4af317f73fce3d488d04:v1.13.9`

```text
SCHEMATIC=b1a6b2ffb73af6f3b9d1f10921a4f5d8ac76aefa10be4af317f73fce3d488d04
/var/folders/yr/h20mxtv56yj1c1pt9tr1_kbc0000gn/T/tmp.arLNUSqyYs/talos-1.yaml is valid for metal mode
VALID talos-1 image=factory.talos.dev/installer/b1a6b2ffb73af6f3b9d1f10921a4f5d8ac76aefa10be4af317f73fce3d488d04:v1.13.9
/var/folders/yr/h20mxtv56yj1c1pt9tr1_kbc0000gn/T/tmp.arLNUSqyYs/talos-2.yaml is valid for metal mode
VALID talos-2 image=factory.talos.dev/installer/b1a6b2ffb73af6f3b9d1f10921a4f5d8ac76aefa10be4af317f73fce3d488d04:v1.13.9
/var/folders/yr/h20mxtv56yj1c1pt9tr1_kbc0000gn/T/tmp.arLNUSqyYs/talos-3.yaml is valid for metal mode
VALID talos-3 image=factory.talos.dev/installer/b1a6b2ffb73af6f3b9d1f10921a4f5d8ac76aefa10be4af317f73fce3d488d04:v1.13.9
installer_embeds_new_schematic_and_v1.13.9=true
```
</details>
<details>
<summary>Evidence: Installer image inspect (pulled)</summary>

`0c90612572b87f7e5504c20d5aabac58dabfc4b5d61d12ef54fea2edde9b3b63 amd64 222014738 factory.talos.dev/installer/b1a6b2ffb73af6f3b9d1f10921a4f5d8ac76aefa10be4af317f73fce3d488d04:v1.13.9`

```text
0c90612572b87f7e5504c20d5aabac58dabfc4b5d61d12ef54fea2edde9b3b63 amd64 222014738 factory.talos.dev/installer/b1a6b2ffb73af6f3b9d1f10921a4f5d8ac76aefa10be4af317f73fce3d488d04:v1.13.9
manifest_head=200
```
</details>
<details>
<summary>Evidence: scripts/ci/talos-validate.sh</summary>

`OK: 3 node config(s) render and validate; schematic renders`

```text
/var/folders/yr/h20mxtv56yj1c1pt9tr1_kbc0000gn/T/tmp.4AwKMYnIat/talos-1.yaml is valid for metal mode
/var/folders/yr/h20mxtv56yj1c1pt9tr1_kbc0000gn/T/tmp.4AwKMYnIat/talos-2.yaml is valid for metal mode
/var/folders/yr/h20mxtv56yj1c1pt9tr1_kbc0000gn/T/tmp.4AwKMYnIat/talos-3.yaml is valid for metal mode
OK: 3 node config(s) render and validate; schematic renders
```
</details>
<details>
<summary>Evidence: scripts/ci/version-consistency.sh</summary>

`OK: 6 machineconfig version pin(s) match the tuppr CRs (Talos v1.13.9, Kubernetes v1.36.3)`

```text
OK: 6 machineconfig version pin(s) match the tuppr CRs (Talos v1.13.9, Kubernetes v1.36.3)
```
</details>
<details>
<summary>Evidence: Scope check (only schematic.yaml.j2)</summary>

```text
files_changed_vs_base:
talos/schematic.yaml.j2
only_schematic=true
machineconfig_unchanged=0
tuppr_unchanged=0
--- force_probe lines (source comments) ---
21:    - xe.force_probe=a7a0 # Bind xe to the Raptor Lake i9-13900H iGPU (8086:a7a0), which xe skips by default
22:    - i915.force_probe=!a7a0 # Keep i915 off the iGPU so xe owns it (load-bearing: siderolabs/i915 ships i915.ko)
34:      # iGPU by i915.force_probe=!a7a0 above, so xe still owns it.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"a9badf60ff361d49db59543676bf3c9542680241","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`curl -X POST https://factory.talos.dev/schematics` baseline vs HEAD schematic (IDs 6b46d2c0… → b1a6b2ff…)</code>
- `Factory response extension list includes siderolabs/i915 + siderolabs/xe; kernel arg values unchanged`
- <code>`GET https://factory.talos.dev/version/v1.13.9/extensions/official` for i915/xe refs 20260810-v1.13.9</code>
- <code>`podman pull/export ghcr.io/siderolabs/i915:20260810-v1.13.9` — adlp_dmc.bin, adlp_dmc_ver2_16.bin, adlp_guc_70.bin, i915.ko@6.18.44-talos present; no firmware/xe</code>
- <code>`podman pull/export ghcr.io/siderolabs/xe:20260810-v1.13.9` — only xe/ blobs; no firmware/i915; no firmware path collisions</code>
- <code>CI-style render of talos-1/2/3 with real schematic id + `talosctl validate -m metal`</code>
- <code>`podman pull factory.talos.dev/installer/b1a6b2ff…:v1.13.9` (amd64 image exists)</code>
- `./scripts/ci/talos-validate.sh`
- `./scripts/ci/version-consistency.sh`
- <code>Scope check: only `talos/schematic.yaml.j2` changed; machineconfig/tuppr untouched</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
